### PR TITLE
Disable Port Forwarding feature for bridged networking

### DIFF
--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -394,9 +394,11 @@ static size_t sysctl_read(const char *name) {
         if (self.configuration.networkDhcpDomain.length > 0) {
             [netstr appendFormat:@",domainname=%@", self.configuration.networkDhcpDomain];
         }
-        for (NSUInteger i = 0; i < [self.configuration countPortForwards]; i++) {
-            UTMConfigurationPortForward *portForward = [self.configuration portForwardForIndex:i];
-            [netstr appendFormat:@",hostfwd=%@:%@:%@-%@:%@", portForward.protocol, portForward.hostAddress, portForward.hostPort, portForward.guestAddress, portForward.guestPort];
+        if (![self.configuration.networkMode isEqualToString:@"bridged"]) {
+            for (NSUInteger i = 0; i < [self.configuration countPortForwards]; i++) {
+                UTMConfigurationPortForward *portForward = [self.configuration portForwardForIndex:i];
+                [netstr appendFormat:@",hostfwd=%@:%@:%@-%@:%@", portForward.protocol, portForward.hostAddress, portForward.hostPort, portForward.guestAddress, portForward.guestPort];
+            }
         }
         [self pushArgv:netstr];
     } else {

--- a/Platform/Shared/VMConfigNetworkView.swift
+++ b/Platform/Shared/VMConfigNetworkView.swift
@@ -56,7 +56,10 @@ struct VMConfigNetworkView: View {
                         #endif
                     }
                     
-                    VMConfigNetworkPortForwardView(config: config)
+                    /// Bridged networking doesn't support port forwarding
+                    if config.networkMode != "bridged" {
+                        VMConfigNetworkPortForwardView(config: config)
+                    }
                 }
             }
         }


### PR DESCRIPTION
Port forwarding is not needed and not supported when using bridged networking.