### PR TITLE
config(apple): save config.plist as human-readable xml

### DIFF
--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -469,6 +469,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         try cleanupAllFiles(at: dataURL, notIncluding: existingDataURLs)
         // create config.plist
         let encoder = PropertyListEncoder()
+        encoder.outputFormat = .xml
         let settingsData = try encoder.encode(self)
         try settingsData.write(to: packageURL.appendingPathComponent(kUTMBundleConfigFilename))
     }


### PR DESCRIPTION
I have tested that this change is backward and forward compatible, meaning that I can save an xml config, and open it with UTM 3.0.3 (Beta) which expects a binary config (and if saving changes with 3.0.3 it will re-write it as binary), and I can also open a binary config with this code and when saving it will re-write it as xml.