### PR TITLE
macOS(qemu): add support for drives on external disks

### DIFF
--- a/Configuration/UTMQemuConfiguration+Drives.h
+++ b/Configuration/UTMQemuConfiguration+Drives.h
@@ -39,6 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)recoverOrphanedDrives;
 
 - (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface;
+- (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface reference:(BOOL)isReference;
 - (NSInteger)newRemovableDrive:(NSString *)name type:(UTMDiskImageType)type interface:(NSString *)interface;
 - (nullable NSString *)driveNameForIndex:(NSInteger)index;
 - (void)setDriveName:(NSString *)name forIndex:(NSInteger)index;
@@ -50,6 +51,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)setDriveImageType:(UTMDiskImageType)type forIndex:(NSInteger)index;
 - (BOOL)driveRemovableForIndex:(NSInteger)index;
 - (void)setDriveRemovable:(BOOL)isRemovable forIndex:(NSInteger)index;
+- (BOOL)driveReferenceForIndex:(NSInteger)index;
+- (void)setDriveReference:(BOOL)isReference forIndex:(NSInteger)index;
 - (void)moveDriveIndex:(NSInteger)index to:(NSInteger)newIndex;
 - (void)removeDriveAtIndex:(NSInteger)index;
 - (NSString *)driveLabelForIndex:(NSInteger)index;

--- a/Configuration/UTMQemuConfiguration+Drives.m
+++ b/Configuration/UTMQemuConfiguration+Drives.m
@@ -25,6 +25,7 @@ static const NSString *const kUTMConfigImagePathKey = @"ImagePath";
 static const NSString *const kUTMConfigImageTypeKey = @"ImageType";
 static const NSString *const kUTMConfigInterfaceTypeKey = @"InterfaceType";
 static const NSString *const kUTMConfigRemovableKey = @"Removable";
+static const NSString *const kUTMConfigReferenceKey = @"Reference";
 static const NSString *const kUTMConfigCdromKey = @"Cdrom";
 
 @interface UTMQemuConfiguration ()
@@ -116,13 +117,18 @@ static const NSString *const kUTMConfigCdromKey = @"Cdrom";
 }
 
 - (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface {
+    return [self newDrive:name path:path type:type interface:interface reference:NO];
+}
+
+- (NSInteger)newDrive:(NSString *)name path:(NSString *)path type:(UTMDiskImageType)type interface:(NSString *)interface reference:(BOOL)isReference {
     NSInteger index = [self countDrives];
     NSString *strType = [UTMQemuConfiguration supportedImageTypes][type];
     NSMutableDictionary *drive = [[NSMutableDictionary alloc] initWithDictionary:@{
         kUTMConfigDriveNameKey: name,
         kUTMConfigImagePathKey: path,
         kUTMConfigImageTypeKey: strType,
-        kUTMConfigInterfaceTypeKey: interface
+        kUTMConfigInterfaceTypeKey: interface,
+        kUTMConfigReferenceKey: @(isReference)
     }];
     [self propertyWillChange];
     [self.rootDict[kUTMConfigDrivesKey] addObject:drive];
@@ -214,6 +220,19 @@ static const NSString *const kUTMConfigCdromKey = @"Cdrom";
     if (isRemovable) {
         [self.rootDict[kUTMConfigDrivesKey][index] removeObjectForKey:kUTMConfigImagePathKey];
     }
+    [self propertyWillChange];
+}
+
+- (BOOL)driveReferenceForIndex:(NSInteger)index {
+    if (index >= self.countDrives) {
+        return NO;
+    } else {
+        return [self.rootDict[kUTMConfigDrivesKey][index][kUTMConfigReferenceKey] boolValue];
+    }
+}
+
+- (void)setDriveReference:(BOOL)isReference forIndex:(NSInteger)index {
+    self.rootDict[kUTMConfigDrivesKey][index][kUTMConfigReferenceKey] = @(isReference);
     [self propertyWillChange];
 }
 

--- a/Managers/UTMQemuSystem.m
+++ b/Managers/UTMQemuSystem.m
@@ -291,6 +291,7 @@ static size_t sysctl_read(const char *name) {
         NSString *path = [self.configuration driveImagePathForIndex:i];
         UTMDiskImageType type = [self.configuration driveImageTypeForIndex:i];
         BOOL hasImage = ![self.configuration driveRemovableForIndex:i] && path;
+        BOOL isReference = [self.configuration driveReferenceForIndex:i];
         NSURL *fullPathURL;
         
         if (hasImage) {
@@ -299,10 +300,21 @@ static size_t sysctl_read(const char *name) {
             } else {
                 fullPathURL = [[self.imgPath URLByAppendingPathComponent:[UTMQemuConfiguration diskImagesDirectory]] URLByAppendingPathComponent:[self.configuration driveImagePathForIndex:i]];
             }
-            [self accessDataWithBookmark:[fullPathURL bookmarkDataWithOptions:0
-                                               includingResourceValuesForKeys:nil
-                                                                relativeToURL:nil
-                                                                        error:nil]];
+            
+            if (isReference) {
+                NSData *bookmark = [[NSData alloc] initWithContentsOfURL:fullPathURL];
+                fullPathURL = [[NSURL alloc] initByResolvingBookmarkData:bookmark
+                                                                 options:0
+                                                           relativeToURL:nil
+                                                     bookmarkDataIsStale:nil
+                                                                   error:nil];
+                [self accessDataWithBookmark:bookmark];
+            } else {
+                [self accessDataWithBookmark:[fullPathURL bookmarkDataWithOptions:0
+                                                   includingResourceValuesForKeys:nil
+                                                                    relativeToURL:nil
+                                                                            error:nil]];
+            }
         }
         
         switch (type) {

--- a/Platform/Shared/VMConfigDriveDetailsView.swift
+++ b/Platform/Shared/VMConfigDriveDetailsView.swift
@@ -42,7 +42,7 @@ struct VMConfigDriveDetailsView: View {
             config.setDriveRemovable($0, for: index)
         }
         self._name = Binding<String?> {
-            return config.driveImagePath(for: index)
+            return config.driveImagePath(for: index)?.replacingOccurrences(of: ".reference$", with: " (reference)", options: .regularExpression)
         } set: {
             if let name = $0 {
                 config.setImagePath(name, for: index)


### PR DESCRIPTION
Full list of changes made:
- Add a `Reference` key to the drive configuration.
- Generate bookmark and access with it in argsForDrives if needed.
- Display drive on external disk with ` (reference)` appended.
- Add `reference` parameter to `importDrive`, used to change whether to
  perform a copy from source to dest, or to write bookmark data to dest.
- Add `newIndexCompletion` parameter to `importDrive`, used to return
  the new index after adding the drive. This is needed in
  `moveDriveToExternal` in order to maintain the boot order.
- Add `moveDriveToExternal` method that first performs the actual move
  of the drive, then calls `importDrive` with `reference` set to `true`
  in order to import and save a bookmark to the drive. It also then
  calls `moveDrive` in order to maintain the boot order.
- Change the icon used with the `Delete Drive` button to have an `xmark`
  instead of a `plus`, since that indicates removal/deletion.
- Add `Move to External Disk` button in the settings.
- Add `moveToExternal` function in `VMConfigDrivesButtons.swift` that
  opens a `NSSavePanel` with a default directory of `/Volumes` to ask
  the user where to move the drive to, then calls `moveDriveToExternal`
  with the selected destination.

Still to do:
- [ ] Error handling
- [ ] Possibly more when I think of them