### PR TITLE
display(macOS): fix invert mouse scroll doing nothing

### DIFF
--- a/Platform/macOS/Display/VMDisplayMetalWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayMetalWindowController.swift
@@ -368,11 +368,9 @@ extension VMDisplayMetalWindowController: VMMetalViewInputDelegate {
     }
     
     func mouseScroll(dy: CGFloat, button: CSInputButton) {
-        var scrollDy = dy
-        if vmQemuConfig?.inputScrollInvert ?? false {
-            scrollDy = -scrollDy
-        }
-        vmInput?.sendMouseScroll(.smooth, button: button, dy: dy)
+        let scrollInvert = vmQemuConfig?.inputScrollInvert ?? false
+        let scrollDy = scrollInvert ? -dy : dy
+        vmInput?.sendMouseScroll(.smooth, button: button, dy: scrollDy)
     }
     
     private func sendExtendedKey(_ button: CSInputKey, keyCode: Int) {


### PR DESCRIPTION
The scroll amount variable was being properly inverted, but it wasn't
being used in the function call. Also changed to use ternary operator
and no `var`.

Fixes #3497

I checked, and this code problem isn't in the iOS code.