### PR TITLE
iOS: Make it possible to allocate more than about 5 GB of memory

### DIFF
--- a/Platform/iOS/iOS.entitlements
+++ b/Platform/iOS/iOS.entitlements
@@ -4,5 +4,7 @@
 <dict>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
 	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
 </dict>
 </plist>

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -195,6 +195,8 @@ deb )
 	<true/>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
 	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
+	<true/>
 </dict>
 </plist>
 EOL
@@ -211,6 +213,8 @@ ipa )
 	<key>get-task-allow</key>
 	<true/>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 	<!-- https://siguza.github.io/psychicpaper/ -->
 	<!---><!-->
@@ -242,6 +246,8 @@ ipa-se )
 <plist version="1.0">
 <dict>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>
+	<true/>
+	<key>com.apple.developer.kernel.extended-virtual-addressing</key>
 	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
As described [here](https://developer.apple.com/forums/thread/685084?answerId=695278022#695278022), you need two entitlements in order to use more than 5 GB of memory on iOS and iPadOS.

`com.apple.developer.kernel.increased-memory-limit` already has been added to [iOS.entitlements](https://github.com/utmapp/UTM/blob/6524c733d36f183c5b393b54e91f7f0cd2ae7ad7/Platform/iOS/iOS.entitlements#L5), but it's insufficient.

The results of my experiments in my app showed that `com.apple.developer.kernel.increased-memory-limit` certainly increased the return value of `os_proc_available_memory`, it was about 12 GB on the iPad Pro that has 16GB of memory, but the actual limit of memory that can be allocated was only about 5 GB. So I also added the `com.apple.developer.kernel.extended-virtual-addressing` entitlement, and now the app can allocate about 12 GB.

Therefore, you should add this entitlement in order to use more than 5 GB of memory.