### PR TITLE
Fix the error when importing drive

### DIFF
--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -310,6 +310,9 @@ class UTMData: ObservableObject {
     // MARK: - Disk drive functions
     
     func importDrive(_ drive: URL, forConfig: UTMConfiguration, copy: Bool = true) throws {
+        _ = drive.startAccessingSecurityScopedResource()
+        defer { drive.stopAccessingSecurityScopedResource() }
+        
         let name = drive.lastPathComponent
         let imagesPath = forConfig.imagesPath
         let dstPath = imagesPath.appendingPathComponent(name)


### PR DESCRIPTION
`URL.startAccessingSecurityScopedResource()` is required to access a file outside its sandbox. I added `URL.startAccessingSecurityScopedResource()` and `URL.stopAccessingSecurityScopedResource()` so that UTM can import a disk image. See #490.

Fixes #490