### PR TITLE
Fix dual sandbox path

### DIFF
--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -104,7 +104,9 @@ fake_sign() {
 	mkdir -p "$_output"
 	cp -a "$_input" "$_output/"
 	find "$_output" -type f \( -path '*/Frameworks/*.framework/*' -and -not -name 'Info.plist' \) -exec ldid -S \{\} \;
-	ldid -S${_fakeent} "$_output/Applications/$_name.app/$_name"
+	mv "$_output/Applications/$_name.app/$_name" "$_output/Applications/$_name.app/com.utmapp.UTM"
+	ldid -S${_fakeent} "$_output/Applications/$_name.app/com.utmapp.UTM"
+	mv "$_output/Applications/$_name.app/com.utmapp.UTM" "$_output/Applications/$_name.app/$_name"
 }
 
 create_deb() {


### PR DESCRIPTION
This change will fix an issues cause UTM got dual sandbox path on iOS.
When installing UTM, iOS will create an sandbox named the CFBundleIdentifier: _com.utmapp.UTM_. However, if we signed UTM main executable with ldid, the executable's Identifier will be as _UTM_! So iOS will make UTM running in another sandbox path that difference with the system records. This change will make ldid sign UTM's Identifier as _com.utmapp.UTM_.
![DF6AD7B2-3F7E-48E0-B1C0-B25DCBA963F4](https://user-images.githubusercontent.com/45062120/140399224-0d57fa94-dce5-41ac-a746-3ba0115fbee3.png)

