### PR TITLE
Use USB 1.1 controller for pc systems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ iOSInjectionProject/
 
 build/
 sysroot*/
+.DS_Store

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -348,6 +348,9 @@ static size_t sysctl_read(const char *name) {
     if ([self.configuration.systemTarget hasPrefix:@"virt"]) {
         [self pushArgv:@"-device"];
         [self pushArgv:@"qemu-xhci"];
+    } else if ([self.configuration.systemTarget hasPrefix:@"pc"]) {
+        // USB 1.0 controller for old PC system
+        [self pushArgv:@"-usb"];
     } else { // USB 2.0 controller is most compatible
         [self pushArgv:@"-device"];
         [self pushArgv:@"usb-ehci"];


### PR DESCRIPTION
Currently UTM adds a USB 2.0 controller for non-virt systems. This causes issues with old Windows guests like 98. So I changed it to add a USB 1.1 controller if the system is `pc`. 

I also added `.DS_Store` files to .gitignore.