### PR TITLE
Add iOS External Screen support

### DIFF
--- a/CocoaSpice/CSDisplayMetal.h
+++ b/CocoaSpice/CSDisplayMetal.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)initWithSession:(nonnull SpiceSession *)session channelID:(NSInteger)channelID;
 - (void)updateVisibleAreaWithRect:(CGRect)rect;
 - (void)requestResolution:(CGRect)bounds;
+- (void)requestResolution:(CGRect)bounds monitorID:(NSInteger)monitorID;
 
 @end
 

--- a/CocoaSpice/CSDisplayMetal.m
+++ b/CocoaSpice/CSDisplayMetal.m
@@ -408,13 +408,18 @@ static void cs_channel_destroy(SpiceSession *s, SpiceChannel *channel, gpointer 
 }
 
 - (void)requestResolution:(CGRect)bounds {
+    [self requestResolution:bounds monitorID:self.monitorID];
+}
+
+- (void)requestResolution:(CGRect)bounds monitorID:(NSInteger)monitorID {
+    
     if (!_main) {
         UTMLog(@"ignoring change resolution because main channel not found");
         return;
     }
-    spice_main_channel_update_display_enabled(_main, (int)self.monitorID, TRUE, FALSE);
+    spice_main_channel_update_display_enabled(_main, (int)monitorID, TRUE, FALSE);
     spice_main_channel_update_display(_main,
-                                      (int)self.monitorID,
+                                      (int)monitorID,
                                       bounds.origin.x,
                                       bounds.origin.y,
                                       bounds.size.width,

--- a/Managers/UTMSpiceIO.h
+++ b/Managers/UTMSpiceIO.h
@@ -35,6 +35,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithConfiguration: (UTMConfiguration*) configuration port:(NSInteger)port NS_DESIGNATED_INITIALIZER;
 - (void)changeSharedDirectory:(NSURL *)url;
+- (CSConnection*)getSpiceConnection;
 
 @end
 

--- a/Managers/UTMSpiceIO.m
+++ b/Managers/UTMSpiceIO.m
@@ -182,6 +182,10 @@ typedef void (^connectionCallback_t)(BOOL success, NSString * _Nullable msg);
     }
 }
 
+- (CSConnection *)getSpiceConnection {
+    return _spiceConnection;
+}
+
 #pragma mark - CSConnectionDelegate
 
 - (void)spiceConnected:(CSConnection *)connection {
@@ -216,6 +220,9 @@ typedef void (^connectionCallback_t)(BOOL success, NSString * _Nullable msg);
             self.connectionCallback(YES, nil);
             self.connectionCallback = nil;
         }
+    } else {
+        // TODO external
+        [[NSNotificationCenter defaultCenter] postNotificationName:@"externalDisplayAdded" object:nil userInfo:@{@"display":display, @"input":input}];
     }
 }
 

--- a/Platform/iOS/Display/VMDisplayMetalViewController+Touch.m
+++ b/Platform/iOS/Display/VMDisplayMetalViewController+Touch.m
@@ -82,17 +82,17 @@ const CGFloat kScrollResistance = 10.0f;
     _longPress.allowedTouchTypes = @[ @(UITouchTypeDirect) ];
     _pinch = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(gesturePinch:)];
     _pinch.delegate = self;
-    [self.mtkView addGestureRecognizer:_swipeUp];
-    [self.mtkView addGestureRecognizer:_swipeDown];
-    [self.mtkView addGestureRecognizer:_swipeScrollUp];
-    [self.mtkView addGestureRecognizer:_swipeScrollDown];
-    [self.mtkView addGestureRecognizer:_pan];
-    [self.mtkView addGestureRecognizer:_twoPan];
-    [self.mtkView addGestureRecognizer:_threePan];
-    [self.mtkView addGestureRecognizer:_tap];
-    [self.mtkView addGestureRecognizer:_twoTap];
-    [self.mtkView addGestureRecognizer:_longPress];
-    [self.mtkView addGestureRecognizer:_pinch];
+    [self.view addGestureRecognizer:_swipeUp];
+    [self.view addGestureRecognizer:_swipeDown];
+    [self.view addGestureRecognizer:_swipeScrollUp];
+    [self.view addGestureRecognizer:_swipeScrollDown];
+    [self.view addGestureRecognizer:_pan];
+    [self.view addGestureRecognizer:_twoPan];
+    [self.view addGestureRecognizer:_threePan];
+    [self.view addGestureRecognizer:_tap];
+    [self.view addGestureRecognizer:_twoTap];
+    [self.view addGestureRecognizer:_longPress];
+    [self.view addGestureRecognizer:_pinch];
     
     // Feedback generator for clicks
     _clickFeedbackGenerator = [[UISelectionFeedbackGenerator alloc] init];
@@ -584,7 +584,7 @@ static CGFloat CGPointToPixel(CGFloat point) {
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     if (!self.vmConfiguration.inputLegacy) {
-        for (UITouch *touch in [event touchesForView:self.mtkView]) {
+        for (UITouch *touch in [event touchesForView:self.view]) {
             VMMouseType type = [self touchTypeToMouseType:touch.type];
             if ([self switchMouseType:type]) {
                 [self dragCursor:UIGestureRecognizerStateEnded primary:YES secondary:YES middle:YES]; // reset drag
@@ -592,7 +592,7 @@ static CGFloat CGPointToPixel(CGFloat point) {
                 BOOL primary = YES;
                 BOOL secondary = NO;
                 BOOL middle = NO;
-                CGPoint pos = [touch locationInView:self.mtkView];
+                CGPoint pos = [touch locationInView:self.view];
                 // iOS 13.4+ Pointing device support
                 if (@available(iOS 13.4, *)) {
                     if (touch.type == UITouchTypeIndirectPointer) {
@@ -622,8 +622,8 @@ static CGFloat CGPointToPixel(CGFloat point) {
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event {
     // move cursor in client mode, in server mode we handle in gesturePan
     if (!self.vmConfiguration.inputLegacy && !self.vmInput.serverModeCursor) {
-        for (UITouch *touch in [event touchesForView:self.mtkView]) {
-            [_cursor updateMovement:[touch locationInView:self.mtkView]];
+        for (UITouch *touch in [event touchesForView:self.view]) {
+            [_cursor updateMovement:[touch locationInView:self.view]];
             break; // handle single touch
         }
     }

--- a/Platform/iOS/Display/VMDisplayMetalViewController.h
+++ b/Platform/iOS/Display/VMDisplayMetalViewController.h
@@ -67,6 +67,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) BOOL serverModeCursor;
 
 - (void)sendExtendedKey:(CSInputKey)type code:(int)code;
+- (void)resetDisplay;
+- (void)displayResize:(CGSize)size;
 
 @end
 

--- a/Platform/iOS/Display/VMDisplayMetalViewController.m
+++ b/Platform/iOS/Display/VMDisplayMetalViewController.m
@@ -31,6 +31,12 @@
 #import "UTMScreenshot.h"
 #import "UTM-Swift.h"
 
+@interface VMDisplayMetalViewController ()
+
+@property (nonatomic) ExternalScreenController *externalController;
+
+@end
+
 @implementation VMDisplayMetalViewController {
     UTMRenderer *_renderer;
 }
@@ -84,6 +90,8 @@
     if (@available(iOS 12.1, *)) {
         [self initPencilInteraction];
     }
+    // External screen
+    _externalController = [[ExternalScreenController alloc] initWithVmViewController:self metalView: self.mtkView sourceScreen: self.vmDisplay sourceCursor: self.vmInput];
 }
 
 - (void)viewDidAppear:(BOOL)animated {
@@ -97,7 +105,7 @@
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [self displayResize:size];
+    [self displayResize:[self.externalController displaySize]];
 }
 
 - (void)virtualMachine:(UTMVirtualMachine *)vm transitionToState:(UTMVMState)state {
@@ -127,6 +135,7 @@
             if (self.vmConfiguration.shareClipboardEnabled) {
                 [[UTMPasteboard generalPasteboard] requestPollingModeForObject:self];
             }
+            //[self displayResize: [self.externalController displaySize]];
             break;
         }
         default: {

--- a/Platform/iOS/Display/VMDisplayMetalViewController.m
+++ b/Platform/iOS/Display/VMDisplayMetalViewController.m
@@ -91,7 +91,7 @@
         [self initPencilInteraction];
     }
     // External screen
-    _externalController = [[ExternalScreenController alloc] initWithVmViewController:self metalView: self.mtkView sourceScreen: self.vmDisplay sourceCursor: self.vmInput];
+    _externalController = [[ExternalScreenController alloc] initWithVmViewController:self metalView: self.mtkView];
 }
 
 - (void)viewDidAppear:(BOOL)animated {

--- a/Platform/iOS/Display/VMExternalDisplayMetalViewController.swift
+++ b/Platform/iOS/Display/VMExternalDisplayMetalViewController.swift
@@ -1,0 +1,44 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+class VMExternalDisplayMetalViewController: VMDisplayViewController {
+    private let mtkView = MTKView()
+    
+    var renderer: UTMRenderer!
+    var screenSize: CGSize!
+    var sourceScreen: UTMRenderSource?
+    var sourceCursor: UTMRenderSource?
+
+    override func viewDidLoad() {
+        // don't call VMDisplayViewController.viewDidLoad because that inits the accesory view
+        (self as UIViewController).viewDidLoad()
+        
+        view.addSubview(mtkView)
+        mtkView.bindFrameToSuperviewBounds()
+        
+        // Set the view to use the default device
+        mtkView.device = MTLCreateSystemDefaultDevice();
+        if ((self.mtkView.device == nil)) {
+            UTM.logger.critical("Metal is not supported on this device")
+            return;
+        }
+        
+        mtkView.delegate = renderer
+    }
+
+}

--- a/Platform/iOS/ExternalScreen.swift
+++ b/Platform/iOS/ExternalScreen.swift
@@ -1,0 +1,156 @@
+//
+// Copyright © 2020 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import UIKit
+
+@objc class ExternalScreenController: NSObject {
+    static var didActivateExternalDisplay = false
+    
+    private weak var vmViewController: VMDisplayMetalViewController!
+    private var metalView: MTKView!
+    private var externalWindow: UIWindow?
+    private weak var externalVC: UIViewController?
+    
+    private var sourceScreen: UTMRenderSource?
+    private var sourceCursor: UTMRenderSource?
+    
+    @objc init(vmViewController: VMDisplayMetalViewController, metalView: MTKView, sourceScreen: UTMRenderSource?, sourceCursor: UTMRenderSource?) {
+        super.init()
+        self.vmViewController = vmViewController
+        self.metalView = metalView
+        self.sourceScreen = sourceScreen
+        self.sourceCursor = sourceCursor
+        
+        // Listen for external screen events
+        NotificationCenter.default.addObserver(forName: UIScreen.didConnectNotification, object: nil, queue: nil) { [weak self] notification in
+            guard let self = self else { return }
+            // got a new screen connected
+            guard let newScreen = notification.object as? UIScreen else { return }
+            
+            guard !Self.didActivateExternalDisplay else { return }
+            Self.didActivateExternalDisplay = true
+            self.setupExternalScreen(newScreen)
+        }
+        
+        NotificationCenter.default.addObserver(forName: UIScreen.didDisconnectNotification, object: nil, queue: nil) { [weak self] notification in
+            guard Self.didActivateExternalDisplay else { return }
+            Self.didActivateExternalDisplay = false
+            
+            guard let self = self else { return }
+            
+            guard let oldScreen = notification.object as? UIScreen else { return }
+            
+            if let window = self.externalWindow, window.screen == oldScreen {
+                if let extVC = self.externalVC as? VMExternalDisplayMetalViewController {
+                    // discard external metal view
+                    extVC.renderer = nil // ?
+                } else if let extVC = self.externalVC {
+                    extVC.view.removeFromSuperview()
+                    metalView.removeFromSuperview()
+                    // move metal view to internal vc
+                    vmViewController.view!.insertSubview(metalView, at: 0)
+                    metalView.bindFrameToSuperviewBounds()
+                }
+                let newSize = UIApplication.shared.keyWindow!.bounds.size
+                vmViewController.displayResize(newSize)
+                vmViewController.resetDisplay()
+                let renderer = (self.metalView!.delegate as! UTMRenderer)
+                renderer.mtkView(self.metalView!, drawableSizeWillChange: newSize)
+                DispatchQueue.main.async {
+                    self.metalView!.drawableSize = newSize
+                }
+                self.externalWindow = nil
+                self.externalVC = nil
+            }
+        }
+        
+        // screen already connected?
+        if UIScreen.screens.count > 1 {
+            let newScreen = UIScreen.screens[1]
+            guard !Self.didActivateExternalDisplay else { return }
+            Self.didActivateExternalDisplay = true
+            setupExternalScreen(newScreen)
+        }
+    }
+    
+    deinit {
+        vmViewController = nil
+        externalWindow = nil
+        externalVC = nil
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    private func setupExternalScreen(_ newScreen: UIScreen) {
+        // TODO offer resolution switch? Only possible while no window is attached
+//        let modes = newScreen.availableModes
+//        for (index, mode) in modes.enumerated() {
+//            print("External screen mode \(index): \(mode.size.width) x \(mode.size.height)")
+//        }
+
+        let screenFrame = CGRect(origin: .zero, size: newScreen.currentMode!.size)
+        let newWindow = UIWindow(frame: screenFrame)
+        externalWindow = newWindow
+        newWindow.screen = newScreen
+        
+        metalView.removeFromSuperview()
+
+        makeExternalOnlyVC(newWindow: newWindow)
+//        makeExternalDuplicateVC(newWindow: newWindow)
+        
+        newWindow.isHidden = false
+        
+        print("setup external display")
+    }
+    
+    @objc func displaySize() -> CGSize {
+        if let externalWindow = externalWindow {
+            return externalWindow.bounds.size
+        } else {
+            return vmViewController.view!.bounds.size
+        }
+    }
+    
+    private func makeExternalDuplicateVC(newWindow: UIWindow) {
+        let extVC = VMExternalDisplayMetalViewController()
+        extVC.screenSize = newWindow.bounds.size
+        extVC.renderer = (metalView!.delegate as! UTMRenderer)
+        extVC.sourceScreen = sourceScreen
+        extVC.sourceCursor = sourceCursor
+        newWindow.rootViewController = extVC
+        extVC.loadView()
+        DispatchQueue.main.async {
+            let renderer = (self.metalView!.delegate as! UTMRenderer)
+            renderer.mtkView(self.metalView!, drawableSizeWillChange: self.externalWindow!.bounds.size)
+            self.metalView!.drawableSize = newWindow.bounds.size
+        }
+        self.externalVC = extVC
+    }
+    
+    private func makeExternalOnlyVC(newWindow: UIWindow) {
+        let externalVC = UIViewController()
+        newWindow.rootViewController = externalVC
+        externalVC.view.addSubview(metalView)
+        metalView.bindFrameToSuperviewBounds()
+        DispatchQueue.main.async {
+            self.vmViewController.displayResize(self.externalWindow!.bounds.size)
+            self.vmViewController.resetDisplay()
+            let renderer = (self.metalView!.delegate as! UTMRenderer)
+            renderer.mtkView(self.metalView!, drawableSizeWillChange: self.externalWindow!.bounds.size)
+            self.metalView!.drawableSize = self.externalWindow!.bounds.size
+        }
+        self.externalVC = externalVC
+    }
+}

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -29,6 +29,8 @@
 		2CE8EB0A2572E173000E2EBB /* qapi-visit-block-export.c in Sources */ = {isa = PBXBuildFile; fileRef = 2CE8EB082572E173000E2EBB /* qapi-visit-block-export.c */; };
 		2CE8EB41257811E8000E2EBB /* UTMConfiguration+Defaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CE8EB40257811E8000E2EBB /* UTMConfiguration+Defaults.m */; };
 		2CE8EB42257811E8000E2EBB /* UTMConfiguration+Defaults.m in Sources */ = {isa = PBXBuildFile; fileRef = 2CE8EB40257811E8000E2EBB /* UTMConfiguration+Defaults.m */; };
+		839322EA2530408C009CA087 /* ExternalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839322E92530408C009CA087 /* ExternalScreen.swift */; };
+		839322ED25305D25009CA087 /* VMExternalDisplayMetalViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 839322EC25305D25009CA087 /* VMExternalDisplayMetalViewController.swift */; };
 		CE020BA324AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA424AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA724AEDEF000B44AB6 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = CE020BA624AEDEF000B44AB6 /* Logging */; };
@@ -948,6 +950,8 @@
 		52873FD8247F5B1B0063E4C8 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Main.strings"; sourceTree = "<group>"; };
 		52873FD9247F5B1B0063E4C8 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		52873FDA247F5B1B0063E4C8 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		839322E92530408C009CA087 /* ExternalScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalScreen.swift; sourceTree = "<group>"; };
+		839322EC25305D25009CA087 /* VMExternalDisplayMetalViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMExternalDisplayMetalViewController.swift; sourceTree = "<group>"; };
 		83FBDD53242FA71900D2C5D7 /* VMDisplayMetalViewController+Pointer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "VMDisplayMetalViewController+Pointer.h"; sourceTree = "<group>"; };
 		83FBDD55242FA7BC00D2C5D7 /* VMDisplayMetalViewController+Pointer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "VMDisplayMetalViewController+Pointer.m"; sourceTree = "<group>"; };
 		C8958B6C243634DA002D86B4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Main.strings; sourceTree = "<group>"; };
@@ -1846,6 +1850,7 @@
 				CE2D954C24AD4F980059923A /* VMSettingsView.swift */,
 				CE2D954F24AD4F980059923A /* Info.plist */,
 				5286EC91243748AC007E6CBC /* Settings.bundle */,
+				839322E92530408C009CA087 /* ExternalScreen.swift */,
 			);
 			path = iOS;
 			sourceTree = "<group>";
@@ -2320,6 +2325,7 @@
 				E2151A58241451120008E6AC /* UIViewController+Extensions.m */,
 				E2B0F9D02426E5510065DFBE /* WKWebView+Workarounds.h */,
 				E2B0F9D12426E5510065DFBE /* WKWebView+Workarounds.m */,
+				839322EC25305D25009CA087 /* VMExternalDisplayMetalViewController.swift */,
 			);
 			path = Display;
 			sourceTree = "<group>";
@@ -2752,6 +2758,7 @@
 				CE2D92B824AD46670059923A /* qapi-events-trace.c in Sources */,
 				2C6D9E142571AFE5003298E6 /* UTMQcow2.c in Sources */,
 				2CE8EAFE2572E14D000E2EBB /* qapi-types-block-export.c in Sources */,
+				839322ED25305D25009CA087 /* VMExternalDisplayMetalViewController.swift in Sources */,
 				CE2D92B924AD46670059923A /* qapi-events-qdev.c in Sources */,
 				CEBE02642588494100B9BCA8 /* CSSession+Sharing.m in Sources */,
 				2C33B3A92566C9B100A954A6 /* VMContextMenuModifier.swift in Sources */,
@@ -2761,6 +2768,7 @@
 				CE2D92BB24AD46670059923A /* qapi-types-tpm.c in Sources */,
 				CE2D92BC24AD46670059923A /* UTMConfiguration+Drives.m in Sources */,
 				CE2D92BD24AD46670059923A /* qapi-visit-char.c in Sources */,
+				839322EA2530408C009CA087 /* ExternalScreen.swift in Sources */,
 				CE2D92BE24AD46670059923A /* qapi-types-error.c in Sources */,
 				CE2D92BF24AD46670059923A /* qapi-commands-authz.c in Sources */,
 				CE2D92C024AD46670059923A /* VMDisplayTerminalViewController+Keyboard.m in Sources */,


### PR DESCRIPTION
This is currently very WIP! This is eventually intended to implement #220. 

Current status: if an external screen is connected, the VM display will be moved there. This breaks touch and cursor input to the VM, which will require separating the touch handling from the `MTKView to fix`. As a 'band aid' fix, I have redirected touch handling to the VM container view (`VMDisplayMetalViewController+Touch.m`), which enables a small portion of the screen to be used to control the VM pointer.

Help needed with mirroring mode: I have attempted to implement a display mirroring mode by introducing a second `MTKView` on a new `VMExternalDisplayMetalViewController.swift` and setting its `UTMRenderer`, `sourceDisplay` and `sourceInput` the same as the internal ones. The relevant code is in `ExternalScreenController.swift` line 126. Unfortunately with regards to the `UTMRenderer` and `MTKView`, I have no idea what I'm doing. So if you use this mode by uncommenting it, that currently results in a blank screen. 