### PR TITLE
Add SidebarCommands to be able to bring Sidebar back.

### DIFF
--- a/Platform/UTMApp.swift
+++ b/Platform/UTMApp.swift
@@ -23,7 +23,7 @@ struct UTMApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView().environmentObject(data)
-        }
+        }.commands { SidebarCommands() }
         #if os(macOS)
         Settings {
             SettingsView()


### PR DESCRIPTION
On macOS, user is able to adjust sidebar width by dragging the separator. If the user drag it to near 0 width, it's impossible to get the sidebar back again. Adding SidebarCommands would have a command in View menu for user to toggle sidebar, as well as a key shortcut for doing so.

<img width="320" alt="image" src="https://user-images.githubusercontent.com/2545261/102710186-8b7e7380-42eb-11eb-8230-67766c0d3133.png">
