### PR TITLE
fix: Update VM images URL

### DIFF
--- a/Platform/Shared/VMPlaceholderView.swift
+++ b/Platform/Shared/VMPlaceholderView.swift
@@ -35,7 +35,7 @@ struct VMPlaceholderView: View {
                     createNewVMPresented.toggle()
                 }
                 TileButton(titleKey: "Browse UTM Gallery", systemImage: "square.grid.3x2") {
-                    openURL(URL(string: "https://getutm.app/gallery/")!)
+                    openURL(URL(string: "https://getutm.app/vms/")!)
                 }
                 TileButton(titleKey: "User Guide", systemImage: "questionmark.circle") {
                     #if os(macOS)


### PR DESCRIPTION
## Why?

Currently, when tapping the "Browse UTM Gallery" button, it redirects to the old website (https://getutm.app/gallery/). This results in 404 Not Found page.

This wil fix #2086

## What Changed?

I updated the URL from https://getutm.app/gallery/ to https://getutm.app/vms/. That's all!