### PR TITLE
Add URL scheme

### DIFF
--- a/Platform/iOS/Info.plist
+++ b/Platform/iOS/Info.plist
@@ -33,6 +33,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.utmapp.UTM</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>UTM</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Platform/macOS/Info.plist
+++ b/Platform/macOS/Info.plist
@@ -37,6 +37,19 @@
 	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.utmapp.UTM</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>UTM</string>
+			</array>
+		</dict>
+	</array>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>


### PR DESCRIPTION
A UTM scheme `utm://` is implemented that offers commands for managing VMs.

For example, the URL `utm://start?name=Ubuntu` would open UTM and start a VM called "Ubuntu".

## Commands

Proposed list of commands and their parameters, in pseudocode:

- start(name)
- stop(name)
- restart(name)
- suspend(name)
- resume(name)

Possible additional commands:
- keystroke(name, string)
- click(name, x, y)

## Status

I have implemented the start command using UTMData.run and will implement the remaining ones as well.

Not sure about the additional commands, and please feel free to comment your ideas.