### PR TITLE
Differentiate the main UTM window from VM windows

### DIFF
--- a/Platform/Shared/VMCommands.swift
+++ b/Platform/Shared/VMCommands.swift
@@ -19,6 +19,9 @@ import SwiftUI
 @available(iOS 14, macOS 11, *)
 struct VMCommands: Commands {
     @Environment(\.openURL) private var openURL
+    #if os(macOS)
+    var appDelegate: AppDelegate
+    #endif
     
     @CommandsBuilder
     var body: some Commands {
@@ -34,6 +37,15 @@ struct VMCommands: Commands {
         }
         SidebarCommands()
         ToolbarCommands()
+        #if os(macOS)
+        CommandGroup(replacing: .windowArrangement) {
+            Button {
+                appDelegate.mainWindow?.makeKeyAndOrderFront(nil)
+            } label: {
+                Text("UTM")
+            }
+        }
+        #endif
         CommandGroup(replacing: .help) {
             Button(action: { openLink("https://mac.getutm.app/gallery/") }, label: {
                 Text("Virtual Machine Gallery")

--- a/Platform/UTMApp.swift
+++ b/Platform/UTMApp.swift
@@ -26,7 +26,14 @@ struct UTMApp: App {
     var body: some Scene {
         WindowGroup {
             ContentView().environmentObject(data)
-        }.commands { VMCommands() }
+        }.commands {
+            #if os(macOS)
+            // Since you can't make a ApplicationDelegateAdaptor a StateObject, we have to go the whole hog and pass the entire appDelegate.
+            VMCommands(appDelegate: appDelegate) 
+            #else
+            VMCommands()
+            #endif
+        }
         #if os(macOS)
         Settings {
             SettingsView()

--- a/Platform/macOS/AppDelegate.swift
+++ b/Platform/macOS/AppDelegate.swift
@@ -15,7 +15,27 @@
 //
 
 class AppDelegate: NSObject, NSApplicationDelegate {
+    var mainWindow: NSWindow?
+    
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         true
+    }
+    
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        if let window = NSApplication.shared.windows.first {
+            mainWindow = window
+            window.isExcludedFromWindowsMenu = true
+        }
+    }
+    
+    func applicationDockMenu(_ sender: NSApplication) -> NSMenu? {
+        let menu = NSMenu()
+        let utmItem = NSMenuItem(title: "UTM", action: #selector(mainWindowFront), keyEquivalent: "")
+        menu.addItem(utmItem)
+        return menu
+    }
+    
+    @objc func mainWindowFront() {
+        mainWindow?.makeKeyAndOrderFront(nil)
     }
 }


### PR DESCRIPTION
Fixes #3099 by setting isExcludedFromWindowsMenu, then adding a custom
'UTM' menu item that brings the main UTM window front

Note: Should the `UTM` menu item have a different name (like `Open Main Window`) since just `UTM` isn't clear what it does?