### PR TITLE
Fix downloadVM URL action failing to import downloaded file

### DIFF
--- a/Platform/Shared/UTMImportFromWebTask.swift
+++ b/Platform/Shared/UTMImportFromWebTask.swift
@@ -46,12 +46,13 @@ class UTMImportFromWebTask: NSObject, URLSessionDelegate, URLSessionDownloadDele
                 try fileManager.removeItem(at: downloadedZip)
             }
             try fileManager.moveItem(at: location, to: downloadedZip)
-            let unzippedURL = try Zip.quickUnzipFile(downloadedZip)
+            let unzippedPath = tempDir.appendingPathComponent(originalFilename.replacingOccurrences(of: ".zip", with: ""))
+            try Zip.unzipFile(downloadedZip, destination: unzippedPath, overwrite: true, password: nil)
             /// remove the downloaded ZIP file
             try fileManager.removeItem(at: downloadedZip)
-            handleUnzipped(unzippedURL)
+            handleUnzipped(unzippedPath)
             /// remove unzipped file
-            try FileManager.default.removeItem(at: unzippedURL)
+            try FileManager.default.removeItem(at: unzippedPath)
         } catch {
             logger.error(Logger.Message(stringLiteral: error.localizedDescription))
             try? fileManager.removeItem(at: downloadedZip)

--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -320,7 +320,11 @@ class UTMData: ObservableObject {
         } else {
             try fileManager.copyItem(at: at, to: to)
         }
-        guard let vm = UTMVirtualMachine(url: to) else {
+    }
+    
+    /// Attempts to read from the URL and appends the VM to the list of virtual machines.
+    func readUTMFromURL(fileURL: URL) throws {
+        guard let vm = UTMVirtualMachine(url: fileURL) else {
             throw NSLocalizedString("Failed to parse imported VM.", comment: "UTMData")
         }
         DispatchQueue.main.async {
@@ -355,9 +359,11 @@ class UTMData: ObservableObject {
         } else if (fileBasePath.resolvingSymlinksInPath().path == documentsURL.appendingPathComponent("Inbox", isDirectory: true).path) {
             logger.info("moving from Inbox")
             try copyUTM(at: url, to: dest, move: true)
+            try readUTMFromURL(fileURL: dest)
         } else {
             logger.info("copying to Documents")
             try copyUTM(at: url, to: dest)
+            try readUTMFromURL(fileURL: dest)
         }
     }
     

--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ UTM is also available for macOS: https://mac.getutm.app/
 
 UTM is distributed under the permissive Apache 2.0 license. However, it uses several (L)GPL components. Most are dynamically linked but the gstreamer plugins are statically linked and parts of the code are taken from qemu. Please be aware of this if you intend on redistributing this application.
 
-Some icons made by [Freepik](https://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com/).
-
+Some icons made by [Freepik](https://www.freepik.com) from [www.flaticon.com](https://www.flaticon.com/).  
+UTM uses [ZIP Foundation](https://github.com/weichsel/ZIPFoundation), which is released under the MIT License.
+  
   [1]: https://github.com/utmapp/UTM/actions?query=event%3Arelease+workflow%3ABuild
   [2]: screen.png
   [3]: https://github.com/ktemkin/qemu/blob/with_tcti/tcg/aarch64-tcti/README.md

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -36,9 +36,9 @@
 		835AA7B126AB7C85007A0411 /* UTMPendingVirtualMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835AA7B026AB7C85007A0411 /* UTMPendingVirtualMachine.swift */; };
 		835AA7B226AB7C85007A0411 /* UTMPendingVirtualMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835AA7B026AB7C85007A0411 /* UTMPendingVirtualMachine.swift */; };
 		835AA7B326AB7C85007A0411 /* UTMPendingVirtualMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 835AA7B026AB7C85007A0411 /* UTMPendingVirtualMachine.swift */; };
-		836A40D526AA2A03002068F8 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 836A40D426AA2A03002068F8 /* Zip */; };
-		836A40D726AA2A2C002068F8 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 836A40D626AA2A2C002068F8 /* Zip */; };
-		836A40D926AA2A30002068F8 /* Zip in Frameworks */ = {isa = PBXBuildFile; productRef = 836A40D826AA2A30002068F8 /* Zip */; };
+		83993290272F4A400059355F /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 8399328F272F4A400059355F /* ZIPFoundation */; };
+		83993292272F68550059355F /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 83993291272F68550059355F /* ZIPFoundation */; };
+		83993294272F685F0059355F /* ZIPFoundation in Frameworks */ = {isa = PBXBuildFile; productRef = 83993293272F685F0059355F /* ZIPFoundation */; };
 		83A004B926A8CC95001AC09E /* UTMImportFromWebTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A004B826A8CC95001AC09E /* UTMImportFromWebTask.swift */; };
 		83A004BA26A8CC95001AC09E /* UTMImportFromWebTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A004B826A8CC95001AC09E /* UTMImportFromWebTask.swift */; };
 		83A004BB26A8CC95001AC09E /* UTMImportFromWebTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83A004B826A8CC95001AC09E /* UTMImportFromWebTask.swift */; };
@@ -2124,6 +2124,7 @@
 				CE2D934024AD46670059923A /* libgstosxaudio.a in Frameworks */,
 				CE2D934124AD46670059923A /* gmodule-2.0.0.framework in Frameworks */,
 				CE2D934224AD46670059923A /* jpeg.62.framework in Frameworks */,
+				83993292272F68550059355F /* ZIPFoundation in Frameworks */,
 				CE2D934324AD46670059923A /* intl.8.framework in Frameworks */,
 				CE2D934424AD46670059923A /* gstapp-1.0.0.framework in Frameworks */,
 				CE2D934524AD46670059923A /* gthread-2.0.0.framework in Frameworks */,
@@ -2139,7 +2140,6 @@
 				CE2D934F24AD46670059923A /* phodav-2.0.0.framework in Frameworks */,
 				CEA9059025FC6A1700801E7C /* usbredirparser.1.framework in Frameworks */,
 				CE0E9B87252FD06B0026E02B /* SwiftUI.framework in Frameworks */,
-				836A40D726AA2A2C002068F8 /* Zip in Frameworks */,
 				CE2D935024AD46670059923A /* gstcontroller-1.0.0.framework in Frameworks */,
 				CE2D935124AD46670059923A /* gstaudio-1.0.0.framework in Frameworks */,
 				CE2D935224AD46670059923A /* gpg-error.0.framework in Frameworks */,
@@ -2226,12 +2226,12 @@
 				CE03D08924D90F0700F76B84 /* glib-2.0.0.framework in Frameworks */,
 				CE0B6EC224AD677200FE012D /* libgstvideorate.a in Frameworks */,
 				CE0B6F0C24AD677200FE012D /* gstreamer-1.0.0.framework in Frameworks */,
-				836A40D526AA2A03002068F8 /* Zip in Frameworks */,
 				CEF83F89250094A400557D15 /* png16.16.framework in Frameworks */,
 				CE0B6F0224AD677200FE012D /* libgstjpeg.a in Frameworks */,
 				CE0B6EFC24AD677200FE012D /* libgstaudiotestsrc.a in Frameworks */,
 				CE0B6EF824AD677200FE012D /* gstsdp-1.0.0.framework in Frameworks */,
 				CE0B6EEA24AD677200FE012D /* libgstcoreelements.a in Frameworks */,
+				83993290272F4A400059355F /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2300,12 +2300,12 @@
 				CEA45F59263519B5002FA97D /* gstpbutils-1.0.0.framework in Frameworks */,
 				CEA45F5A263519B5002FA97D /* gstallocators-1.0.0.framework in Frameworks */,
 				CEA45F5B263519B5002FA97D /* gstcheck-1.0.0.framework in Frameworks */,
-				836A40D926AA2A30002068F8 /* Zip in Frameworks */,
 				CEA45F5C263519B5002FA97D /* iconv.2.framework in Frameworks */,
 				CEA45F5D263519B5002FA97D /* gstsdp-1.0.0.framework in Frameworks */,
 				CEA45F5E263519B5002FA97D /* ssl.1.1.framework in Frameworks */,
 				CEA45F5F263519B5002FA97D /* spice-server.1.framework in Frameworks */,
 				CEA45F60263519B5002FA97D /* pixman-1.0.framework in Frameworks */,
+				83993294272F685F0059355F /* ZIPFoundation in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3192,7 +3192,7 @@
 			packageProductDependencies = (
 				CE020BA624AEDEF000B44AB6 /* Logging */,
 				CE93759824BB821F0074066F /* IQKeyboardManagerSwift */,
-				836A40D626AA2A2C002068F8 /* Zip */,
+				83993291272F68550059355F /* ZIPFoundation */,
 			);
 			productName = UTM;
 			productReference = CE2D93BE24AD46670059923A /* UTM.app */;
@@ -3217,7 +3217,7 @@
 			name = macOS;
 			packageProductDependencies = (
 				CE020BA824AEDF3000B44AB6 /* Logging */,
-				836A40D426AA2A03002068F8 /* Zip */,
+				8399328F272F4A400059355F /* ZIPFoundation */,
 			);
 			productName = UTM;
 			productReference = CE2D951C24AD48BE0059923A /* UTM.app */;
@@ -3259,7 +3259,7 @@
 			packageProductDependencies = (
 				CEA45E20263519B5002FA97D /* Logging */,
 				CEA45E22263519B5002FA97D /* IQKeyboardManagerSwift */,
-				836A40D826AA2A30002068F8 /* Zip */,
+				83993293272F685F0059355F /* ZIPFoundation */,
 			);
 			productName = UTM;
 			productReference = CEA45FB9263519B5002FA97D /* UTM SE.app */;
@@ -3327,7 +3327,7 @@
 			packageReferences = (
 				CE020BA524AEDEF000B44AB6 /* XCRemoteSwiftPackageReference "swift-log" */,
 				CE93759724BB821F0074066F /* XCRemoteSwiftPackageReference "IQKeyboardManager" */,
-				836A40D326AA2A03002068F8 /* XCRemoteSwiftPackageReference "Zip" */,
+				8399328E272F4A400059355F /* XCRemoteSwiftPackageReference "ZIPFoundation" */,
 			);
 			productRefGroup = CE550BCA225947990063E575 /* Products */;
 			projectDirPath = "";
@@ -4906,12 +4906,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		836A40D326AA2A03002068F8 /* XCRemoteSwiftPackageReference "Zip" */ = {
+		8399328E272F4A400059355F /* XCRemoteSwiftPackageReference "ZIPFoundation" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/marmelroy/Zip.git";
+			repositoryURL = "https://github.com/weichsel/ZIPFoundation.git";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.1.1;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.9.9;
 			};
 		};
 		CE020BA524AEDEF000B44AB6 /* XCRemoteSwiftPackageReference "swift-log" */ = {
@@ -4949,20 +4949,20 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		836A40D426AA2A03002068F8 /* Zip */ = {
+		8399328F272F4A400059355F /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 836A40D326AA2A03002068F8 /* XCRemoteSwiftPackageReference "Zip" */;
-			productName = Zip;
+			package = 8399328E272F4A400059355F /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
-		836A40D626AA2A2C002068F8 /* Zip */ = {
+		83993291272F68550059355F /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 836A40D326AA2A03002068F8 /* XCRemoteSwiftPackageReference "Zip" */;
-			productName = Zip;
+			package = 8399328E272F4A400059355F /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
-		836A40D826AA2A30002068F8 /* Zip */ = {
+		83993293272F685F0059355F /* ZIPFoundation */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 836A40D326AA2A03002068F8 /* XCRemoteSwiftPackageReference "Zip" */;
-			productName = Zip;
+			package = 8399328E272F4A400059355F /* XCRemoteSwiftPackageReference "ZIPFoundation" */;
+			productName = ZIPFoundation;
 		};
 		CE020BA624AEDEF000B44AB6 /* Logging */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -4926,8 +4926,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/hackiftekhar/IQKeyboardManager.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 6.5.5;
+				kind = exactVersion;
+				version = 6.5.6;
 			};
 		};
 		CEA45E21263519B5002FA97D /* XCRemoteSwiftPackageReference "swift-log" */ = {


### PR DESCRIPTION
A file path confusion existed where the downloaded ZIP was extracted to the UTM
Documents directory instead of the temporary folder (I believe this change may have been caused by an update of the ZIP library in use). As a result, UTM failed to import the downloaded file because a folder with the same name already existed (as seen in the console log).

This is fixed by manually specifying the path for the unzip call.