### PR TITLE
Add ios_simulator-tci to the build matrix so we start getting artifacts for iOS SE Simulator 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         arch: [arm64, x86_64]
-        platform: [ios, ios_simulator, ios-tci, macos]
+        platform: [ios, ios_simulator, ios_simulator-tci, ios-tci, macos]
         exclude:
           - arch: x86_64
             platform: ios

--- a/README.md
+++ b/README.md
@@ -56,3 +56,5 @@ Some icons made by [Freepik](https://www.freepik.com) from [www.flaticon.com](ht
   [3]: https://github.com/ktemkin/qemu/blob/with_tcti/tcg/aarch64-tcti/README.md
   [4]: https://github.com/ish-app/ish
   [5]: https://github.com/holzschu/a-shell
+  
+  Build test

--- a/README.md
+++ b/README.md
@@ -56,5 +56,3 @@ Some icons made by [Freepik](https://www.freepik.com) from [www.flaticon.com](ht
   [3]: https://github.com/ktemkin/qemu/blob/with_tcti/tcg/aarch64-tcti/README.md
   [4]: https://github.com/ish-app/ish
   [5]: https://github.com/holzschu/a-shell
-  
-  Build test


### PR DESCRIPTION
Adds the ios_simulator-tci to the build matrix so we get sysroot assets to be able to fill out the full [dependencies](https://github.com/utmapp/UTM/blob/master/Documentation/iOSDevelopment.md#dependencies) table from the iOS dev docs.