### PR TITLE
Save view state

### DIFF
--- a/Configuration/UTMViewState.h
+++ b/Configuration/UTMViewState.h
@@ -1,0 +1,36 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface UTMViewState : NSObject
+
+@property (nonatomic, weak, readonly) NSDictionary *dictRepresentation;
+
+@property (nonatomic, assign) double displayScale;
+@property (nonatomic, assign) double displayOriginX;
+@property (nonatomic, assign) double displayOriginY;
+@property (nonatomic, assign) BOOL showToolbar;
+@property (nonatomic, assign) BOOL showKeyboard;
+
+- (id)initDefaults;
+- (id)initWithDictionary:(NSMutableDictionary *)dictionary;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Configuration/UTMViewState.m
+++ b/Configuration/UTMViewState.m
@@ -1,0 +1,104 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#import "UTMViewState.h"
+
+const NSString *const kUTMViewStateDisplayScaleKey = @"DisplayScale";
+const NSString *const kUTMViewStateDisplayOriginXKey = @"DisplayOriginX";
+const NSString *const kUTMViewStateDisplayOriginYKey = @"DisplayOriginY";
+const NSString *const kUTMViewStateShowToolbarKey = @"ShowToolbar";
+const NSString *const kUTMViewStateShowKeyboardKey = @"ShowKeyboard";
+
+@interface UTMViewState ()
+
+@property (nonatomic, nullable) NSURL *path;
+
+@end
+
+@implementation UTMViewState {
+    NSMutableDictionary *_rootDict;
+}
+
+#pragma mark - Properties
+
+- (NSDictionary *)dictRepresentation {
+    return (NSDictionary *)_rootDict;
+}
+
+- (double)displayScale {
+    return [_rootDict[kUTMViewStateDisplayScaleKey] doubleValue];
+}
+
+- (void)setDisplayScale:(double)displayScale {
+    _rootDict[kUTMViewStateDisplayScaleKey] = [NSNumber numberWithDouble:displayScale];
+}
+
+- (double)displayOriginX {
+    return [_rootDict[kUTMViewStateDisplayOriginXKey] doubleValue];
+}
+
+- (void)setDisplayOriginX:(double)displayOriginX {
+    _rootDict[kUTMViewStateDisplayOriginXKey] = [NSNumber numberWithDouble:displayOriginX];
+}
+
+- (double)displayOriginY {
+    return [_rootDict[kUTMViewStateDisplayOriginYKey] doubleValue];
+}
+
+- (void)setDisplayOriginY:(double)displayOriginY {
+    _rootDict[kUTMViewStateDisplayOriginYKey] = [NSNumber numberWithDouble:displayOriginY];
+}
+
+- (BOOL)showToolbar {
+    return [_rootDict[kUTMViewStateShowToolbarKey] boolValue];
+}
+
+- (void)setShowToolbar:(BOOL)showToolbar {
+    _rootDict[kUTMViewStateShowToolbarKey] = [NSNumber numberWithBool:showToolbar];
+}
+
+- (BOOL)showKeyboard {
+    return [_rootDict[kUTMViewStateShowKeyboardKey] boolValue];
+}
+
+- (void)setShowKeyboard:(BOOL)showKeyboard {
+    _rootDict[kUTMViewStateShowKeyboardKey] = [NSNumber numberWithBool:showKeyboard];
+}
+
+#pragma mark - Init
+
+- (id)initDefaults {
+    self = [self init];
+    if (self) {
+        _rootDict = [NSMutableDictionary dictionary];
+        self.displayScale = 1.0;
+        self.displayOriginX = 0;
+        self.displayOriginY = 0;
+        self.showKeyboard = NO;
+        self.showToolbar = YES;
+    }
+    return self;
+}
+
+- (id)initWithDictionary:(NSMutableDictionary *)dictionary {
+    self = [self init];
+    if (self) {
+        _rootDict = dictionary;
+    }
+    return self;
+}
+
+@end

--- a/Managers/UTMVirtualMachineDelegate.h
+++ b/Managers/UTMVirtualMachineDelegate.h
@@ -43,6 +43,8 @@ typedef NS_ENUM(NSUInteger, UTMVMState) {
 @property (nonatomic, weak) CSDisplayMetal *vmDisplay;
 @property (nonatomic, weak) CSInput *vmInput;
 @property (nonatomic, weak) UTMConfiguration *vmConfiguration;
+@property (nonatomic, assign) BOOL toolbarVisible;
+@property (nonatomic, assign) BOOL keyboardVisible;
 
 - (void)virtualMachine:(UTMVirtualMachine *)vm transitionToState:(UTMVMState)state;
 

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -256,6 +256,7 @@
 		CE5E4958225C5A4400148CEF /* VMConfigExistingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE5E4957225C5A4400148CEF /* VMConfigExistingViewController.m */; };
 		CE5F165C2261395000F3D56B /* UTMVirtualMachine.m in Sources */ = {isa = PBXBuildFile; fileRef = CE5F165B2261395000F3D56B /* UTMVirtualMachine.m */; };
 		CE664511226935F000B0849A /* CSInput.m in Sources */ = {isa = PBXBuildFile; fileRef = CE664510226935F000B0849A /* CSInput.m */; };
+		CE6EDCDF241C4A6800A719DC /* UTMViewState.m in Sources */ = {isa = PBXBuildFile; fileRef = CE6EDCDE241C4A6800A719DC /* UTMViewState.m */; };
 		CE74C288225D88ED004E4FF1 /* VMConfigNetworkingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE74C276225D88EC004E4FF1 /* VMConfigNetworkingViewController.m */; };
 		CE74C28A225D88ED004E4FF1 /* VMConfigPrintingViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE74C279225D88EC004E4FF1 /* VMConfigPrintingViewController.m */; };
 		CE74C28B225D88ED004E4FF1 /* VMConfigDisplayViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = CE74C27D225D88EC004E4FF1 /* VMConfigDisplayViewController.m */; };
@@ -751,6 +752,8 @@
 		CE66450E2269355F00B0849A /* CocoaSpice.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CocoaSpice.h; sourceTree = "<group>"; };
 		CE66450F226935F000B0849A /* CSInput.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CSInput.h; sourceTree = "<group>"; };
 		CE664510226935F000B0849A /* CSInput.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CSInput.m; sourceTree = "<group>"; };
+		CE6EDCDD241C4A6800A719DC /* UTMViewState.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UTMViewState.h; sourceTree = "<group>"; };
+		CE6EDCDE241C4A6800A719DC /* UTMViewState.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UTMViewState.m; sourceTree = "<group>"; };
 		CE74C276225D88EC004E4FF1 /* VMConfigNetworkingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMConfigNetworkingViewController.m; sourceTree = "<group>"; };
 		CE74C277225D88EC004E4FF1 /* VMConfigSystemViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = VMConfigSystemViewController.h; sourceTree = "<group>"; };
 		CE74C279225D88EC004E4FF1 /* VMConfigPrintingViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = VMConfigPrintingViewController.m; sourceTree = "<group>"; };
@@ -998,6 +1001,8 @@
 				CE31C243225E553500A965DD /* UTMConfiguration.h */,
 				CE31C244225E555600A965DD /* UTMConfiguration.m */,
 				CE31C246225E9FED00A965DD /* UTMConfigurationDelegate.h */,
+				CE6EDCDD241C4A6800A719DC /* UTMViewState.h */,
+				CE6EDCDE241C4A6800A719DC /* UTMViewState.m */,
 			);
 			path = Configuration;
 			sourceTree = "<group>";
@@ -1540,6 +1545,7 @@
 				CE36B26A22763F28004A1435 /* UTMJSONStream.m in Sources */,
 				CE23C18023FCEC0A001177D6 /* qapi-commands-sockets.c in Sources */,
 				CE2C67D8227F6F1200AEF1D0 /* VMConfigDrivePickerViewController.m in Sources */,
+				CE6EDCDF241C4A6800A719DC /* UTMViewState.m in Sources */,
 				CE2C67DB227F769300AEF1D0 /* VMConfigDriveCreateViewController.m in Sources */,
 				CE26FC25226EBC5A0090BE9B /* CSMain.m in Sources */,
 				CE23C19223FCEC0A001177D6 /* qapi-visit-block-core.c in Sources */,

--- a/Views/VMDisplayMetalViewController.m
+++ b/Views/VMDisplayMetalViewController.m
@@ -161,6 +161,9 @@
     // Feedback generator for clicks
     self.clickFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
     self.resizeFeedbackGenerator = [[UIImpactFeedbackGenerator alloc] init];
+    
+    [self addObserver:self forKeyPath:@"vmDisplay.viewportScale" options:0 context:nil];
+    [self addObserver:self forKeyPath:@"vmDisplay.displaySize" options:0 context:nil];
 }
 
 - (void)viewWillAppear:(BOOL)animated {
@@ -169,8 +172,6 @@
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillShow:) name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillHide:) name:UIKeyboardWillHideNotification object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(keyboardWillChangeFrame:) name:UIKeyboardWillChangeFrameNotification object:nil];
-    [self addObserver:self forKeyPath:@"vmDisplay.viewportScale" options:0 context:nil];
-    [self addObserver:self forKeyPath:@"vmDisplay.displaySize" options:0 context:nil];
 }
 
 - (void)viewWillDisappear:(BOOL)animated {
@@ -179,8 +180,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillShowNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillHideNotification object:nil];
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillChangeFrameNotification object:nil];
-    [self removeObserver:self forKeyPath:@"vmDisplay.viewportScale"];
-    [self removeObserver:self forKeyPath:@"vmDisplay.displaySize"];
 }
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary<NSKeyValueChangeKey,id> *)change context:(void *)context {

--- a/Views/VMDisplayMetalViewController.m
+++ b/Views/VMDisplayMetalViewController.m
@@ -55,6 +55,10 @@
     UITapGestureRecognizer *_twoTap;
     UILongPressGestureRecognizer *_longPress;
     UIPinchGestureRecognizer *_pinch;
+    
+    // visibility
+    BOOL _toolbarVisible;
+    BOOL _keyboardVisible;
 }
 
 @synthesize vmScreenshot;
@@ -162,6 +166,9 @@
     self.clickFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
     self.resizeFeedbackGenerator = [[UIImpactFeedbackGenerator alloc] init];
     
+    // view state and observers
+    _toolbarVisible = YES;
+    _keyboardVisible = NO;
     [self addObserver:self forKeyPath:@"vmDisplay.viewportScale" options:0 context:nil];
     [self addObserver:self forKeyPath:@"vmDisplay.displaySize" options:0 context:nil];
 }
@@ -413,20 +420,20 @@ static CGFloat CGPointToPixel(CGFloat point) {
 
 - (IBAction)gestureSwipeUp:(UISwipeGestureRecognizer *)sender {
     if (sender.state == UIGestureRecognizerStateEnded) {
-        if (!self.toolbarAccessoryView.hidden) {
-            [self hideToolbar];
-        } else if (!self.keyboardView.isFirstResponder) {
-            [self.keyboardView becomeFirstResponder];
+        if (self.toolbarVisible) {
+            self.toolbarVisible = NO;
+        } else if (!self.keyboardVisible) {
+            self.keyboardVisible = YES;
         }
     }
 }
 
 - (IBAction)gestureSwipeDown:(UISwipeGestureRecognizer *)sender {
     if (sender.state == UIGestureRecognizerStateEnded) {
-        if (self.keyboardView.isFirstResponder) {
-            [self.keyboardView resignFirstResponder];
-        } else if (self.toolbarAccessoryView.hidden) {
-            [self showToolbar];
+        if (self.keyboardVisible) {
+            self.keyboardVisible = NO;
+        } else if (!self.toolbarVisible) {
+            self.toolbarVisible = YES;
         }
     }
 }
@@ -514,6 +521,32 @@ static CGFloat CGPointToPixel(CGFloat point) {
     } completion:nil];
 }
 
+- (BOOL)toolbarVisible {
+    return _toolbarVisible;
+}
+
+- (void)setToolbarVisible:(BOOL)toolbarVisible {
+    if (toolbarVisible) {
+        [self showToolbar];
+    } else {
+        [self hideToolbar];
+    }
+    _toolbarVisible = toolbarVisible;
+}
+
+- (BOOL)keyboardVisible {
+    return _keyboardVisible;
+}
+
+- (void)setKeyboardVisible:(BOOL)keyboardVisible {
+    if (keyboardVisible) {
+        [self.keyboardView becomeFirstResponder];
+    } else {
+        [self.keyboardView resignFirstResponder];
+    }
+    _keyboardVisible = keyboardVisible;
+}
+
 - (void)setLastDisplayChangeResize:(BOOL)lastDisplayChangeResize {
     _lastDisplayChangeResize = lastDisplayChangeResize;
     if (lastDisplayChangeResize) {
@@ -562,15 +595,11 @@ static CGFloat CGPointToPixel(CGFloat point) {
 }
 
 - (IBAction)showKeyboardButton:(UIButton *)sender {
-    if (self.keyboardView.isFirstResponder) {
-        [self.keyboardView resignFirstResponder];
-    } else {
-        [self.keyboardView becomeFirstResponder];
-    }
+    self.keyboardVisible = !self.keyboardVisible;
 }
 
 - (IBAction)hideToolbarButton:(UIButton *)sender {
-    [self hideToolbar];
+    self.toolbarVisible = NO;
     NSUserDefaults *defaults = [NSUserDefaults standardUserDefaults];
     if (![defaults boolForKey:@"HasShownHideToolbarAlert"]) {
         [self showAlert:NSLocalizedString(@"Hint: To show the toolbar again, use a three-finger swipe down on the screen.", @"Shown once when hiding toolbar.") completion:^(UIAlertAction *action){

--- a/Views/VMListViewController.m
+++ b/Views/VMListViewController.m
@@ -46,6 +46,8 @@
 @synthesize vmDisplay;
 @synthesize vmInput;
 @synthesize vmConfiguration;
+@synthesize toolbarVisible;
+@synthesize keyboardVisible;
 
 - (void)viewDidLoad {
     [super viewDidLoad];


### PR DESCRIPTION
This implements a way to save the current view state for the VM. This includes the scaling, and origin X, Y positions as well as the visibility of the toolbar and keyboard.

Closes #102 