### PR TITLE
Add support for Disk Images on external Drives (macOS only)

### DIFF
--- a/Configuration/UTMConfiguration+Drives.h
+++ b/Configuration/UTMConfiguration+Drives.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)recoverOrphanedDrives;
 
 - (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface;
+- (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface bookmark:(BOOL)isBookmark;
 - (NSInteger)newRemovableDrive:(NSString *)name type:(UTMDiskImageType)type interface:(NSString *)interface;
 - (nullable NSString *)driveNameForIndex:(NSInteger)index;
 - (void)setDriveName:(NSString *)name forIndex:(NSInteger)index;
@@ -50,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setDriveImageType:(UTMDiskImageType)type forIndex:(NSInteger)index;
 - (BOOL)driveRemovableForIndex:(NSInteger)index;
 - (void)setDriveRemovable:(BOOL)isRemovable forIndex:(NSInteger)index;
+- (BOOL)driveBookmarkForIndex:(NSInteger)index;
+- (void)setDriveBookmark:(BOOL)isBookmark forIndex:(NSInteger)index;
 - (void)moveDriveIndex:(NSInteger)index to:(NSInteger)newIndex;
 - (void)removeDriveAtIndex:(NSInteger)index;
 

--- a/Configuration/UTMConfiguration+Drives.m
+++ b/Configuration/UTMConfiguration+Drives.m
@@ -25,6 +25,7 @@ static const NSString *const kUTMConfigImagePathKey = @"ImagePath";
 static const NSString *const kUTMConfigImageTypeKey = @"ImageType";
 static const NSString *const kUTMConfigInterfaceTypeKey = @"InterfaceType";
 static const NSString *const kUTMConfigRemovableKey = @"Removable";
+static const NSString *const kUTMConfigBookmarkKey = @"Bookmark";
 static const NSString *const kUTMConfigCdromKey = @"Cdrom";
 
 @interface UTMConfiguration ()
@@ -116,13 +117,18 @@ static const NSString *const kUTMConfigCdromKey = @"Cdrom";
 }
 
 - (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface {
+    return [self newDrive:name path:path type:type interface:interface bookmark:NO];
+}
+
+- (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface bookmark:(BOOL)isBookmark {
     NSInteger index = [self countDrives];
     NSString *strType = [UTMConfiguration supportedImageTypes][type];
     NSMutableDictionary *drive = [[NSMutableDictionary alloc] initWithDictionary:@{
         kUTMConfigDriveNameKey: name,
         kUTMConfigImagePathKey: path,
         kUTMConfigImageTypeKey: strType,
-        kUTMConfigInterfaceTypeKey: interface
+        kUTMConfigInterfaceTypeKey: interface,
+        kUTMConfigBookmarkKey: @(isBookmark)
     }];
     [self propertyWillChange];
     [self.rootDict[kUTMConfigDrivesKey] addObject:drive];
@@ -214,6 +220,19 @@ static const NSString *const kUTMConfigCdromKey = @"Cdrom";
     if (isRemovable) {
         [self.rootDict[kUTMConfigDrivesKey][index] removeObjectForKey:kUTMConfigImagePathKey];
     }
+    [self propertyWillChange];
+}
+
+- (BOOL)driveBookmarkForIndex:(NSInteger)index {
+    if (index >= self.countDrives) {
+        return NO;
+    } else {
+        return [self.rootDict[kUTMConfigDrivesKey][index][kUTMConfigBookmarkKey] boolValue];
+    }
+}
+
+- (void)setDriveBookmark:(BOOL)isBookmark forIndex:(NSInteger)index {
+    self.rootDict[kUTMConfigDrivesKey][index][kUTMConfigBookmarkKey] = @(isBookmark);
     [self propertyWillChange];
 }
 

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -298,6 +298,9 @@ static size_t sysctl_read(const char *name) {
                                                            relativeToURL:nil
                                                      bookmarkDataIsStale:nil
                                                                    error:nil];
+                if (!fullPathURL) {
+                    // TODO: Some error alert like `Cannot access disk image from external drive. Is the drive plugged in?`
+                }
                 [self accessDataWithBookmark:bookmark];
             } else {
                 [self accessDataWithBookmark:[fullPathURL bookmarkDataWithOptions:0

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -281,6 +281,7 @@ static size_t sysctl_read(const char *name) {
         NSString *path = [self.configuration driveImagePathForIndex:i];
         UTMDiskImageType type = [self.configuration driveImageTypeForIndex:i];
         BOOL hasImage = ![self.configuration driveRemovableForIndex:i] && path;
+        BOOL isBookmark = [self.configuration driveBookmarkForIndex:i];
         NSURL *fullPathURL;
         
         if (hasImage) {
@@ -289,10 +290,21 @@ static size_t sysctl_read(const char *name) {
             } else {
                 fullPathURL = [[self.imgPath URLByAppendingPathComponent:[UTMConfiguration diskImagesDirectory]] URLByAppendingPathComponent:[self.configuration driveImagePathForIndex:i]];
             }
-            [self accessDataWithBookmark:[fullPathURL bookmarkDataWithOptions:0
-                                               includingResourceValuesForKeys:nil
-                                                                relativeToURL:nil
-                                                                        error:nil]];
+            if (isBookmark) {
+                fullPathURL = [fullPathURL URLByAppendingPathExtension:@"bookmark"];
+                NSData *bookmark = [[NSData alloc] initWithContentsOfURL:fullPathURL];
+                fullPathURL = [[NSURL alloc] initByResolvingBookmarkData:bookmark
+                                                                 options:0
+                                                           relativeToURL:nil
+                                                     bookmarkDataIsStale:nil
+                                                                   error:nil];
+                [self accessDataWithBookmark:bookmark];
+            } else {
+                [self accessDataWithBookmark:[fullPathURL bookmarkDataWithOptions:0
+                                                   includingResourceValuesForKeys:nil
+                                                                    relativeToURL:nil
+                                                                            error:nil]];
+            }
         }
         
         switch (type) {

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -291,7 +291,6 @@ static size_t sysctl_read(const char *name) {
                 fullPathURL = [[self.imgPath URLByAppendingPathComponent:[UTMConfiguration diskImagesDirectory]] URLByAppendingPathComponent:[self.configuration driveImagePathForIndex:i]];
             }
             if (isBookmark) {
-                fullPathURL = [fullPathURL URLByAppendingPathExtension:@"bookmark"];
                 NSData *bookmark = [[NSData alloc] initWithContentsOfURL:fullPathURL];
                 fullPathURL = [[NSURL alloc] initByResolvingBookmarkData:bookmark
                                                                  options:0
@@ -300,6 +299,7 @@ static size_t sysctl_read(const char *name) {
                                                                    error:nil];
                 if (!fullPathURL) {
                     // TODO: Some error alert like `Cannot access disk image from external drive. Is the drive plugged in?`
+                    NSLog(@"Couldn't get fullPathURL");
                 }
                 [self accessDataWithBookmark:bookmark];
             } else {

--- a/Platform/Shared/VMConfigDriveDetailsView.swift
+++ b/Platform/Shared/VMConfigDriveDetailsView.swift
@@ -42,7 +42,7 @@ struct VMConfigDriveDetailsView: View {
             config.setDriveRemovable($0, for: index)
         }
         self._name = Binding<String?> {
-            return config.driveImagePath(for: index)
+            return config.driveImagePath(for: index)?.replacingOccurrences(of: ".bookmark", with: " (external)")
         } set: {
             if let name = $0 {
                 config.setImagePath(name, for: index)

--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -473,7 +473,7 @@ class UTMData: ObservableObject {
         _ = image.startAccessingSecurityScopedResource()
         defer { image.stopAccessingSecurityScopedResource() }
 
-        let path = image.lastPathComponent
+        let path = image.appendingPathExtension("bookmark").lastPathComponent
 
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: image.path, isDirectory: &isDir), !isDir.boolValue else {
@@ -488,7 +488,7 @@ class UTMData: ObservableObject {
         do {
             let bookmark = try image.bookmarkData()
             let imagesPath = config.imagesPath
-            let dstPath = imagesPath.appendingPathComponent(path).appendingPathExtension("bookmark")
+            let dstPath = imagesPath.appendingPathComponent(path)
             if !fileManager.fileExists(atPath: imagesPath.path) {
                 try fileManager.createDirectory(at: imagesPath, withIntermediateDirectories: false, attributes: nil)
             }

--- a/Platform/UTMExtensions.swift
+++ b/Platform/UTMExtensions.swift
@@ -99,6 +99,7 @@ extension UTType {
     static let UTM = UTType(exportedAs: "utm")
     
     static let appleLog = UTType(filenameExtension: "log")!
+    static let qcow2 = UTType(filenameExtension: "qcow2")!
 }
 
 extension Sequence where Element: Hashable {

--- a/Platform/macOS/Display/VMDisplayWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayWindowController.swift
@@ -286,6 +286,7 @@ extension VMDisplayWindowController: UTMVirtualMachineDelegate {
         for drive in drives {
             let item = NSMenuItem()
             item.title = drive.label
+                .replacingOccurrences(of: ".bookmark", with: " (external)")
             if drive.status == .fixed {
                 item.isEnabled = false
             } else {

--- a/Platform/macOS/VMConfigDrivesView.swift
+++ b/Platform/macOS/VMConfigDrivesView.swift
@@ -94,7 +94,9 @@ struct VMConfigDrivesView: View {
         openPanel.begin { result in
             if result == .OK {
                 if let imageUrl = openPanel.url {
-                    try! data.importDriveFromExternal(imageUrl, for: config)
+                    data.busyWork {
+                        try data.importDriveFromExternal(imageUrl, for: config)
+                    }
                 }
             }
         }

--- a/Platform/macOS/VMConfigDrivesView.swift
+++ b/Platform/macOS/VMConfigDrivesView.swift
@@ -124,6 +124,13 @@ struct DriveCard: View {
                     Button(action: deleteDrive, label: {
                         Label("Delete", systemImage: "trash").labelStyle(IconOnlyLabelStyle()).foregroundColor(.red)
                     })
+                    if !config.driveBookmark(for: index) {
+                        Button {
+                            moveDriveToExternal()
+                        } label: {
+                            Text("Move drive to external disk")
+                        }.padding(.leading, 20)
+                    }
                     Spacer()
                     if index != 0 {
                         Button(action: moveDriveUp, label: {
@@ -140,6 +147,22 @@ struct DriveCard: View {
         }
     }
     
+    func moveDriveToExternal() {
+        let savePanel = NSSavePanel()
+        savePanel.directoryURL = URL(fileURLWithPath: "/Volumes")
+        savePanel.title = "Select a location on an external disk to move the drive to:"
+        savePanel.nameFieldStringValue = config.driveName(for: index) ?? "drive"
+        savePanel.begin { result in
+            if result == .OK {
+                if let dstUrl = savePanel.url {
+                    data.busyWork {
+                        try data.moveDriveToExternal(at: index, url: dstUrl, for: config)
+                    }
+                }
+            }
+        }
+    }
+
     func deleteDrive() {
         data.busyWork {
             try data.removeDrive(at: index, for: config)

--- a/Platform/macOS/VMConfigDrivesView.swift
+++ b/Platform/macOS/VMConfigDrivesView.swift
@@ -29,11 +29,16 @@ struct VMConfigDrivesView: View {
             HStack {
                 Spacer()
                 Button(action: { importDrivePresented.toggle() }, label: {
-                    Label("Import Drive", systemImage: "square.and.arrow.down").labelStyle(TitleOnlyLabelStyle())
+                    Text("Import Drive")
                 })
                 .fileImporter(isPresented: $importDrivePresented, allowedContentTypes: [.item], onCompletion: importDrive)
+                Button {
+                    importDriveFromExternal()
+                } label: {
+                    Text("Import Drive from External Disk")
+                }
                 Button(action: { newDrivePopover.toggle() }, label: {
-                    Label("New Drive", systemImage: "plus").labelStyle(TitleOnlyLabelStyle())
+                    Text("New Drive")
                 })
                 .onChange(of: newDrivePopover, perform: { showPopover in
                     if showPopover {
@@ -82,6 +87,19 @@ struct VMConfigDrivesView: View {
         }
     }
     
+    private func importDriveFromExternal() {
+        let openPanel = NSOpenPanel()
+        openPanel.directoryURL = URL(fileURLWithPath: "/Volumes")
+        openPanel.message = "Choose a Disk Image from an External Drive to import:"
+        openPanel.begin { result in
+            if result == .OK {
+                if let imageUrl = openPanel.url {
+                    try! data.importDriveFromExternal(imageUrl, for: config)
+                }
+            }
+        }
+    }
+
     private func addNewDrive(_ newDrive: VMDriveImage) {
         newDrivePopover = false // hide popover
         data.busyWork {

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -2478,11 +2478,11 @@
 				CE2D953E24AD4F980059923A /* VMConfigNetworkPortForwardView.swift */,
 				CE2D953D24AD4F980059923A /* VMSettingsView.swift */,
 				53A0BDD426D79FE40010EDC5 /* SavePanel.swift */,
+				83C15C5E26CC441000ADFD45 /* KeyCodeMap.swift */,
 				CE2D954124AD4F980059923A /* Info.plist */,
 				FFB02A8E266CB09C006CD71A /* InfoPlist.strings */,
 				CE2D953F24AD4F980059923A /* macOS.entitlements */,
 				CEF6F5EA26DDD60500BC434D /* macOS-unsigned.entitlements */,
-				83C15C5E26CC441000ADFD45 /* KeyCodeMap.swift */,
 			);
 			path = macOS;
 			sourceTree = "<group>";
@@ -2909,6 +2909,7 @@
 				CE6EDCE0241DA0E900A719DC /* UTMLogging.h */,
 				CE6EDCE1241DA0E900A719DC /* UTMLogging.m */,
 				CEDF83F8258AE24E0030E4AC /* UTMPasteboard.swift */,
+				835AA7B026AB7C85007A0411 /* UTMPendingVirtualMachine.swift */,
 				CEF83ED124FDEA9400557D15 /* UTMPortAllocator.h */,
 				CEF83ED224FDEA9400557D15 /* UTMPortAllocator.m */,
 				2C6D9E122571AFE5003298E6 /* UTMQcow2.h */,
@@ -2945,7 +2946,6 @@
 				CE0B6D8324AD5ADE00FE012D /* UTMScreenshot.h */,
 				CE0B6D8424AD5ADE00FE012D /* UTMScreenshot.m */,
 				CE020BB524B14F8400B44AB6 /* UTMVirtualMachineExtension.swift */,
-				835AA7B026AB7C85007A0411 /* UTMPendingVirtualMachine.swift */,
 			);
 			path = Managers;
 			sourceTree = "<group>";


### PR DESCRIPTION
#### ToDo:
- [x] Fix the bookmark file not being moved to the final directory (currently it only works if you have an already created VM).
- [x] Opening the Drives configuration pane initially shows both the drive and the drive bookmark. And later the bookmark becomes deleted.
~~These above 2 problems are because I store the bookmark data in a file with the image name + `.bookmark` extension, so the orphaned drives check is considering it orphaned. I **can** store the name with the `.bookmark` extension in the config but then users will see (for example) `disk-0.qcow2.bookmark` in the Drives tab. The other alternative is for the Drives tab to remove the `.bookmark` extension before putting it into the UI.~~
- [ ] Show error alert if bookmark cannot be resolved (if the drive isn't plugged in). Bit difficult since resolving the bookmark is done in `UTMQemuSystem.m` which doesn't have access to the UI. (@osy some help here please?)
- [ ] In the `VMConfigDriveDetailsView` show a text with which volume name the bookmark is from (might not be possible since the bookmark is a NSData and it can't be resolved into a URL if the drive folder doesn't exist).
- [x] In the `VMConfigDriveDetailsView` add a button to move a VM drive to an external drive
- [x] Add ability to create new disk in external drive

Fixes #3138 and #3142

The changes to `UTM.xcodeproj/project.pbxproj` are alphabetically re-ordering the files conath added in the URL scheme PR.