### PR TITLE
Add support for aarch64 architecture

### DIFF
--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -52,6 +52,22 @@
         [self pushArgv:@"-vga"];
         [self pushArgv:@"qxl"];
     }
+    if ([self.configuration.systemArchitecture isEqualToString:@"aarch64"]) {
+        [self pushArgv:@"-bios"];
+        [self pushArgv:[[NSBundle mainBundle] URLForResource:@"qemu/QEMU_EFI" withExtension:@"fd"].path];
+        [self pushArgv:@"-cpu"];
+        [self pushArgv:@"cortex-a72"];
+        [self pushArgv:@"-device"];
+        [self pushArgv:@"VGA"];
+        [self pushArgv:@"-device"];
+        [self pushArgv:@"nec-usb-xhci"];
+        [self pushArgv:@"-device"];
+        [self pushArgv:@"usb-kbd"];
+        [self pushArgv:@"-device"];
+        [self pushArgv:@"usb-tablet"];
+        [self pushArgv:@"-device"];
+        [self pushArgv:@"usb-mouse"];
+    }
     if (![self.configuration.systemBootDevice isEqualToString:@"hdd"]) {
         [self pushArgv:@"-boot"];
         if ([self.configuration.systemBootDevice isEqualToString:@"floppy"]) {
@@ -77,8 +93,15 @@
         } else {
             fullPathURL = [[self.imgPath URLByAppendingPathComponent:[UTMConfiguration diskImagesDirectory]] URLByAppendingPathComponent:[self.configuration driveImagePathForIndex:i]];
         }
-        [self pushArgv:@"-drive"];
-        [self pushArgv:[NSString stringWithFormat:@"file=%@,if=%@,media=%@", fullPathURL.path, [self.configuration driveInterfaceTypeForIndex:i], [self.configuration driveIsCdromForIndex:i] ? @"cdrom" : @"disk"]];
+        if([self.configuration.systemArchitecture isEqualToString:@"aarch64"]){
+            [self pushArgv:@"-device"];
+            [self pushArgv:[NSString stringWithFormat:@"virtio-blk,drive=arm%lu",(unsigned long)i]];
+            [self pushArgv:@"-drive"];
+            [self pushArgv:[NSString stringWithFormat:@"file=%@,if=%@,media=%@,id=arm%lu", fullPathURL.path, [self.configuration driveInterfaceTypeForIndex:i], [self.configuration driveIsCdromForIndex:i] ? @"cdrom" : @"disk",(unsigned long)i]];
+        } else{
+            [self pushArgv:@"-drive"];
+            [self pushArgv:[NSString stringWithFormat:@"file=%@,if=%@,media=%@", fullPathURL.path, [self.configuration driveInterfaceTypeForIndex:i], [self.configuration driveIsCdromForIndex:i] ? @"cdrom" : @"disk"]];
+        }
     }
     if (self.configuration.displayConsoleOnly) {
         [self pushArgv:@"-display"];

--- a/scripts/build_dependencies.sh
+++ b/scripts/build_dependencies.sh
@@ -412,5 +412,7 @@ fi
 fixup_all
 remove_shared_gst_plugins # another hack...
 generate_qapi $QEMU_SRC
+curl -L -O $QEMU_AARCH64_EFI #get efi firmware for aarch64
+cp "QEMU_EFI.fd" "$SYSROOT_DIR/share/qemu/"
 echo "${GREEN}All done!${NC}"
 touch "$BUILD_DIR/BUILD_SUCCESS"

--- a/scripts/sources
+++ b/scripts/sources
@@ -15,6 +15,7 @@ OPUS_SRC="https://archive.mozilla.org/pub/opus/opus-1.3.tar.gz"
 SPICE_PROTOCOL_SRC="https://www.spice-space.org/download/releases/spice-protocol-0.12.15.tar.bz2"
 SPICE_SERVER_SRC="https://www.spice-space.org/download/releases/spice-server/spice-0.14.1.tar.bz2"
 NCURSES_SRC="https://invisible-mirror.net/archives/ncurses/ncurses-6.1.tar.gz"
+QEMU_AARCH64_EFI="https://releases.linaro.org/reference-platform/enterprise/17.08/uefi/release/qemu64/QEMU_EFI.fd"
 QEMU_SRC="https://download.qemu.org/qemu-4.2.0.tar.xz"
 
 # Source files for spice-client


### PR DESCRIPTION
Unlike other architectures, QEMU doesn’t provide a bios file for aarch64 by default. This fix manually sets a EFI firmware for aarch64 VMs and improves some configurations.

