### PR TITLE
Add extra vertical padding to Preferences (Mac)

### DIFF
--- a/Platform/macOS/SettingsView.swift
+++ b/Platform/macOS/SettingsView.swift
@@ -53,7 +53,8 @@ struct SettingsView: View {
                     Text("Do not show prompt when USB device is plugged in")
                 })
             }
-        }.padding()
+        }.padding([.vertical])
+        .padding()
     }
 }
 


### PR DESCRIPTION
Currently the Preferences view on Mac has a bit too little padding on the Top and Bottom:
<img width="508" alt="Screenshot 2021-08-10 at 11 21 19 AM" src="https://user-images.githubusercontent.com/71804605/128803374-8e87b156-5b94-4378-9ad4-1842d9af68b8.png">