### PR TITLE
Fix Microphone access (on macOS)

### DIFF
--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -23,6 +23,7 @@ import UIKit
 #if canImport(AltKit)
 import AltKit
 #endif
+import AVFoundation
 
 @available(iOS 14, macOS 11, *)
 struct AlertMessage: Identifiable {
@@ -179,6 +180,14 @@ class UTMData: ObservableObject {
     
     func save(vm: UTMVirtualMachine) throws {
         do {
+            #if os(macOS)
+            if vm.configuration.soundCard?.contains("hda") ?? false {
+                /// get mic permisison
+                AVCaptureDevice.requestAccess(for: .audio) { access in
+                    print(access)
+                }
+            }
+            #endif
             let oldPath = vm.path
             try vm.saveUTM()
             let newPath = vm.path

--- a/Platform/macOS/Info.plist
+++ b/Platform/macOS/Info.plist
@@ -56,6 +56,8 @@
 	<string>public.app-category.business</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allow access to allow VMs to use the Microphone.</string>
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/Platform/macOS/macOS-unsigned.entitlements
+++ b/Platform/macOS/macOS-unsigned.entitlements
@@ -12,6 +12,8 @@
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
 	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
This so far only requests permission when saving a VM with HDA card, needs to be extended to cover AC97 as well. Preferably it should be determined by the VM Config if microphone access is needed, and not in the `UTMData`.

Also just giving access does not seem to fix the guest mic access issue (recording still contains silence).