### PR TITLE
Support R/W accessing image files on external drives

### DIFF
--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -233,6 +233,8 @@ static size_t sysctl_read(const char *name) {
         if (hasImage) {
             if ([path characterAtIndex:0] == '/') {
                 fullPathURL = [NSURL fileURLWithPath:path isDirectory:NO];
+            } else if ([path hasPrefix:@"file://"]) {
+                fullPathURL = [NSURL URLWithString:path];
             } else {
                 fullPathURL = [[self.imgPath URLByAppendingPathComponent:[UTMConfiguration diskImagesDirectory]] URLByAppendingPathComponent:[self.configuration driveImagePathForIndex:i]];
             }

--- a/Managers/UTMVirtualMachine.m
+++ b/Managers/UTMVirtualMachine.m
@@ -255,7 +255,7 @@ error:
 }
 
 - (void)errorTriggered:(nullable NSString *)msg {
-    if (self.state != kVMStopped && self.state != kVMError) {
+    /*if (self.state != kVMStopped && self.state != kVMError) {
         self.viewState.suspended = NO;
         [self saveViewState];
         [self quitVMForce:true];
@@ -263,7 +263,7 @@ error:
     if (self.state != kVMError) { // don't stack errors
         self.delegate.vmMessage = msg;
         [self changeState:kVMError];
-    }
+    }*/
 }
 
 - (BOOL)startVM {

--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -350,7 +350,7 @@ class UTMData: ObservableObject {
         
         let name = drive.lastPathComponent
         let imageType: UTMDiskImageType = drive.pathExtension.lowercased() == "iso" ? .CD : .disk
-        let imagesPath = config.imagesPath
+        /*let imagesPath = config.imagesPath
         let dstPath = imagesPath.appendingPathComponent(name)
         if !fileManager.fileExists(atPath: imagesPath.path) {
             try fileManager.createDirectory(at: imagesPath, withIntermediateDirectories: false, attributes: nil)
@@ -359,7 +359,7 @@ class UTMData: ObservableObject {
             try fileManager.copyItem(at: drive, to: dstPath)
         } else {
             try fileManager.moveItem(at: drive, to: dstPath)
-        }
+        }*/
         DispatchQueue.main.async {
             let interface: String
             if let target = config.systemTarget {
@@ -367,7 +367,7 @@ class UTMData: ObservableObject {
             } else {
                 interface = "none"
             }
-            config.newDrive(name, type: imageType, interface: interface)
+            config.newDrive(drive.absoluteString, type: imageType, interface: interface)
         }
     }
     


### PR DESCRIPTION
This is a proof of concept that changes the "Import Drive" feature to instead link to the drive file. Additionally, qemu runtime errors are ignored to prevent the VM from quitting when I/O errors occur. (this causes instability because the errors that are ignored are not filtered)

These changes allow image files on external drives to be read and written to in the VM. For example, I was able to attach a QCOW2 image to a Windows VM and copy a file to it.