### PR TITLE
Set USB-XHCI bus for USB storage when using aarch64 system architecture

### DIFF
--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -209,7 +209,10 @@ static size_t sysctl_read(const char *name) {
         [self pushArgv:[NSString stringWithFormat:@"nvme,drive=%@,serial=%@,bootindex=%lu", identifier, identifier, bootindex++]];
     } else if ([interface isEqualToString:@"usb"]) {
         [self pushArgv:@"-device"];
-        [self pushArgv:[NSString stringWithFormat:@"usb-storage,drive=%@,removable=%@,bootindex=%lu", identifier, removable ? @"true" : @"false", bootindex++]];
+        /// use usb 3 bus for virt system, unless using legacy input setting (this mirrors the code in argsForUsb)
+        bool useUSB3 = !self.configuration.inputLegacy && [self.configuration.systemTarget hasPrefix:@"virt"];
+        NSString *bus = useUSB3 ? @",bus=usb-bus.0" : @"";
+        [self pushArgv:[NSString stringWithFormat:@"usb-storage,drive=%@,removable=%@,bootindex=%lu%@", identifier, removable ? @"true" : @"false", bootindex++, bus]];
     } else if ([interface isEqualToString:@"floppy"] && [self.configuration.systemTarget hasPrefix:@"q35"]) {
         [self pushArgv:@"-device"];
         [self pushArgv:[NSString stringWithFormat:@"isa-fdc,id=fdc%lu,bootindexA=%lu", busindex, bootindex++]];


### PR DESCRIPTION
~~Fixes~~ Partially fixes #3194 (Windows 11 installer causes QEMU EHCI reset, aborting install)

The result of this PR is that for `aarch64` guest, the USB CD drive is connected to the XHCI bus:
<img width="459" alt="Screen Shot 2021-10-27 at 22 36 55" src="https://user-images.githubusercontent.com/12073163/139143507-d400f066-e65e-4a6a-bc02-a7801a5e5ec0.png">

This has the nice side effect of increasing the speed of the USB drive.

Edit: added "partially" above to reflect my findings while testing. See [my comment](https://github.com/utmapp/UTM/issues/3194#issuecomment-953314235) for details.