### PR TITLE
Change default display upscaling mode to Nearest Neighbor

### DIFF
--- a/Configuration/UTMQemuConfiguration+Defaults.m
+++ b/Configuration/UTMQemuConfiguration+Defaults.m
@@ -42,7 +42,7 @@
         self.systemBootDevice = @"cd";
     }
     self.systemUUID = [[NSUUID UUID] UUIDString];
-    self.displayUpscaler = @"linear";
+    self.displayUpscaler = @"nearest";
     self.displayDownscaler = @"linear";
     self.consoleFont = @"Menlo";
     self.consoleFontSize = @12;


### PR DESCRIPTION
Closes #3371
Nearest Neighbor offers better contrast and increases sharpness for upscaling;
the reverse is true for downscaling so it is not changed.