### PR TITLE
Add virtio-rng-pci device to qemu commandline

### DIFF
--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -638,6 +638,10 @@ static size_t sysctl_read(const char *name) {
             [self pushArgv:@"-device"];
             [self pushArgv:self.configuration.displayCard];
         }
+        if (self.configuration.systemBootUefi) {
+            [self pushArgv:@"-device"];
+            [self pushArgv:@"virtio-rng-pci"];
+        }
     }
 }
 


### PR DESCRIPTION
https://wiki.qemu.org/Features/VirtIORNG#Invocation

@conath could you help to test that this doesn't break Windows etc. VMs? You can just add `-device virtio-rng-pci` to the QEMU arguments.

**Edit:**
It seems according to [this](https://www.redhat.com/en/blog/red-hat-enterprise-linux-virtual-machines-access-random-numbers-made-easy), virtio RNG should work on Windows guests too?