### PR TITLE
Improve removable drives state and UI

### DIFF
--- a/Managers/UTMVirtualMachine+Drives.m
+++ b/Managers/UTMVirtualMachine+Drives.m
@@ -37,31 +37,24 @@ extern NSString *const kUTMErrorDomain;
 - (NSArray<UTMDrive *> *)drives {
     NSInteger count = self.configuration.countDrives;
     id drives = [NSMutableArray<UTMDrive *> arrayWithCapacity:count];
-    id removableDrives = self.qemu.removableDrives;
     for (NSInteger i = 0; i < count; i++) {
         UTMDrive *drive = [UTMDrive new];
         drive.index = i;
         drive.imageType = [self.configuration driveImageTypeForIndex:i];
         drive.interface = [self.configuration driveInterfaceTypeForIndex:i];
         drive.name = [NSString stringWithFormat:@"drive%lu", i];
-        NSString *path = removableDrives[drive.name];
         if ([self.configuration driveRemovableForIndex:i]) {
-            // removable drive
+            // removable drive -> path stored only in viewState
+            NSString *path = [self.viewState pathForRemovableDrive:drive.name];
             if (path.length > 0) {
                 drive.status = UTMDriveStatusInserted;
                 drive.path = path;
             } else {
-                path = [self.configuration driveImagePathForIndex:i];
-                if (path.length > 0) {
-                    drive.status = UTMDriveStatusInserted;
-                    drive.path = path;
-                } else {
-                    drive.status = UTMDriveStatusEjected;
-                    drive.path = nil;
-                }
+                drive.status = UTMDriveStatusEjected;
+                drive.path = nil;
             }
         } else {
-            // fixed drive
+            // fixed drive -> path stored in configuration
             drive.status = UTMDriveStatusFixed;
             drive.path = [self.configuration driveImagePathForIndex:i];
         }
@@ -73,11 +66,10 @@ extern NSString *const kUTMErrorDomain;
 - (BOOL)ejectDrive:(UTMDrive *)drive force:(BOOL)force error:(NSError * _Nullable __autoreleasing *)error {
     NSString *oldPath = [self.viewState pathForRemovableDrive:drive.name];
     [self.viewState removeBookmarkForRemovableDrive:drive.name];
-    [self.configuration setImagePath:@"" forIndex:drive.index];
     [self saveViewState];
     [self.system stopAccessingPath:oldPath];
     if (!self.qemu.isConnected) {
-        return YES; // not ready yet
+        return YES; // not running
     }
     return [self.qemu ejectDrive:drive.name force:force error:error];
 }
@@ -97,7 +89,6 @@ extern NSString *const kUTMErrorDomain;
     }
     if (!self.qemu.isConnected) {
         [self.viewState setBookmark:bookmark path:url.path forRemovableDrive:drive.name persistent:YES];
-        [self.configuration setImagePath:url.path forIndex:drive.index];
         [self saveViewState];
         return YES; // not ready yet
     } else {

--- a/Platform/Shared/VMDetailsView.swift
+++ b/Platform/Shared/VMDetailsView.swift
@@ -129,37 +129,45 @@ struct Details: View {
     var body: some View {
         VStack {
             HStack {
-                Label("Status", systemImage: "info.circle")
+                plainLabel("Status", systemImage: "info.circle")
                 Spacer()
                 Text(sessionConfig.active ? "Running" : (sessionConfig.suspended ? "Suspended" : "Not running"))
                     .foregroundColor(.secondary)
             }
             HStack {
-                Label("Architecture", systemImage: "cpu")
+                plainLabel("Architecture", systemImage: "cpu")
                 Spacer()
                 Text(config.systemArchitecturePretty)
                     .foregroundColor(.secondary)
             }
             HStack {
-                Label("Machine", systemImage: "desktopcomputer")
+                plainLabel("Machine", systemImage: "desktopcomputer")
                 Spacer()
                 Text(config.systemTargetPretty)
                     .foregroundColor(.secondary)
             }
             HStack {
-                Label("Memory", systemImage: "memorychip")
+                plainLabel("Memory", systemImage: "memorychip")
                 Spacer()
                 Text(config.systemMemoryPretty)
                     .foregroundColor(.secondary)
             }
             HStack {
-                Label("Size", systemImage: "internaldrive")
+                plainLabel("Size", systemImage: "internaldrive")
                 Spacer()
                 Text(sizeLabel)
                     .foregroundColor(.secondary)
             }
         }.lineLimit(1)
         .truncationMode(.tail)
+    }
+    
+    private func plainLabel(_ text: String, systemImage: String) -> some View {
+        return Label {
+            Text(text)
+        } icon: {
+            Image(systemName: systemImage).foregroundColor(.primary)
+        }
     }
 }
 


### PR DESCRIPTION
The removable drives list in the VM details isn't very nice to look at currently. This PR includes some of the UI changes from my previous PR #531, and includes a fix for incorrect `UTMDrive.state`. 