### PR TITLE
Fix #3388 invalid drive id for manually placed files

### DIFF
--- a/Configuration/UTMQemuConfiguration+Drives.m
+++ b/Configuration/UTMQemuConfiguration+Drives.m
@@ -104,7 +104,7 @@ static const NSString *const kUTMConfigCdromKey = @"Cdrom";
 - (void)recoverOrphanedDrives {
     NSArray<NSString *> *orphans = self.orphanedDrives;
     for (NSInteger i = 0; i < orphans.count; i++) {
-        NSString *name = [NSUUID UUID].UUIDString;
+        NSString *name = [NSString stringWithFormat:@"drive%@", [[NSUUID UUID] UUIDString]];
         [self newDrive:name path:orphans[i] type:UTMDiskImageTypeNone interface:@""];
     }
 }


### PR DESCRIPTION
QEMU drive ids must start with a letter.
However if an image files was manually placed in the VM images folder,
this code path is triggered and a UUID set for the id.
This causes ids starting with numbers to be set sometimes.

This commit changes the name for these drives to use sequential driveX numbering instead of UUID. Fixes #3388 

Tested successfully on macOS 12.1:

1. Place an image file in the Images folder of an existing UTM VM
2. Opening VM config
3. Click Drives tab
4. Change the new drive at the bottom of the list to type "disk image"
5. Click Save

Start VM → no error
Open Config QEMU tab → see drive id "driveX" instead of UUID.