### PR TITLE
Show alert before closing window or quitting

### DIFF
--- a/Platform/UTMApp.swift
+++ b/Platform/UTMApp.swift
@@ -26,6 +26,11 @@ struct UTMApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView().environmentObject(data)
+            #if os(macOS)
+                .onAppear {
+                    appDelegate.data = data
+                }
+            #endif
         }.commands { VMCommands() }
         #if os(macOS)
         Settings {

--- a/Platform/macOS/Display/VMDisplayMetalWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayMetalWindowController.swift
@@ -417,7 +417,7 @@ extension VMDisplayMetalWindowController: VMMetalViewInputDelegate {
     }
     
     private func handleCaptureKeys(for event: NSEvent) -> Bool {
-        // if captured we route all keyevents to view, even Cmd+Q and Cmd+W
+        // if captured we route all keyevents to view
         if let metalView = metalView, metalView.isMouseCaptured {
             if event.type == .keyDown {
                 metalView.keyDown(with: event)
@@ -426,27 +426,8 @@ extension VMDisplayMetalWindowController: VMMetalViewInputDelegate {
             }
             return true
         }
-        // otherwise, we confirm Cmd+Q and Cmd+W
-        if event.modifierFlags.contains(.command) && event.type == .keyDown {
-            if event.keyCode == kVK_ANSI_Q {
-                showConfirmAlert(NSLocalizedString("Quitting UTM will kill all running VMs.", comment: "VMDisplayMetalWindowController")) {
-                    NSApp.terminate(self)
-                }
-                return true
-            } else if event.keyCode == kVK_ANSI_W {
-                if vm.state == .vmStarted {
-                    showConfirmAlert(NSLocalizedString("Closing this window will kill the VM.", comment: "VMDisplayMetalWindowController")) {
-                        DispatchQueue.global(qos: .background).async {
-                            self.vm.quitVM()
-                        }
-                    }
-                } else if vm.state == .vmStopped || vm.state == .vmError {
-                    return false // we can close the window
-                } else {
-                    return true // do not close window when in progress
-                }
-            }
-        } else if event.modifierFlags.contains(.command) && event.type == .keyUp {
+        
+        if event.modifierFlags.contains(.command) && event.type == .keyUp {
             // for some reason, macOS doesn't like to send Cmd+KeyUp
             metalView.keyUp(with: event)
             return true

--- a/Platform/macOS/Display/VMDisplayWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayWindowController.swift
@@ -181,6 +181,22 @@ extension VMDisplayWindowController: NSWindowDelegate {
         return [.autoHideToolbar, .autoHideMenuBar, .fullScreen]
     }
     
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = NSLocalizedString("Confirmation", comment: "VMDisplayWindowController")
+        alert.informativeText = NSLocalizedString("Closing this window will kill the VM.", comment: "VMDisplayMetalWindowController")
+        alert.addButton(withTitle: NSLocalizedString("OK", comment: "VMDisplayWindowController"))
+        alert.addButton(withTitle: NSLocalizedString("Cancel", comment: "VMDisplayWindowController"))
+        let response = alert.runModal()
+        switch response {
+        case .alertFirstButtonReturn:
+            return true
+        default:
+            return false
+        }
+    }
+    
     func windowWillClose(_ notification: Notification) {
         DispatchQueue.global(qos: .background).async {
             self.vm.quitVM(force: true)


### PR DESCRIPTION
Fixes #3103 by putting the alert code in windowShouldClose/applicationShouldTerminate instead of listening for key press events

I'm intentionally using the blocking `runModal` on the Alerts since you wouldn't want to be able to ignore a `Do you want to quit` alert.

<sub><sub>Side note: Isn't it funny how Swift 5.5 is available on Mac but the new APIs like `Task` aren't? For example I can use `#if` on modifiers already...</sub></sub>