### PR TITLE
Fix crash when setting custom VM icon (#2387)

### DIFF
--- a/Managers/UTMVirtualMachine.m
+++ b/Managers/UTMVirtualMachine.m
@@ -140,6 +140,7 @@ NSString *const kSuspendSnapshotName = @"suspend";
     if (self) {
         self.parentPath = dstUrl;
         self.configuration = configuration;
+        self.configuration.selectedCustomIconPath = configuration.selectedCustomIconPath;
         self.viewState = [[UTMViewState alloc] init];
     }
     return self;
@@ -195,14 +196,16 @@ NSString *const kSuspendSnapshotName = @"suspend";
     }
     // save icon
     if (self.configuration.iconCustom && self.configuration.selectedCustomIconPath) {
-        NSURL *oldIconPath = [url URLByAppendingPathComponent:self.configuration.icon];
+        if (self.configuration.icon != nil) {
+            NSURL *oldIconPath = [url URLByAppendingPathComponent:self.configuration.icon];
+            // delete old icon
+            if ([fileManager fileExistsAtPath:oldIconPath.path]) {
+                [fileManager removeItemAtURL:oldIconPath error:&_err]; // Ignore error
+            }
+        }
         NSString *newIcon = self.configuration.selectedCustomIconPath.lastPathComponent;
         NSURL *newIconPath = [url URLByAppendingPathComponent:newIcon];
         
-        // delete old icon
-        if ([fileManager fileExistsAtPath:oldIconPath.path]) {
-            [fileManager removeItemAtURL:oldIconPath error:&_err]; // ignore error
-        }
         // copy new icon
         if (![fileManager copyItemAtURL:self.configuration.selectedCustomIconPath toURL:newIconPath error:&_err]) {
             goto error;


### PR DESCRIPTION
It turns out there were two unrelated problems.

**First, and caused the crash (Line 199):**
The first time you set a custom icon, the `self.configuration.icon` is `nil`, which crashes `NSURL`'s `- (nullable NSURL *)URLByAppendingPathComponent:(NSString *)pathComponent`. I changed the code to check for `self.configuration.icon` being `nil` so it would skip over the deleting the previous icon.

**Second, fix custom icon not being set creating a new VM (Line 143):**
The setting `self.configuration` with the `configuration` parameter wasn't setting the `selectedCustomIconPath`. I added an extra line to also set just the `selectedCustomIconPath`.