### PR TITLE
Fixed: "auxiliaryStorage is nil" when creating macOS VM on M1 Mac

### DIFF
--- a/AppleVirtualization/UTMAppleConfiguration.swift
+++ b/AppleVirtualization/UTMAppleConfiguration.swift
@@ -423,8 +423,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     
     func save(to packageURL: URL) throws {
         let fileManager = FileManager.default
-        // validate
-        try apple.validate()
+
         // create package directory
         if !fileManager.fileExists(atPath: packageURL.path) {
             try fileManager.createDirectory(at: packageURL, withIntermediateDirectories: false)
@@ -437,6 +436,10 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         var existingDataURLs = [URL]()
         existingDataURLs += try saveIcon(to: dataURL)
         existingDataURLs += try saveBootloader(to: dataURL)
+
+        // validate
+        try apple.validate()
+
         existingDataURLs += try saveImportedDrives(to: dataURL)
         // create new drives
         existingDataURLs += try createNewDrives(at: dataURL)


### PR DESCRIPTION
I've tried to create a new macOS Monterey VM on a M1 Mac using [v3.0.0 (Beta)](https://github.com/utmapp/UTM/releases/tag/v3.0.0)

It fails with:
> Invalid virtual machine configuration. “auxiliaryStorage” is nil.

<img width="475" alt="Screen Shot 2022-01-01 at 21 55 01" src="https://user-images.githubusercontent.com/1675298/147858090-7673ada9-6918-43a0-95d4-6928280fceb3.png">

As far as I can tell, `apple.validate()` is the call that shows the message.
`auxiliaryStorage` is initialized later in the scope by `saveBootloader()`, but does not get called cause an error is thrown.

I've updated the code so that `apple.validate()` is called *after* `saveBootloader()`.
