### PR TITLE
Disable library validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ DerivedData/
 *.ipa
 *.dSYM.zip
 *.dSYM
+Package.resolved
 
 # CocoaPods
 #

--- a/Platform/macOS/macOS.entitlements
+++ b/Platform/macOS/macOS.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
I received the following error when trying to run UTM on macOS on an M1 Macbook Pro.
```
dyld: Library not loaded: @rpath/libgstcontroller-1.0.0.utm.dylib
  Referenced from: /Users/gavinpacini/Library/Developer/Xcode/DerivedData/UTM-cikncsuzksiqipewuixwagqgtfyz/Build/Products/Debug/UTM.app/Contents/MacOS/UTM
  Reason: no suitable image found.  Did find:
	/Users/gavinpacini/Library/Developer/Xcode/DerivedData/UTM-cikncsuzksiqipewuixwagqgtfyz/Build/Products/Debug/UTM.app/Contents/MacOS/../Frameworks/libgstcontroller-1.0.0.utm.dylib: code signature in (/Users/gavinpacini/Library/Developer/Xcode/DerivedData/UTM-cikncsuzksiqipewuixwagqgtfyz/Build/Products/Debug/UTM.app/Contents/MacOS/../Frameworks/libgstcontroller-1.0.0.utm.dylib) not valid for use in process using Library Validation: mapped file has no Team ID and is not a platform binary (signed with custom identity or adhoc?)
```

<img width="1138" alt="Screenshot 2021-04-02 at 06 57 49" src="https://user-images.githubusercontent.com/1523414/113382025-c67b5300-9380-11eb-9576-e51084c5a051.png">

It seems I needed to [disable library validation](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-library-validation) to get it to work. Is this due to an issue with my setup? Or is anyone else seeing this too?

UTM Version: v2.0.25 - master
OS Version: 11.2.3
Apple Silicon