### PR TITLE
Implement argument list view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,4 +68,4 @@ fastlane/test_output
 iOSInjectionProject/
 
 build/
-sysroot/
+sysroot*/

--- a/Configuration/UTMConfiguration.h
+++ b/Configuration/UTMConfiguration.h
@@ -40,7 +40,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSNumber *systemCPUCount;
 @property (nonatomic, nullable, copy) NSString *systemTarget;
 @property (nonatomic, nullable, copy) NSString *systemBootDevice;
-@property (nonatomic, nullable, copy) NSString *systemAddArgs;
 
 @property (nonatomic, assign) BOOL displayConsoleOnly;
 @property (nonatomic, assign) BOOL displayFixedResolution;
@@ -63,8 +62,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, assign) BOOL sharingClipboardEnabled;
 
+- (void)migrateDictionaryIfNecessary;
 - (id)initDefaults:(NSString *)name;
 - (id)initWithDictionary:(NSMutableDictionary *)dictionary name:(NSString *)name path:(NSURL *)path;
+
+- (NSUInteger)countArguments;
+- (NSUInteger)newArgument:(NSString *)argument;
+- (nullable NSString *)argumentForIndex:(NSUInteger)index;
+- (void)moveArgumentIndex:(NSUInteger)index to:(NSUInteger)newIndex;
+- (void)updateArgumentAtIndex:(NSUInteger)index withValue:(NSString*)argument;
+- (void)removeArgumentAtIndex:(NSUInteger)index;
+- (NSArray *)systemArguments;
+
 - (NSUInteger)countDrives;
 - (NSUInteger)newDrive:(NSString *)name interface:(NSString *)interface isCdrom:(BOOL)isCdrom;
 - (nullable NSString *)driveImagePathForIndex:(NSUInteger)index;

--- a/ConfigurationViews/VMConfigSystemArgumentsViewController.h
+++ b/ConfigurationViews/VMConfigSystemArgumentsViewController.h
@@ -1,0 +1,34 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+#import "UTMConfigurationDelegate.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface VMConfigSystemArgumentsViewController : UITableViewController<UTMConfigurationDelegate>
+
+@property (weak, nonatomic) IBOutlet UIBarButtonItem *addButtonItem;
+@property (strong, nonatomic) IBOutlet UITableView *argTableView;
+
+@end
+
+@interface VMConfigSystemArgumentsTextCell : UITableViewCell<UTMConfigurationDelegate>
+@property (weak, nonatomic) IBOutlet UITextField *argTextItem;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ConfigurationViews/VMConfigSystemArgumentsViewController.m
+++ b/ConfigurationViews/VMConfigSystemArgumentsViewController.m
@@ -1,0 +1,148 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "VMConfigSystemArgumentsViewController.h"
+#import "VMConfigDriveDetailViewController.h"
+#import "UTMConfiguration.h"
+
+@interface VMConfigSystemArgumentsViewController ()
+
+@end
+
+@implementation VMConfigSystemArgumentsViewController
+
+@synthesize configuration;
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+    self.navigationItem.rightBarButtonItems = @[ self.addButtonItem, self.editButtonItem ];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self refreshViewFromConfiguration];
+}
+
+- (void)refreshViewFromConfiguration {
+    [self.tableView reloadData];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    NSAssert(section == 0, @"Invalid section.");
+    NSInteger count = self.configuration.countArguments;
+    
+    // Insert an empty argument if there are no existing arguments.
+    if (count == 0) {
+        [self.configuration newArgument:@""];
+        return count + 1;
+    }
+    
+    return count;
+}
+
+- (VMConfigSystemArgumentsTextCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    VMConfigSystemArgumentsTextCell *cell = [tableView dequeueReusableCellWithIdentifier:@"argumentCell" forIndexPath:indexPath];
+    NSAssert(indexPath.section == 0, @"Invalid section");
+    NSAssert(cell, @"Invalid cell");
+    
+    NSInteger row = indexPath.row;
+    cell.argTextItem.tag = row;
+    cell.argTextItem.text = [self.configuration argumentForIndex:row];
+    cell.configuration = configuration;
+    return cell;
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSAssert(indexPath.section == 0, @"Invalid section");
+    return YES;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSAssert(indexPath.section == 0, @"Invalid section");
+    if (editingStyle == UITableViewCellEditingStyleDelete) {
+        // If there's only one argument, add a new item at 1 before deleting the first so we're never at 0 rows.
+        if ([self.configuration countArguments] == 1) {
+            [self.configuration updateArgumentAtIndex:0 withValue:@""];
+        } else {
+            // Delete the row and coorresponding argument.
+            [self.configuration removeArgumentAtIndex:indexPath.row];
+            [tableView deleteRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationFade];
+        }
+        
+        [tableView reloadData];
+    }
+}
+
+- (void)tableView:(UITableView *)tableView moveRowAtIndexPath:(NSIndexPath *)fromIndexPath toIndexPath:(NSIndexPath *)toIndexPath {
+    NSAssert(fromIndexPath.section == 0, @"Invalid section");
+    NSAssert(toIndexPath.section == 0, @"Invalid section");
+    [self.configuration moveArgumentIndex:fromIndexPath.row to:toIndexPath.row];
+}
+
+- (BOOL)tableView:(UITableView *)tableView canMoveRowAtIndexPath:(NSIndexPath *)indexPath {
+    NSAssert(indexPath.section == 0, @"Invalid section");
+    return YES;
+}
+
+- (IBAction)addButton:(id *)sender {
+    // Insert a new empty argument.
+    [self.configuration newArgument:@""];
+    [self.tableView reloadData];
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    // done button was pressed - dismiss keyboard
+    [textField resignFirstResponder];
+    return YES;
+}
+
+@end
+
+#pragma mark - Text input from cell
+
+@interface VMConfigSystemArgumentsTextCell()
+
+@end
+
+@implementation VMConfigSystemArgumentsTextCell
+@synthesize configuration;
+
+- (void)refreshViewFromConfiguration {
+    // The table would update before we could do anything.
+    return;
+}
+
+- (IBAction)editingDidEnd:(UITextField *)sender {
+    [self.configuration updateArgumentAtIndex:sender.tag withValue:sender.text];
+    [self.argTextItem endEditing:true];
+}
+
+
+- (IBAction)valueWasChanged:(UITextField *)sender {
+    [self.argTextItem endEditing:true];
+}
+
+- (IBAction)touchWasCancelled:(UITextField *)sender {
+    [self.argTextItem endEditing:true];
+}
+
+@end

--- a/ConfigurationViews/VMConfigSystemViewController.h
+++ b/ConfigurationViews/VMConfigSystemViewController.h
@@ -41,14 +41,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic) IBOutlet UITableViewCell *systemPickerCell;
 @property (weak, nonatomic) IBOutlet UIPickerView *systemPicker;
 @property (nonatomic, assign) BOOL systemPickerActive;
-@property (weak, nonatomic) IBOutlet UITextField *additionalArgsField;
 
 @property (nonatomic) NSNumber *memorySize;
 @property (nonatomic) NSNumber *cpuCount;
-
 - (IBAction)memorySizeFieldEdited:(UITextField *)sender;
 - (IBAction)cpuCountFieldEdited:(UITextField *)sender;
-- (IBAction)additionalArgsFieldEdited:(UITextField *)sender;
 
 @end
 

--- a/ConfigurationViews/VMConfigSystemViewController.m
+++ b/ConfigurationViews/VMConfigSystemViewController.m
@@ -35,7 +35,6 @@
     self.architectureLabel.text = self.configuration.systemArchitecture;
     self.bootLabel.text = self.configuration.systemBootDevice;
     self.systemLabel.text = self.configuration.systemTarget;
-    self.additionalArgsField.text = self.configuration.systemAddArgs;
     self.memorySize = self.configuration.systemMemory;
     self.cpuCount = self.configuration.systemCPUCount;
 }
@@ -187,11 +186,6 @@
     } else {
         // TODO: error handler
     }
-}
-
-- (IBAction)additionalArgsFieldEdited:(UITextField *)sender {
-    NSAssert(sender == self.additionalArgsField, @"Invalid sender");
-    self.configuration.systemAddArgs = sender.text;
 }
 
 @end

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -99,6 +99,30 @@
         }
         [self pushArgv:netstr];
     }
+    
+    if (self.configuration.systemArguments.count != 0) {
+        NSArray *addArgs = self.configuration.systemArguments;
+        // Splits all spaces into their own, except when between quotes.
+        NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:@"(\"[^\"]+\"|\\+|\\S+)" options:0 error:nil];
+        
+        for (NSString *arg in addArgs) {
+            // No need to operate on empty arguments.
+            if (arg.length == 0) {
+                continue;
+            }
+            
+            NSArray *splitArgsArray = [regex matchesInString:arg
+                                              options:0
+                                                range:NSMakeRange(0, [arg length])];
+            
+            
+            for (NSTextCheckingResult *match in splitArgsArray) {
+                NSRange matchRange = [match rangeAtIndex:1];
+                NSString *argFragment = [arg substringWithRange:matchRange];
+                [self pushArgv:argFragment];
+            }
+        }
+    }
 }
 
 - (void)startWithCompletion:(void (^)(BOOL, NSString * _Nonnull))completion {

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		423BCE66240F6A80001989AC /* VMConfigSystemArgumentsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 423BCE65240F6A80001989AC /* VMConfigSystemArgumentsViewController.m */; };
 		CE23C16123FCEC0A001177D6 /* qapi-commands-run-state.c in Sources */ = {isa = PBXBuildFile; fileRef = CE23C07E23FCEBFF001177D6 /* qapi-commands-run-state.c */; };
 		CE23C16223FCEC0A001177D6 /* qapi-visit-tpm.c in Sources */ = {isa = PBXBuildFile; fileRef = CE23C07F23FCEBFF001177D6 /* qapi-visit-tpm.c */; };
 		CE23C16323FCEC0A001177D6 /* qapi-commands-rocker.c in Sources */ = {isa = PBXBuildFile; fileRef = CE23C08123FCEBFF001177D6 /* qapi-commands-rocker.c */; };
@@ -380,6 +381,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		423BCE65240F6A80001989AC /* VMConfigSystemArgumentsViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = VMConfigSystemArgumentsViewController.m; sourceTree = "<group>"; };
+		423BCE67240F6A8A001989AC /* VMConfigSystemArgumentsViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VMConfigSystemArgumentsViewController.h; sourceTree = "<group>"; };
 		7D75C517240427170098CF2F /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Main.strings"; sourceTree = "<group>"; };
 		CE23C07B23FCEBFF001177D6 /* qapi-visit-error.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "qapi-visit-error.h"; path = "sysroot-$(PLATFORM_PREFERRED_ARCH)/qapi/qapi-visit-error.h"; sourceTree = SOURCE_ROOT; };
 		CE23C07C23FCEBFF001177D6 /* qapi-events-machine.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "qapi-events-machine.h"; path = "sysroot-$(PLATFORM_PREFERRED_ARCH)/qapi/qapi-events-machine.h"; sourceTree = SOURCE_ROOT; };
@@ -1322,6 +1325,8 @@
 				CE74C284225D88ED004E4FF1 /* VMConfigSoundViewController.m */,
 				CE74C277225D88EC004E4FF1 /* VMConfigSystemViewController.h */,
 				CE74C285225D88ED004E4FF1 /* VMConfigSystemViewController.m */,
+				423BCE67240F6A8A001989AC /* VMConfigSystemArgumentsViewController.h */,
+				423BCE65240F6A80001989AC /* VMConfigSystemArgumentsViewController.m */,
 			);
 			path = ConfigurationViews;
 			sourceTree = "<group>";
@@ -1546,6 +1551,7 @@
 				CE74C28A225D88ED004E4FF1 /* VMConfigPrintingViewController.m in Sources */,
 				CE23C19C23FCEC0A001177D6 /* qapi-visit-run-state.c in Sources */,
 				CE23C18223FCEC0A001177D6 /* qapi-commands-tpm.c in Sources */,
+				423BCE66240F6A80001989AC /* VMConfigSystemArgumentsViewController.m in Sources */,
 				CE23C1A423FCEC0A001177D6 /* qapi-visit-common.c in Sources */,
 				CE23C16823FCEC0A001177D6 /* qapi-events-trace.c in Sources */,
 				CE23C17123FCEC0A001177D6 /* qapi-events-qdev.c in Sources */,

--- a/UTM/Base.lproj/Main.storyboard
+++ b/UTM/Base.lproj/Main.storyboard
@@ -13,7 +13,7 @@
             <objects>
                 <collectionViewController id="krH-Hz-4fz" customClass="VMListViewController" sceneMemberID="viewController">
                     <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" contentInsetAdjustmentBehavior="always" keyboardDismissMode="onDrag" dataMode="prototypes" id="2R6-2u-EVP">
-                        <rect key="frame" x="0.0" y="0.0" width="1366" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
                         <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="20" minimumInteritemSpacing="20" id="Hle-hi-gGv">
@@ -167,7 +167,7 @@
             <objects>
                 <tableViewController id="wwu-oM-NlF" customClass="VMConfigExistingViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="nNA-4B-g7f">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <gestureRecognizers/>
@@ -175,14 +175,14 @@
                             <tableViewSection headerTitle="Name" id="BlT-6O-Tm8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="ffD-BN-tfx">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ffD-BN-tfx" id="qt9-XV-EeT">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Kh-jJ-awN">
-                                                    <rect key="frame" x="16" y="11.5" width="343" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="288" height="21"/>
                                                     <gestureRecognizers/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
@@ -205,14 +205,14 @@
                             <tableViewSection headerTitle="Hardware" id="NCJ-Al-5BI">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="riB-R9-dTb" style="IBUITableViewCellStyleDefault" id="Uh7-K8-Cd9">
-                                        <rect key="frame" x="0.0" y="155.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="155.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Uh7-K8-Cd9" id="gUO-nD-d2x">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="System" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="riB-R9-dTb">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -225,14 +225,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="1FD-SU-TVn" style="IBUITableViewCellStyleDefault" id="ptA-DT-lZ3">
-                                        <rect key="frame" x="0.0" y="199.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ptA-DT-lZ3" id="ogr-EI-pev">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Drives" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="1FD-SU-TVn">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -245,14 +245,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="fZG-YK-q4O" style="IBUITableViewCellStyleDefault" id="yLH-HX-o9t">
-                                        <rect key="frame" x="0.0" y="243.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="243.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="yLH-HX-o9t" id="kQP-2D-wX5">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Display" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="fZG-YK-q4O">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -265,14 +265,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="GvK-o6-9qU" style="IBUITableViewCellStyleDefault" id="xM7-rl-j1p">
-                                        <rect key="frame" x="0.0" y="287.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="287.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="xM7-rl-j1p" id="5sC-AT-kE8">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Input" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="GvK-o6-9qU">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -285,14 +285,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="XSI-kB-djk" style="IBUITableViewCellStyleDefault" id="cL1-0x-rat">
-                                        <rect key="frame" x="0.0" y="331.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="331.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cL1-0x-rat" id="9Tq-yB-cOw">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Networking" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XSI-kB-djk">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -305,14 +305,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="gXb-Fk-IyH" style="IBUITableViewCellStyleDefault" id="LlL-Ex-hlq">
-                                        <rect key="frame" x="0.0" y="375.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="375.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="LlL-Ex-hlq" id="PCT-h6-ZRK">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Printing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gXb-Fk-IyH">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -325,14 +325,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="wis-6w-tHz" style="IBUITableViewCellStyleDefault" id="y4a-Wf-GZq">
-                                        <rect key="frame" x="0.0" y="419.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="419.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="y4a-Wf-GZq" id="dcV-Ht-6Fe">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sound" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wis-6w-tHz">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -345,14 +345,14 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="jv0-6r-NAJ" style="IBUITableViewCellStyleDefault" id="qe0-X4-HwM">
-                                        <rect key="frame" x="0.0" y="463.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="463.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qe0-X4-HwM" id="R65-ok-h9A">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Sharing" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jv0-6r-NAJ">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -401,21 +401,21 @@
             <objects>
                 <tableViewController id="fRW-Bh-0Dk" customClass="VMConfigDisplayViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Mua-Ov-iIu">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Type" id="wjd-8h-Xoa">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" textLabel="3Jg-sa-a1s" style="IBUITableViewCellStyleDefault" id="osW-lA-u2m">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="osW-lA-u2m" id="Fdz-Uo-dCh">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Full Graphics" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3Jg-sa-a1s">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -425,14 +425,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" textLabel="nGh-ET-2qO" style="IBUITableViewCellStyleDefault" id="2qy-IZ-c5L">
-                                        <rect key="frame" x="0.0" y="99.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2qy-IZ-c5L" id="xiC-oa-N5a">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Console Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="nGh-ET-2qO">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -446,20 +446,20 @@
                             <tableViewSection headerTitle="Resolution" id="DBb-DO-7RN">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="shN-AV-DTv">
-                                        <rect key="frame" x="0.0" y="199.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="shN-AV-DTv" id="f7t-Ni-Ojq">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fixed" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LCF-nv-jEK">
-                                                    <rect key="frame" x="20" y="11.5" width="41" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="41" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Xsw-b2-kv1">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="resolutionFixedSwitchChanged:" destination="fRW-Bh-0Dk" eventType="valueChanged" id="Gpg-bU-aot"/>
                                                     </connections>
@@ -475,21 +475,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="3p4-7o-dMd" detailTextLabel="xVE-hN-Dcf" style="IBUITableViewCellStyleValue1" id="34f-n4-JfB">
-                                        <rect key="frame" x="0.0" y="243.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="243.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="34f-n4-JfB" id="THa-zL-IVd">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Max Resolution" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3p4-7o-dMd">
-                                                    <rect key="frame" x="20" y="12" width="117" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="117" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="1024x768" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="xVE-hN-Dcf">
-                                                    <rect key="frame" x="278.5" y="12" width="76.5" height="20.5"/>
+                                                    <rect key="frame" x="227.5" y="12" width="76.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -499,14 +499,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="150" id="zMQ-Xb-T3u">
-                                        <rect key="frame" x="0.0" y="287.5" width="388" height="150"/>
+                                        <rect key="frame" x="0.0" y="287.5" width="333" height="150"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zMQ-Xb-T3u" id="Ssc-US-c4o">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="150"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="150"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="S8l-Yv-OcK">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="150"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="150"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="fRW-Bh-0Dk" id="R5a-Uy-gJO"/>
                                                         <outlet property="delegate" destination="fRW-Bh-0Dk" id="V0w-JJ-147"/>
@@ -526,20 +526,20 @@
                             <tableViewSection headerTitle="Zoom" id="2ao-Lx-lcQ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="I3e-zw-jAD">
-                                        <rect key="frame" x="0.0" y="493.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="493.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="I3e-zw-jAD" id="3s4-Ke-929">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Scale to Fit" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DSd-aZ-Qka">
-                                                    <rect key="frame" x="20" y="11.5" width="85" height="21"/>
+                                                    <rect key="frame" x="8" y="11.5" width="85" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ohs-OI-Wjl">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="276" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="zoomScaleFitSwitchChanged:" destination="fRW-Bh-0Dk" eventType="valueChanged" id="ESE-l9-ugu"/>
                                                     </connections>
@@ -555,20 +555,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="uLK-yj-IDI">
-                                        <rect key="frame" x="0.0" y="537.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="537.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uLK-yj-IDI" id="gYV-Zk-a5J">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Letterbox Mode" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="olW-DK-r4a">
-                                                    <rect key="frame" x="20" y="11.5" width="121" height="21"/>
+                                                    <rect key="frame" x="8" y="11.5" width="121" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Ur-f8-0fb">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="276" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="zoomLetterboxSwitchChanged:" destination="fRW-Bh-0Dk" eventType="valueChanged" id="ot6-oa-ApK"/>
                                                     </connections>
@@ -588,14 +588,14 @@
                             <tableViewSection headerTitle="Console" id="6zB-bx-Y94">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="8ah-qD-hzy" style="IBUITableViewCellStyleDefault" id="45e-Uf-NXZ">
-                                        <rect key="frame" x="0.0" y="637.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="637.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="45e-Uf-NXZ" id="Bxz-pl-Qcd">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="333" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Font (placeholder)" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8ah-qD-hzy">
-                                                    <rect key="frame" x="20" y="0.0" width="335" height="44"/>
+                                                    <rect key="frame" x="15" y="0.0" width="310" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -636,34 +636,34 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5CK-HG-MYg" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4782" y="1247"/>
+            <point key="canvasLocation" x="4789" y="547"/>
         </scene>
         <!--Printing-->
         <scene sceneID="k41-e0-ebL">
             <objects>
                 <tableViewController id="cZY-Ss-RO9" customClass="VMConfigPrintingViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="jn7-u2-Tui">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Hardware" id="Roy-Wv-Hrq">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="uTd-CT-zVU">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="uTd-CT-zVU" id="uyr-yj-zmW">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fDF-an-yxM">
-                                                    <rect key="frame" x="20" y="11.5" width="62" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="62" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="AOp-W0-9IK">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="printingEnabledSwitchChanged:" destination="cZY-Ss-RO9" eventType="valueChanged" id="16t-YV-fzn"/>
                                                     </connections>
@@ -693,35 +693,35 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cRl-5N-Vd6" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="5569" y="1247"/>
+            <point key="canvasLocation" x="4789" y="1247"/>
         </scene>
         <!--System-->
         <scene sceneID="HAX-p4-GLH">
             <objects>
                 <tableViewController id="1m7-hR-fRt" customClass="VMConfigSystemViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="GGE-SJ-g4A">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Hardware" id="spp-Cv-g7X">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="ziF-JQ-bTj" detailTextLabel="9fH-Qw-nVS" style="IBUITableViewCellStyleValue1" id="oTc-93-cjJ">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="oTc-93-cjJ" id="w8n-OI-JSe">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Architecture" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="ziF-JQ-bTj">
-                                                    <rect key="frame" x="20" y="12" width="94.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="94.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9fH-Qw-nVS">
-                                                    <rect key="frame" x="311" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="260" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -731,14 +731,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="199.99999999999997" id="dGM-cA-mXM">
-                                        <rect key="frame" x="0.0" y="99.5" width="388" height="200"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="333" height="200"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="dGM-cA-mXM" id="Ic3-FS-Es6">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="200"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="200"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VIt-Zi-7kt">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="200"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="1m7-hR-fRt" id="oWM-oa-PIF"/>
                                                         <outlet property="delegate" destination="1m7-hR-fRt" id="0tk-VA-2IH"/>
@@ -754,20 +754,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="VsJ-Zw-rWU">
-                                        <rect key="frame" x="0.0" y="299.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="299.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VsJ-Zw-rWU" id="wC7-Vx-zXt">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="MB" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qMH-Bx-PsC">
-                                                    <rect key="frame" x="329.5" y="12" width="25.5" height="20"/>
+                                                    <rect key="frame" x="278.5" y="12" width="25.5" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="512" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="OwS-jd-mte">
-                                                    <rect key="frame" x="161" y="11.5" width="160" height="21"/>
+                                                    <rect key="frame" x="110" y="11.5" width="160" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="ucu-F4-pNg"/>
                                                     </constraints>
@@ -779,7 +779,7 @@
                                                     </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Memory" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SvG-PI-7bh">
-                                                    <rect key="frame" x="20" y="12" width="63" height="20"/>
+                                                    <rect key="frame" x="16" y="12" width="63" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -798,20 +798,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="sAL-j0-QO6">
-                                        <rect key="frame" x="0.0" y="343.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="343.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sAL-j0-QO6" id="IUj-WK-FG9">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CPU Count" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XtU-FE-Mry">
-                                                    <rect key="frame" x="20" y="11.5" width="86" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="86" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="2" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="I4t-8W-Nev">
-                                                    <rect key="frame" x="203" y="11.5" width="152" height="21"/>
+                                                    <rect key="frame" x="199" y="11.5" width="105" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                     <connections>
@@ -830,21 +830,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="XhT-dg-bb9" detailTextLabel="KYQ-B4-Cf3" style="IBUITableViewCellStyleValue1" id="m8p-hi-s01">
-                                        <rect key="frame" x="0.0" y="387.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="387.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="m8p-hi-s01" id="ZrJ-KO-2G2">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="System" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="XhT-dg-bb9">
-                                                    <rect key="frame" x="20" y="12" width="57" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="57" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="KYQ-B4-Cf3">
-                                                    <rect key="frame" x="311" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="260" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -854,14 +854,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="100" id="kbU-h1-FsP">
-                                        <rect key="frame" x="0.0" y="431.5" width="388" height="100"/>
+                                        <rect key="frame" x="0.0" y="431.5" width="333" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kbU-h1-FsP" id="HJR-87-kHI">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="100"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="iB1-OW-p4N">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="100"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="333" height="100"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="1m7-hR-fRt" id="MLD-yU-D4a"/>
                                                         <outlet property="delegate" destination="1m7-hR-fRt" id="XCj-7h-pOC"/>
@@ -881,21 +881,21 @@
                             <tableViewSection headerTitle="Boot" id="aje-ee-mJi">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="Yzl-hW-dz8" detailTextLabel="bwc-uM-EKo" style="IBUITableViewCellStyleValue1" id="aN0-e6-gWq">
-                                        <rect key="frame" x="0.0" y="587.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="587.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aN0-e6-gWq" id="a3A-BY-NuO">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Try booting first from" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Yzl-hW-dz8">
-                                                    <rect key="frame" x="20" y="12" width="161.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="161.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Disk Drive" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="bwc-uM-EKo">
-                                                    <rect key="frame" x="277.5" y="12" width="77.5" height="20.5"/>
+                                                    <rect key="frame" x="226.5" y="12" width="77.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -905,14 +905,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="100" id="2tm-9Y-Ypg">
-                                        <rect key="frame" x="0.0" y="631.5" width="388" height="100"/>
+                                        <rect key="frame" x="0.0" y="631.5" width="333" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2tm-9Y-Ypg" id="02K-L5-unG">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="100"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="nc8-Yn-Bd2">
-                                                    <rect key="frame" x="0.0" y="0.0" width="388" height="100"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="333" height="100"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="1m7-hR-fRt" id="2Xi-Zh-bzB"/>
                                                         <outlet property="delegate" destination="1m7-hR-fRt" id="SpR-Fv-ijj"/>
@@ -927,34 +927,25 @@
                                             </constraints>
                                         </tableViewCellContentView>
                                     </tableViewCell>
-                                </cells>
-                            </tableViewSection>
-                            <tableViewSection headerTitle="Additional qemu arguments" id="vTy-bl-QrM">
-                                <cells>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="2lD-9C-lUf">
-                                        <rect key="frame" x="0.0" y="787.5" width="388" height="44"/>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="default" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationWidth="10" textLabel="7RD-FU-agJ" style="IBUITableViewCellStyleDefault" id="2lD-9C-lUf">
+                                        <rect key="frame" x="0.0" y="731.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="2lD-9C-lUf" id="b9d-4I-3HK">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
-                                                <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="eAV-yI-ZCT">
-                                                    <rect key="frame" x="8" y="11" width="372" height="22"/>
+                                                <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Additional QEMU Arguments" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7RD-FU-agJ">
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
+                                                    <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                                    <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet" returnKeyType="done" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
-                                                    <connections>
-                                                        <action selector="additionalArgsFieldEdited:" destination="1m7-hR-fRt" eventType="editingDidEnd" id="kwo-h9-oeJ"/>
-                                                        <outlet property="delegate" destination="1m7-hR-fRt" id="C7Q-Ag-Bsu"/>
-                                                    </connections>
-                                                </textField>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
                                             </subviews>
-                                            <constraints>
-                                                <constraint firstItem="eAV-yI-ZCT" firstAttribute="leading" secondItem="b9d-4I-3HK" secondAttribute="leadingMargin" id="MHm-34-Yqb"/>
-                                                <constraint firstItem="eAV-yI-ZCT" firstAttribute="trailing" secondItem="b9d-4I-3HK" secondAttribute="trailingMargin" id="dPJ-Yk-bHE"/>
-                                                <constraint firstItem="eAV-yI-ZCT" firstAttribute="top" secondItem="b9d-4I-3HK" secondAttribute="topMargin" id="gJy-KM-PoW"/>
-                                                <constraint firstAttribute="bottomMargin" secondItem="eAV-yI-ZCT" secondAttribute="bottom" id="hh8-ty-DgG"/>
-                                            </constraints>
                                         </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="90J-Vp-RTj" kind="show" id="jPf-Go-ZgV"/>
+                                        </connections>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -966,7 +957,6 @@
                     </tableView>
                     <navigationItem key="navigationItem" title="System" id="CRh-Zb-s8B"/>
                     <connections>
-                        <outlet property="additionalArgsField" destination="eAV-yI-ZCT" id="mdu-Ya-5Fw"/>
                         <outlet property="architectureCell" destination="oTc-93-cjJ" id="kZI-ga-SnU"/>
                         <outlet property="architectureLabel" destination="9fH-Qw-nVS" id="aet-o8-TaA"/>
                         <outlet property="architecturePicker" destination="VIt-Zi-7kt" id="cja-CO-VUd"/>
@@ -985,34 +975,34 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Pka-eP-b1w" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="4782" y="549"/>
+            <point key="canvasLocation" x="7102" y="1247"/>
         </scene>
         <!--Networking-->
         <scene sceneID="HjV-mS-zLm">
             <objects>
                 <tableViewController id="5KN-1q-y5w" customClass="VMConfigNetworkingViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Zh6-XT-e8H">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Hardware" id="qCe-97-Cma">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="f3B-Ca-xOy">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="f3B-Ca-xOy" id="pCJ-hP-4sO">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qHe-ss-OZw">
-                                                    <rect key="frame" x="20" y="11.5" width="62" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="62" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="TBl-Mf-rp9">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="networkingEnabledSwitchChanged:" destination="5KN-1q-y5w" eventType="valueChanged" id="b3q-tg-oxE"/>
                                                     </connections>
@@ -1028,20 +1018,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="L7E-R4-cxI">
-                                        <rect key="frame" x="0.0" y="99.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="L7E-R4-cxI" id="4pc-7p-05F">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Local Access Only" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="iS1-Ur-HFa">
-                                                    <rect key="frame" x="20" y="11.5" width="140" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="140" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CkD-IW-UX0">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="localAccessOnlySwitchChanged:" destination="5KN-1q-y5w" eventType="valueChanged" id="cOW-qq-gCh"/>
                                                     </connections>
@@ -1061,20 +1051,20 @@
                             <tableViewSection headerTitle="IP Configuration" id="mTW-BC-BPZ">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="8mF-uj-oTE">
-                                        <rect key="frame" x="0.0" y="199.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="8mF-uj-oTE" id="24L-rr-lhp">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Network" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fOG-3K-1lH">
-                                                    <rect key="frame" x="20" y="11.5" width="65" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="65" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="10.0.2.0/24" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="q6m-Ld-1jH">
-                                                    <rect key="frame" x="182" y="11.5" width="173" height="21"/>
+                                                    <rect key="frame" x="178" y="11.5" width="126" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numbersAndPunctuation" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                     <connections>
@@ -1093,20 +1083,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="aMG-yM-TGa">
-                                        <rect key="frame" x="0.0" y="243.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="243.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="aMG-yM-TGa" id="0gE-Fg-XZu">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="DHCP Start" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5O8-6K-mxz">
-                                                    <rect key="frame" x="20" y="11.5" width="89" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="89" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="10.0.2.0.15" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="sym-7m-1rq">
-                                                    <rect key="frame" x="206" y="11.5" width="149" height="21"/>
+                                                    <rect key="frame" x="202" y="11.5" width="102" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="decimalPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                     <connections>
@@ -1150,7 +1140,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="cR9-D8-uOs" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="qTC-Hg-D1R">
-                        <rect key="frame" x="0.0" y="0.0" width="1366" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -1170,21 +1160,21 @@
             <objects>
                 <tableViewController id="kXN-s4-nI5" customClass="VMConfigCreateViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="eEm-Kb-wUw">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Name" id="kxc-0J-xgO">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="kSL-rH-TmX">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="kSL-rH-TmX" id="pW8-2Y-MIA">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="Name" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0TR-HU-09X">
-                                                    <rect key="frame" x="16" y="11.5" width="343" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="288" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                     <connections>
@@ -1205,21 +1195,21 @@
                             <tableViewSection headerTitle="System" id="7nd-62-tFA">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="9Nu-pG-ywd" detailTextLabel="dhz-mO-gca" style="IBUITableViewCellStyleValue1" id="qee-8g-Jp9">
-                                        <rect key="frame" x="0.0" y="155.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="155.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="qee-8g-Jp9" id="G2J-aA-snj">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Architecture" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="9Nu-pG-ywd">
-                                                    <rect key="frame" x="20" y="12" width="94.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="94.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Detail" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="dhz-mO-gca">
-                                                    <rect key="frame" x="311" y="12" width="44" height="20.5"/>
+                                                    <rect key="frame" x="260" y="12" width="44" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1229,14 +1219,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="200" id="bc3-f4-6aK">
-                                        <rect key="frame" x="0.0" y="199.5" width="388" height="200"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="333" height="200"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="bc3-f4-6aK" id="Xhf-Hc-ucC">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="200"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="200"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YFu-oU-5Lh">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="200"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="200"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="kXN-s4-nI5" id="TlV-5Q-ltZ"/>
                                                         <outlet property="delegate" destination="kXN-s4-nI5" id="ErN-fy-oUU"/>
@@ -1252,20 +1242,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="0aj-qm-Pjc">
-                                        <rect key="frame" x="0.0" y="399.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="399.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="0aj-qm-Pjc" id="5im-ce-owp">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="MB" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MAs-NR-G0n">
-                                                    <rect key="frame" x="329.5" y="12" width="25.5" height="20"/>
+                                                    <rect key="frame" x="278.5" y="12" width="25.5" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="512" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="S2s-iX-Lul">
-                                                    <rect key="frame" x="161" y="11.5" width="160" height="21"/>
+                                                    <rect key="frame" x="110" y="11.5" width="160" height="21"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="o84-0K-Csk"/>
                                                     </constraints>
@@ -1277,7 +1267,7 @@
                                                     </connections>
                                                 </textField>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="Memory" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HRc-mq-43y">
-                                                    <rect key="frame" x="20" y="12" width="63" height="20"/>
+                                                    <rect key="frame" x="16" y="12" width="63" height="20"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1296,20 +1286,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="eDp-ox-TsC">
-                                        <rect key="frame" x="0.0" y="443.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="443.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="eDp-ox-TsC" id="qso-C3-rNk">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CPU Count" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HlJ-Fd-TPS">
-                                                    <rect key="frame" x="20" y="11.5" width="86" height="21"/>
+                                                    <rect key="frame" x="8" y="11.5" width="86" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="2" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="VBD-VX-Usg">
-                                                    <rect key="frame" x="203" y="11.5" width="152" height="21"/>
+                                                    <rect key="frame" x="191" y="11.5" width="134" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                     <connections>
@@ -1332,14 +1322,14 @@
                             <tableViewSection headerTitle="Drives" id="wDi-gr-I7A">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="AP0-ME-jBc" style="IBUITableViewCellStyleDefault" id="POc-sX-Hg2">
-                                        <rect key="frame" x="0.0" y="543.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="543.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="POc-sX-Hg2" id="c2R-t0-duR">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Setup Drives" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="AP0-ME-jBc">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1352,21 +1342,21 @@
                                         </connections>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" textLabel="wrM-Ql-L8D" detailTextLabel="gaX-u8-yz8" style="IBUITableViewCellStyleValue1" id="UAO-KH-tjE">
-                                        <rect key="frame" x="0.0" y="587.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="587.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UAO-KH-tjE" id="Mn0-LS-cbn">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Try booting first from" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="wrM-Ql-L8D">
-                                                    <rect key="frame" x="20" y="12" width="161.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="161.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Disk Drive" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="gaX-u8-yz8">
-                                                    <rect key="frame" x="277.5" y="12" width="77.5" height="20.5"/>
+                                                    <rect key="frame" x="226.5" y="12" width="77.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1376,14 +1366,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" rowHeight="100" id="sht-Hg-il9">
-                                        <rect key="frame" x="0.0" y="631.5" width="388" height="100"/>
+                                        <rect key="frame" x="0.0" y="631.5" width="333" height="100"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="sht-Hg-il9" id="Nhm-cJ-dDa">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="100"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="100"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Z8I-Uh-eB4">
-                                                    <rect key="frame" x="0.0" y="0.0" width="388" height="100"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="333" height="100"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="kXN-s4-nI5" id="Yzs-wk-BNj"/>
                                                         <outlet property="delegate" destination="kXN-s4-nI5" id="SIV-qZ-zMY"/>
@@ -1403,14 +1393,14 @@
                             <tableViewSection headerTitle="Advanced" id="F7q-42-AmC">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="checkmark" indentationWidth="10" textLabel="7DJ-Cp-oMO" style="IBUITableViewCellStyleDefault" id="1Mz-8y-xuP">
-                                        <rect key="frame" x="0.0" y="787.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="787.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="1Mz-8y-xuP" id="DIe-iC-1u8">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="301" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Open Configuration after Creation" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="7DJ-Cp-oMO">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="15" y="0.0" width="278" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1469,26 +1459,26 @@
             <objects>
                 <tableViewController id="Mbd-uC-JXQ" customClass="VMConfigDrivesViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" id="aJj-uC-ujn">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" reuseIdentifier="existingDrive" textLabel="SwZ-ol-btE" detailTextLabel="3G1-cS-MAp" style="IBUITableViewCellStyleSubtitle" id="fdY-fw-waW">
-                                <rect key="frame" x="0.0" y="28" width="388" height="55.5"/>
+                                <rect key="frame" x="0.0" y="28" width="333" height="55.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="fdY-fw-waW" id="Jub-YA-0gw">
-                                    <rect key="frame" x="13" y="0.0" width="344" height="55.5"/>
+                                    <rect key="frame" x="13" y="0.0" width="293" height="55.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="SwZ-ol-btE">
-                                            <rect key="frame" x="20" y="10" width="33.5" height="20.5"/>
+                                            <rect key="frame" x="16" y="10" width="33.5" height="20.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Subtitle" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="3G1-cS-MAp">
-                                            <rect key="frame" x="20" y="31.5" width="44" height="14.5"/>
+                                            <rect key="frame" x="16" y="31.5" width="44" height="14.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                             <nil key="textColor"/>
@@ -1526,28 +1516,28 @@
             <objects>
                 <tableViewController id="LEE-I0-SfL" customClass="VMConfigDriveDetailViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="pfD-3f-7bE">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Image" id="SCF-Z9-xBk">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" textLabel="CDM-d1-Xuf" detailTextLabel="iuP-Eh-P68" style="IBUITableViewCellStyleValue1" id="VTl-xi-ink">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="VTl-xi-ink" id="94n-ta-l2f">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Path" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="CDM-d1-Xuf">
-                                                    <rect key="frame" x="20" y="12" width="35" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="35" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Select..." textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="iuP-Eh-P68">
-                                                    <rect key="frame" x="273.5" y="12" width="62.5" height="20.5"/>
+                                                    <rect key="frame" x="222.5" y="12" width="62.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1564,20 +1554,20 @@
                             <tableViewSection headerTitle="Type" id="S3p-5d-Mq8">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="hYN-7w-tk5">
-                                        <rect key="frame" x="0.0" y="155.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="155.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="hYN-7w-tk5" id="MTf-if-aHq">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rQW-wG-USc">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="isCdromSwitchChanged:" destination="LEE-I0-SfL" eventType="valueChanged" id="7QO-iL-8iC"/>
                                                     </connections>
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CD/DVD Drive" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qVo-Pu-Z7E">
-                                                    <rect key="frame" x="20" y="11.5" width="107" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="107" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
@@ -1594,21 +1584,21 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="EGI-JP-qwU" detailTextLabel="rbw-FB-I5Q" style="IBUITableViewCellStyleValue1" id="17E-cW-AVf">
-                                        <rect key="frame" x="0.0" y="199.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="199.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="17E-cW-AVf" id="gtn-y6-uIO">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Location" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="EGI-JP-qwU">
-                                                    <rect key="frame" x="20" y="12" width="65.5" height="20.5"/>
+                                                    <rect key="frame" x="16" y="12" width="65.5" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="hda1" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="rbw-FB-I5Q">
-                                                    <rect key="frame" x="319" y="12" width="36" height="20.5"/>
+                                                    <rect key="frame" x="268" y="12" width="36" height="20.5"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -1618,14 +1608,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" rowHeight="150" id="zfI-4u-KMR">
-                                        <rect key="frame" x="0.0" y="243.5" width="388" height="150"/>
+                                        <rect key="frame" x="0.0" y="243.5" width="333" height="150"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zfI-4u-KMR" id="pIS-w8-SdC">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="150"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="150"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <pickerView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3H8-Sz-6cX">
-                                                    <rect key="frame" x="0.0" y="0.0" width="375" height="150"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="320" height="150"/>
                                                     <connections>
                                                         <outlet property="dataSource" destination="LEE-I0-SfL" id="mOl-8M-Ehr"/>
                                                         <outlet property="delegate" destination="LEE-I0-SfL" id="DWR-dN-hDX"/>
@@ -1668,19 +1658,19 @@
             <objects>
                 <tableViewController id="yxX-vB-sfR" customClass="VMConfigDrivePickerViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="7Kc-IE-CFO">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="diskImageCell" editingAccessoryType="detailButton" textLabel="FFD-Jl-stc" style="IBUITableViewCellStyleDefault" id="cDV-Sv-rNv">
-                                <rect key="frame" x="0.0" y="55.5" width="388" height="43.5"/>
+                                <rect key="frame" x="0.0" y="55.5" width="333" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="cDV-Sv-rNv" id="4kG-UL-Xzq">
-                                    <rect key="frame" x="13" y="0.0" width="375" height="43.5"/>
+                                    <rect key="frame" x="13" y="0.0" width="320" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="FFD-Jl-stc">
-                                            <rect key="frame" x="20" y="0.0" width="335" height="43.5"/>
+                                            <rect key="frame" x="16" y="0.0" width="288" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                             <nil key="textColor"/>
@@ -1719,27 +1709,27 @@
             <objects>
                 <tableViewController id="zWu-Ga-qH8" customClass="VMConfigDriveCreateViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="PvF-QV-x2T">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Basic" id="npu-cv-8wY">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="ATe-GU-gtb">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ATe-GU-gtb" id="4Pz-NG-WeE">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Name" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a1E-lK-5Yg">
-                                                    <rect key="frame" x="20" y="11.5" width="45" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="45" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="hda.img" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Dx6-pD-sU3">
-                                                    <rect key="frame" x="162" y="11.5" width="193" height="21"/>
+                                                    <rect key="frame" x="158" y="11.5" width="146" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" keyboardType="alphabet" returnKeyType="done" enablesReturnKeyAutomatically="YES" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
                                                     <connections>
@@ -1757,26 +1747,26 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="XXX-uo-0Ss">
-                                        <rect key="frame" x="0.0" y="99.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="XXX-uo-0Ss" id="845-DW-I85">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Size" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2r8-dE-rzF">
-                                                    <rect key="frame" x="20" y="11.5" width="33" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="33" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="MB" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u4W-r9-V11">
-                                                    <rect key="frame" x="329" y="11.5" width="26" height="21"/>
+                                                    <rect key="frame" x="278" y="11.5" width="26" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="1024" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="nKg-bw-usb">
-                                                    <rect key="frame" x="282.5" y="11.5" width="38.5" height="21"/>
+                                                    <rect key="frame" x="231.5" y="11.5" width="38.5" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done" enablesReturnKeyAutomatically="YES"/>
                                                     <connections>
@@ -1797,20 +1787,20 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="AqL-Sy-uGb">
-                                        <rect key="frame" x="0.0" y="143.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="143.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="AqL-Sy-uGb" id="iRE-BO-iLZ">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Expanding" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Nom-x9-xrU">
-                                                    <rect key="frame" x="20" y="11.5" width="81" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="81" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="h64-WC-JVU">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="imageExpandingSwitchChanged:" destination="zWu-Ga-qH8" eventType="valueChanged" id="RcA-ih-sYF"/>
                                                     </connections>
@@ -1874,7 +1864,7 @@
             <objects>
                 <viewController modalTransitionStyle="flipHorizontal" hidesBottomBarWhenPushed="YES" id="ckC-eO-gxn" userLabel="Display Metal" customClass="VMDisplayMetalViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="WSe-Ri-b4c">
-                        <rect key="frame" x="0.0" y="0.0" width="1366" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="0Mf-V7-Aot" customClass="VMKeyboardView">
@@ -1889,22 +1879,22 @@
                                 </connections>
                             </view>
                             <mtkView contentMode="scaleToFill" colorPixelFormat="BGRA8Unorm" depthStencilPixelFormat="Depth32Float" translatesAutoresizingMaskIntoConstraints="NO" id="ZK0-vH-7ok">
-                                <rect key="frame" x="0.0" y="0.0" width="1366" height="1024"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                             </mtkView>
                             <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="VFv-zJ-H5K" userLabel="Toolbar Accessory View">
-                                <rect key="frame" x="0.0" y="0.0" width="1366" height="45"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="45"/>
                                 <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="9yD-Nn-OmR">
-                                    <rect key="frame" x="0.0" y="0.0" width="1366" height="45"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="768" height="45"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <visualEffectView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FYx-cc-jqE">
-                                            <rect key="frame" x="0.0" y="0.0" width="1366" height="45"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="768" height="45"/>
                                             <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="TyK-03-3ux">
-                                                <rect key="frame" x="0.0" y="0.0" width="1366" height="45"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="768" height="45"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="Z0A-c7-3p0">
-                                                        <rect key="frame" x="1182" y="7" width="168" height="30"/>
+                                                        <rect key="frame" x="584" y="7" width="168" height="30"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="m9f-Az-rlH">
                                                                 <rect key="frame" x="0.0" y="0.0" width="30" height="30"/>
@@ -2567,7 +2557,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="2Ff-Ox-yNa" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="9ZU-1e-Pxb">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="50"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="50"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -2584,27 +2574,27 @@
             <objects>
                 <tableViewController id="wCA-Kf-QNP" customClass="VMConfigSoundViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="K36-FW-2X0">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Hardware" id="CeH-xF-3fF">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="nGB-MQ-eF1">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nGB-MQ-eF1" id="3rW-9q-ULI">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aHx-sa-LGi">
-                                                    <rect key="frame" x="20" y="11.5" width="62" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="62" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZtR-9f-f7S">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="soundEnabledSwitchChanged:" destination="wCA-Kf-QNP" eventType="valueChanged" id="41a-rx-B2T"/>
                                                     </connections>
@@ -2641,27 +2631,27 @@
             <objects>
                 <tableViewController id="LLP-fa-BIK" customClass="VMConfigSharingViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="Pqv-sq-ss2">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Clipboard Sharing" id="Fjo-PM-Pc6">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="none" indentationWidth="10" id="Op0-ty-SlQ">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Op0-ty-SlQ" id="gIY-bZ-Sry">
-                                            <rect key="frame" x="13" y="0.0" width="375" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Enabled" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gTm-35-vCi">
-                                                    <rect key="frame" x="20" y="11.5" width="62" height="21"/>
+                                                    <rect key="frame" x="16" y="11.5" width="62" height="21"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d0M-jH-bn7">
-                                                    <rect key="frame" x="306" y="6.5" width="51" height="31"/>
+                                                    <rect key="frame" x="255" y="6.5" width="51" height="31"/>
                                                     <connections>
                                                         <action selector="clipboardSharingEnabledSwitchChanged:" destination="LLP-fa-BIK" eventType="valueChanged" id="h2h-UQ-8ba"/>
                                                     </connections>
@@ -2681,14 +2671,14 @@
                             <tableViewSection headerTitle="Shared Directories" id="dpu-6y-nD0">
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="DvR-Gm-qGA" style="IBUITableViewCellStyleDefault" id="nmW-d9-PT5">
-                                        <rect key="frame" x="0.0" y="155.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="155.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="nmW-d9-PT5" id="ddR-Mm-4Vn">
-                                            <rect key="frame" x="13" y="0.0" width="344" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="293" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Add new..." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="DvR-Gm-qGA">
-                                                    <rect key="frame" x="20" y="0.0" width="316" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="269" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2712,14 +2702,14 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="aec-Ui-ggd" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="6342" y="1247"/>
+            <point key="canvasLocation" x="5569" y="1247"/>
         </scene>
         <!--Input-->
         <scene sceneID="puh-VJ-3sO">
             <objects>
                 <tableViewController id="5Cr-yW-csz" customClass="VMConfigInputViewController" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" keyboardDismissMode="onDrag" dataMode="static" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="uYR-AQ-z2d">
-                        <rect key="frame" x="0.0" y="0.0" width="388" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
@@ -2727,14 +2717,14 @@
                                 <string key="footerTitle">Touchscreen: press anywhere on the screen to click there. Trackpad: move cursor by swipping on the screen and click with a tap. Right click with a two finger tap.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="8i0-5U-XCb" style="IBUITableViewCellStyleDefault" id="Ocd-JM-JrU">
-                                        <rect key="frame" x="0.0" y="55.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="55.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Ocd-JM-JrU" id="ZTn-UL-DZN">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Touchscreen" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="8i0-5U-XCb">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2744,14 +2734,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="jU3-rH-M1U" style="IBUITableViewCellStyleDefault" id="s7O-e0-wWW">
-                                        <rect key="frame" x="0.0" y="99.5" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="99.5" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="s7O-e0-wWW" id="ls3-l4-B5O">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Trackpad" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="jU3-rH-M1U">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2766,14 +2756,14 @@
                                 <string key="footerTitle">Direct: input sent to emulator directly. Can appear to be out of sync with display. Server: input sent to display server. Can have more latency but appear more responsive.</string>
                                 <cells>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="PYT-mF-w3w" style="IBUITableViewCellStyleDefault" id="Wy9-zW-xLY">
-                                        <rect key="frame" x="0.0" y="251" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="267" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="Wy9-zW-xLY" id="yUN-HI-j3r">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Direct" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="PYT-mF-w3w">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2783,14 +2773,14 @@
                                         </tableViewCellContentView>
                                     </tableViewCell>
                                     <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" accessoryType="checkmark" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" textLabel="W6T-YK-tv3" style="IBUITableViewCellStyleDefault" id="UgT-7q-52X">
-                                        <rect key="frame" x="0.0" y="295" width="388" height="44"/>
+                                        <rect key="frame" x="0.0" y="311" width="333" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="UgT-7q-52X" id="a8b-6i-Pok">
-                                            <rect key="frame" x="13" y="0.0" width="331" height="44"/>
+                                            <rect key="frame" x="13" y="0.0" width="280" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <label opaque="NO" multipleTouchEnabled="YES" contentMode="left" insetsLayoutMarginsFromSafeArea="NO" text="Server" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="W6T-YK-tv3">
-                                                    <rect key="frame" x="20" y="0.0" width="303" height="44"/>
+                                                    <rect key="frame" x="16" y="0.0" width="256" height="44"/>
                                                     <autoresizingMask key="autoresizingMask"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <nil key="textColor"/>
@@ -2817,7 +2807,69 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="fxK-8x-htX" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="7103" y="1247"/>
+            <point key="canvasLocation" x="6343" y="1247"/>
+        </scene>
+        <!--Additional QEMU Arguments-->
+        <scene sceneID="wS1-0Y-UiQ">
+            <objects>
+                <tableViewController id="90J-Vp-RTj" userLabel="Additional QEMU Arguments" customClass="VMConfigSystemArgumentsViewController" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="e6v-mL-FH9">
+                        <rect key="frame" x="0.0" y="0.0" width="333" height="480"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <prototypes>
+                            <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="none" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="argumentCell" id="lie-mw-zqD" customClass="VMConfigSystemArgumentsTextCell">
+                                <rect key="frame" x="0.0" y="55.5" width="333" height="43.5"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lie-mw-zqD" id="lNr-hu-oMV">
+                                    <rect key="frame" x="13" y="0.0" width="320" height="43.5"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="QEMU Args" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="upL-Oh-a3A">
+                                            <rect key="frame" x="16" y="13.5" width="288" height="17"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartInsertDeleteType="no" smartQuotesType="no"/>
+                                            <connections>
+                                                <action selector="editingDidEnd:" destination="lie-mw-zqD" eventType="editingDidEnd" id="GwW-M0-bKM"/>
+                                                <action selector="touchWasCancelled:" destination="lie-mw-zqD" eventType="touchCancel" id="7nn-iT-9g1"/>
+                                                <action selector="valueWasChanged:" destination="lie-mw-zqD" eventType="editingDidEnd" id="dto-Gl-FPS"/>
+                                                <outlet property="delegate" destination="e6v-mL-FH9" id="86C-Id-1mL"/>
+                                            </connections>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="upL-Oh-a3A" firstAttribute="leading" secondItem="lNr-hu-oMV" secondAttribute="leading" constant="16" id="Z3u-kZ-erp"/>
+                                        <constraint firstItem="upL-Oh-a3A" firstAttribute="centerY" secondItem="lNr-hu-oMV" secondAttribute="centerY" id="aj5-aW-g4S"/>
+                                        <constraint firstAttribute="trailing" secondItem="upL-Oh-a3A" secondAttribute="trailing" constant="16" id="kdL-BT-Gi5"/>
+                                    </constraints>
+                                </tableViewCellContentView>
+                                <connections>
+                                    <outlet property="argTextItem" destination="upL-Oh-a3A" id="a0A-Ee-MG0"/>
+                                </connections>
+                            </tableViewCell>
+                        </prototypes>
+                        <connections>
+                            <outlet property="dataSource" destination="90J-Vp-RTj" id="Ejq-vt-rd9"/>
+                            <outlet property="delegate" destination="90J-Vp-RTj" id="BVI-Xg-brF"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Additional QEMU Arguments" id="Vsj-CY-Ew5">
+                        <barButtonItem key="rightBarButtonItem" systemItem="add" id="nFI-03-aNY">
+                            <connections>
+                                <action selector="addButton:" destination="90J-Vp-RTj" id="rCi-9p-9Aj"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
+                    <connections>
+                        <outlet property="addButtonItem" destination="nFI-03-aNY" id="lDI-Ab-T6C"/>
+                        <outlet property="argTableView" destination="e6v-mL-FH9" id="EC7-8b-Xen"/>
+                        <segue destination="P88-cm-4Gl" kind="unwind" identifier="returnToDetailSegue" unwindAction="unwindToDriveDetailFromDrivePicker:" id="xKL-Za-lY4"/>
+                    </connections>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CNG-hO-b7A" userLabel="First Responder" sceneMemberID="firstResponder"/>
+                <exit id="P88-cm-4Gl" userLabel="Exit" sceneMemberID="exit"/>
+            </objects>
+            <point key="canvasLocation" x="7922.65625" y="1246.875"/>
         </scene>
     </scenes>
     <resources>
@@ -2835,7 +2887,7 @@
     <inferredMetricsTieBreakers>
         <segue reference="0fe-13-GUd"/>
         <segue reference="M4J-mO-49e"/>
-        <segue reference="eOg-7f-ZC7"/>
+        <segue reference="QMb-O0-K4I"/>
         <segue reference="Ch9-qF-y79"/>
     </inferredMetricsTieBreakers>
 </document>


### PR DESCRIPTION
This partially completes #93. It provides an additional table view separating boot arguments, and has a working method to split the list argument into valid, passable arguments.

Some UX is rather janky in regards to removing inputted text from the UI, so I am submitting this as-is via draft. It additionally does not display flags visually anywhere as the issue calls for.