### PR TITLE
Add support for changing console colors, properly load available font list on macOS

### DIFF
--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -309,6 +309,8 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         case iconCustom
         case notes
         case consoleTheme
+        case consoleTextColor
+        case consoleBackgroundColor
         case consoleFont
         case consoleFontSize
         case consoleCursorBlink
@@ -394,6 +396,10 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         iconCustom = try values.decode(Bool.self, forKey: .iconCustom)
         notes = try values.decodeIfPresent(String.self, forKey: .notes)
         consoleTheme = try values.decodeIfPresent(String.self, forKey: .consoleTheme)
+        let consoleTextColorString = try values.decodeIfPresent(String.self, forKey: .consoleTextColor)
+        consoleTextColor = NSColor(hexString: consoleTextColorString ?? "")
+        let consoleBackgroundColorString = try values.decodeIfPresent(String.self, forKey: .consoleBackgroundColor)
+        consoleBackgroundColor = NSColor(hexString: consoleBackgroundColorString ?? "")
         consoleFont = try values.decodeIfPresent(String.self, forKey: .consoleFont)
         let fontSize = try values.decodeIfPresent(Int.self, forKey: .consoleFontSize)
         if let fontSize = fontSize {
@@ -433,6 +439,8 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         try container.encode(iconCustom, forKey: .iconCustom)
         try container.encodeIfPresent(notes, forKey: .notes)
         try container.encodeIfPresent(consoleTheme, forKey: .consoleTheme)
+        try container.encodeIfPresent(consoleTextColor?.hexString, forKey: .consoleTextColor)
+        try container.encodeIfPresent(consoleBackgroundColor?.hexString, forKey: .consoleBackgroundColor)
         try container.encodeIfPresent(consoleFont, forKey: .consoleFont)
         try container.encodeIfPresent(consoleFontSize?.intValue, forKey: .consoleFontSize)
         try container.encode(consoleCursorBlink, forKey: .consoleCursorBlink)

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -45,9 +45,9 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     
     @Published var consoleTheme: String?
     
-    @Published var consoleTextColor: NSColor?
+    @Published var consoleTextColor: String?
     
-    @Published var consoleBackgroundColor: NSColor?
+    @Published var consoleBackgroundColor: String?
     
     @Published var consoleFont: String?
     
@@ -396,10 +396,8 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         iconCustom = try values.decode(Bool.self, forKey: .iconCustom)
         notes = try values.decodeIfPresent(String.self, forKey: .notes)
         consoleTheme = try values.decodeIfPresent(String.self, forKey: .consoleTheme)
-        let consoleTextColorString = try values.decodeIfPresent(String.self, forKey: .consoleTextColor)
-        consoleTextColor = NSColor(hexString: consoleTextColorString ?? "")
-        let consoleBackgroundColorString = try values.decodeIfPresent(String.self, forKey: .consoleBackgroundColor)
-        consoleBackgroundColor = NSColor(hexString: consoleBackgroundColorString ?? "")
+        consoleTextColor = try values.decodeIfPresent(String.self, forKey: .consoleTextColor)
+        consoleBackgroundColor = try values.decodeIfPresent(String.self, forKey: .consoleBackgroundColor)
         consoleFont = try values.decodeIfPresent(String.self, forKey: .consoleFont)
         let fontSize = try values.decodeIfPresent(Int.self, forKey: .consoleFontSize)
         consoleFontSize = NSNumber(value: fontSize ?? 12)
@@ -435,8 +433,8 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         try container.encode(iconCustom, forKey: .iconCustom)
         try container.encodeIfPresent(notes, forKey: .notes)
         try container.encodeIfPresent(consoleTheme, forKey: .consoleTheme)
-        try container.encodeIfPresent(consoleTextColor?.hexString, forKey: .consoleTextColor)
-        try container.encodeIfPresent(consoleBackgroundColor?.hexString, forKey: .consoleBackgroundColor)
+        try container.encodeIfPresent(consoleTextColor, forKey: .consoleTextColor)
+        try container.encodeIfPresent(consoleBackgroundColor, forKey: .consoleBackgroundColor)
         try container.encodeIfPresent(consoleFont, forKey: .consoleFont)
         try container.encodeIfPresent(consoleFontSize?.intValue, forKey: .consoleFontSize)
         try container.encode(consoleCursorBlink, forKey: .consoleCursorBlink)

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -402,11 +402,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         consoleBackgroundColor = NSColor(hexString: consoleBackgroundColorString ?? "")
         consoleFont = try values.decodeIfPresent(String.self, forKey: .consoleFont)
         let fontSize = try values.decodeIfPresent(Int.self, forKey: .consoleFontSize)
-        if let fontSize = fontSize {
-            consoleFontSize = NSNumber(value: fontSize)
-        } else {
-            consoleFontSize = nil
-        }
+        consoleFontSize = NSNumber(value: fontSize ?? 12)
         consoleCursorBlink = try values.decode(Bool.self, forKey: .consoleCursorBlink)
         consoleResizeCommand = try values.decodeIfPresent(String.self, forKey: .consoleResizeCommand)
     }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -45,6 +45,10 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     
     @Published var consoleTheme: String?
     
+    @Published var consoleTextColor: NSColor?
+    
+    @Published var consoleBackgroundColor: NSColor?
+    
     @Published var consoleFont: String?
     
     @Published var consoleFontSize: NSNumber?

--- a/Configuration/UTMConfigurable.h
+++ b/Configuration/UTMConfigurable.h
@@ -15,7 +15,13 @@
 //
 
 #import <Foundation/Foundation.h>
+#if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+#define PlatformColor NSColor
+#else
+#import <UIKit/UIKit.h>
+#define PlatformColor UIColor
+#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,8 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, nullable, copy) NSString *consoleTheme;
 // TODO: Maybe use CGColor (But hard to handle)
-@property (nonatomic, nullable, copy) NSColor *consoleTextColor;
-@property (nonatomic, nullable, copy) NSColor *consoleBackgroundColor;
+@property (nonatomic, nullable, copy) PlatformColor *consoleTextColor;
+@property (nonatomic, nullable, copy) PlatformColor *consoleBackgroundColor;
 @property (nonatomic, nullable, copy) NSString *consoleFont;
 @property (nonatomic, nullable, copy) NSNumber *consoleFontSize;
 @property (nonatomic, assign) BOOL consoleCursorBlink;

--- a/Configuration/UTMConfigurable.h
+++ b/Configuration/UTMConfigurable.h
@@ -15,13 +15,6 @@
 //
 
 #import <Foundation/Foundation.h>
-#if TARGET_OS_OSX
-#import <AppKit/AppKit.h>
-#define PlatformColor NSColor
-#else
-#import <UIKit/UIKit.h>
-#define PlatformColor UIColor
-#endif
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -36,9 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSString *notes;
 
 @property (nonatomic, nullable, copy) NSString *consoleTheme;
-// TODO: Maybe use CGColor (But hard to handle)
-@property (nonatomic, nullable, copy) PlatformColor *consoleTextColor;
-@property (nonatomic, nullable, copy) PlatformColor *consoleBackgroundColor;
+@property (nonatomic, nullable, copy) NSString *consoleTextColor;
+@property (nonatomic, nullable, copy) NSString *consoleBackgroundColor;
 @property (nonatomic, nullable, copy) NSString *consoleFont;
 @property (nonatomic, nullable, copy) NSNumber *consoleFontSize;
 @property (nonatomic, assign) BOOL consoleCursorBlink;

--- a/Configuration/UTMConfigurable.h
+++ b/Configuration/UTMConfigurable.h
@@ -15,6 +15,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -29,6 +30,9 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSString *notes;
 
 @property (nonatomic, nullable, copy) NSString *consoleTheme;
+// TODO: Maybe use CGColor (But hard to handle)
+@property (nonatomic, nullable, copy) NSColor *consoleTextColor;
+@property (nonatomic, nullable, copy) NSColor *consoleBackgroundColor;
 @property (nonatomic, nullable, copy) NSString *consoleFont;
 @property (nonatomic, nullable, copy) NSNumber *consoleFontSize;
 @property (nonatomic, assign) BOOL consoleCursorBlink;

--- a/Configuration/UTMQemuConfiguration+Constants.h
+++ b/Configuration/UTMQemuConfiguration+Constants.h
@@ -34,8 +34,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (NSArray<NSString *>*)supportedDriveInterfacesPretty;
 + (NSArray<NSString *>*)supportedScalersPretty;
 + (NSArray<NSString *>*)supportedScalers;
-+ (NSArray<NSString *>*)supportedConsoleThemes API_AVAILABLE(ios(11));
-+ (NSArray<NSString *>*)supportedConsoleFonts API_AVAILABLE(ios(11));
++ (NSArray<NSString *>*)supportedConsoleThemes;
++ (NSArray<NSString *>*)supportedConsoleFonts;
++ (NSArray<NSString *>*)supportedConsoleFontsPretty;
 + (NSArray<NSString *>*)supportedNetworkModes;
 + (NSArray<NSString *>*)supportedNetworkModesPretty;
 

--- a/Configuration/UTMQemuConfiguration+Constants.m
+++ b/Configuration/UTMQemuConfiguration+Constants.m
@@ -206,7 +206,7 @@
         for (NSString *family in UIFont.familyNames) {
             UIFont *font = [UIFont fontWithName:family size:1];
             if (font.fontDescriptor.symbolicTraits & UIFontDescriptorTraitMonoSpace) {
-                [families addObject:family];
+                [families addObjectsFromArray:[UIFont fontNamesForFamilyName:family]];
             }
         }
     }

--- a/Configuration/UTMQemuConfiguration+Constants.m
+++ b/Configuration/UTMQemuConfiguration+Constants.m
@@ -17,6 +17,8 @@
 #import <TargetConditionals.h>
 #if !TARGET_OS_OSX
 #import <UIKit/UIKit.h>
+#else
+#import <AppKit/AppKit.h>
 #endif
 #import "UTMQemuConfiguration+Constants.h"
 
@@ -214,7 +216,16 @@
 }
 #else
 + (NSArray<NSString *>*)supportedConsoleFonts {
-    return @[];
+    static NSMutableArray<NSString *> *fonts;
+    if (!fonts) {
+        fonts = [NSMutableArray new];
+        for (NSString *fontName in [NSFontManager.sharedFontManager availableFontNamesWithTraits:NSFixedPitchFontMask]) {
+            NSFont *font = [NSFont fontWithName:fontName size:1];
+            NSString *fontDisplayName = font.displayName;
+            [fonts addObject:fontDisplayName];
+        }
+    }
+    return fonts;
 }
 #endif
 

--- a/Configuration/UTMQemuConfiguration+Constants.m
+++ b/Configuration/UTMQemuConfiguration+Constants.m
@@ -214,15 +214,50 @@
     }
     return families;
 }
+
++ (NSArray<NSString *>*)supportedConsoleFontsPretty {
+    static NSMutableArray<NSString *> *fonts;
+    if (!fonts) {
+        fonts = [NSMutableArray new];
+        for (NSString *fontName in [UTMQemuConfiguration supportedConsoleFonts]) {
+            UIFont *font = [UIFont fontWithName:fontName size:1];
+            UIFontDescriptorSymbolicTraits traits = font.fontDescriptor.symbolicTraits;
+            NSString *description;
+            if ((traits & (UIFontDescriptorTraitItalic | UIFontDescriptorTraitBold)) ==
+                (UIFontDescriptorTraitItalic | UIFontDescriptorTraitBold)) {
+                description = NSLocalizedString(@"Italic, Bold", @"UTMQemuConfiguration+Constants");
+            } else if ((traits & UIFontDescriptorTraitItalic) != 0) {
+                description = NSLocalizedString(@"Italic", @"UTMQemuConfiguration+Constants");
+            } else if ((traits & UIFontDescriptorTraitBold) != 0) {
+                description = NSLocalizedString(@"Bold", @"UTMQemuConfiguration+Constants");
+            } else {
+                description = NSLocalizedString(@"Regular", @"UTMQemuConfiguration+Constants");
+            }
+            NSString *label = [NSString stringWithFormat:@"%@ (%@)", font.familyName, description];
+            [fonts addObject:label];
+        }
+    }
+    return fonts;
+}
 #else
 + (NSArray<NSString *>*)supportedConsoleFonts {
     static NSMutableArray<NSString *> *fonts;
     if (!fonts) {
         fonts = [NSMutableArray new];
         for (NSString *fontName in [NSFontManager.sharedFontManager availableFontNamesWithTraits:NSFixedPitchFontMask]) {
+            [fonts addObject:fontName];
+        }
+    }
+    return fonts;
+}
+
++ (NSArray<NSString *>*)supportedConsoleFontsPretty {
+    static NSMutableArray<NSString *> *fonts;
+    if (!fonts) {
+        fonts = [NSMutableArray new];
+        for (NSString *fontName in [UTMQemuConfiguration supportedConsoleFonts]) {
             NSFont *font = [NSFont fontWithName:fontName size:1];
-            NSString *fontDisplayName = font.displayName;
-            [fonts addObject:fontDisplayName];
+            [fonts addObject:font.displayName];
         }
     }
     return fonts;

--- a/Configuration/UTMQemuConfiguration+Display.h
+++ b/Configuration/UTMQemuConfiguration+Display.h
@@ -29,6 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable, copy) NSString *displayDownscaler;
 @property (nonatomic, readonly) MTLSamplerMinMagFilter displayDownscalerValue;
 @property (nonatomic, nullable, copy) NSString *consoleTheme;
+@property (nonatomic, nullable, copy) NSString *consoleTextColor;
+@property (nonatomic, nullable, copy) NSString *consoleBackgroundColor;
 @property (nonatomic, nullable, copy) NSString *consoleFont;
 @property (nonatomic, nullable, copy) NSNumber *consoleFontSize;
 @property (nonatomic, assign) BOOL consoleCursorBlink;

--- a/Configuration/UTMQemuConfiguration+Display.m
+++ b/Configuration/UTMQemuConfiguration+Display.m
@@ -57,10 +57,10 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
         self.consoleTheme = @"Default";
     }
     if (self.consoleTextColor == nil) {
-        self.consoleTextColor = [NSColor whiteColor];
+        self.consoleTextColor = [PlatformColor whiteColor];
     }
     if (self.consoleBackgroundColor == nil) {
-        self.consoleBackgroundColor = [NSColor blackColor];
+        self.consoleBackgroundColor = [PlatformColor blackColor];
     }
     if (self.consoleFontSize.integerValue == 0) {
         self.consoleFontSize = @12;
@@ -148,26 +148,26 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
     return self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleThemeKey];
 }
 
-- (void)setConsoleTextColor:(NSColor *)consoleTextColor {
+- (void)setConsoleTextColor:(PlatformColor *)consoleTextColor {
     [self propertyWillChange];
     NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleTextColor requiringSecureCoding:YES error:nil];
     self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey] = colorData;
 }
 
-- (NSColor *)consoleTextColor {
+- (PlatformColor *)consoleTextColor {
     NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey];
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSColor class] fromData:colorData error:nil];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:[PlatformColor class] fromData:colorData error:nil];
 }
 
-- (void)setConsoleBackgroundColor:(NSColor *)consoleBackgroundColor {
+- (void)setConsoleBackgroundColor:(PlatformColor *)consoleBackgroundColor {
     [self propertyWillChange];
     NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleBackgroundColor requiringSecureCoding:YES error:nil];
     self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey] = colorData;
 }
 
-- (NSColor *)consoleBackgroundColor {
+- (PlatformColor *)consoleBackgroundColor {
     NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey];
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSColor class] fromData:colorData error:nil];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:[PlatformColor class] fromData:colorData error:nil];
 }
 
 - (void)setConsoleFont:(NSString *)consoleFont {

--- a/Configuration/UTMQemuConfiguration+Display.m
+++ b/Configuration/UTMQemuConfiguration+Display.m
@@ -14,6 +14,7 @@
 // limitations under the License.
 //
 
+#import <TargetConditionals.h>
 #import "UTMQemuConfiguration+Display.h"
 #import "UTM-Swift.h"
 
@@ -51,7 +52,17 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
         self.displayDownscaler = @"linear";
     }
     if (self.consoleFont.length == 0) {
-        self.consoleFont = @"Menlo";
+        self.consoleFont = @"Menlo-Regular";
+    } else if (![[UTMQemuConfiguration supportedConsoleFonts] containsObject:self.consoleFont]) {
+        // migrate to new fully-formed name
+#if TARGET_OS_OSX
+        NSFont *font = [NSFont fontWithName:self.consoleFont size:1];
+#else
+        UIFont *font = [UIFont fontWithName:self.consoleFont size:1];
+#endif
+        if (font) {
+            self.consoleFont = font.fontName;
+        }
     }
     if (self.consoleTheme.length == 0) {
         self.consoleTheme = @"Default";

--- a/Configuration/UTMQemuConfiguration+Display.m
+++ b/Configuration/UTMQemuConfiguration+Display.m
@@ -25,6 +25,8 @@ const NSString *const kUTMConfigDisplayRetinaKey = @"DisplayRetina";
 const NSString *const kUTMConfigDisplayUpscalerKey = @"DisplayUpscaler";
 const NSString *const kUTMConfigDisplayDownscalerKey = @"DisplayDownscaler";
 const NSString *const kUTMConfigConsoleThemeKey = @"ConsoleTheme";
+const NSString *const kUTMConfigConsoleTextColorKey = @"ConsoleTextColor";
+const NSString *const kUTMConfigConsoleBackgroundColorKey = @"ConsoleBackgroundColor";
 const NSString *const kUTMConfigConsoleFontKey = @"ConsoleFont";
 const NSString *const kUTMConfigConsoleFontSizeKey = @"ConsoleFontSize";
 const NSString *const kUTMConfigConsoleBlinkKey = @"ConsoleBlink";
@@ -53,6 +55,12 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
     }
     if (self.consoleTheme.length == 0) {
         self.consoleTheme = @"Default";
+    }
+    if (self.consoleTextColor == nil) {
+        self.consoleTextColor = [NSColor whiteColor];
+    }
+    if (self.consoleBackgroundColor == nil) {
+        self.consoleBackgroundColor = [NSColor blackColor];
     }
     if (self.consoleFontSize.integerValue == 0) {
         self.consoleFontSize = @12;
@@ -138,6 +146,28 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
 
 - (NSString *)consoleTheme {
     return self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleThemeKey];
+}
+
+- (void)setConsoleTextColor:(NSColor *)consoleTextColor {
+    [self propertyWillChange];
+    NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleTextColor requiringSecureCoding:YES error:nil];
+    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey] = colorData;
+}
+
+- (NSColor *)consoleTextColor {
+    NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSColor class] fromData:colorData error:nil];
+}
+
+- (void)setConsoleBackgroundColor:(NSColor *)consoleBackgroundColor {
+    [self propertyWillChange];
+    NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleBackgroundColor requiringSecureCoding:YES error:nil];
+    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey] = colorData;
+}
+
+- (NSColor *)consoleBackgroundColor {
+    NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey];
+    return [NSKeyedUnarchiver unarchivedObjectOfClass:[NSColor class] fromData:colorData error:nil];
 }
 
 - (void)setConsoleFont:(NSString *)consoleFont {

--- a/Configuration/UTMQemuConfiguration+Display.m
+++ b/Configuration/UTMQemuConfiguration+Display.m
@@ -57,10 +57,10 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
         self.consoleTheme = @"Default";
     }
     if (self.consoleTextColor == nil) {
-        self.consoleTextColor = [PlatformColor whiteColor];
+        self.consoleTextColor = @"#ffffff";
     }
     if (self.consoleBackgroundColor == nil) {
-        self.consoleBackgroundColor = [PlatformColor blackColor];
+        self.consoleBackgroundColor = @"#000000";
     }
     if (self.consoleFontSize.integerValue == 0) {
         self.consoleFontSize = @12;
@@ -148,26 +148,22 @@ const NSString *const kUTMConfigDisplayCardKey = @"DisplayCard";
     return self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleThemeKey];
 }
 
-- (void)setConsoleTextColor:(PlatformColor *)consoleTextColor {
+- (void)setConsoleTextColor:(NSString *)consoleTextColor {
     [self propertyWillChange];
-    NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleTextColor requiringSecureCoding:YES error:nil];
-    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey] = colorData;
+    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey] = consoleTextColor;
 }
 
-- (PlatformColor *)consoleTextColor {
-    NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey];
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:[PlatformColor class] fromData:colorData error:nil];
+- (NSString *)consoleTextColor {
+    return self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleTextColorKey];
 }
 
-- (void)setConsoleBackgroundColor:(PlatformColor *)consoleBackgroundColor {
+- (void)setConsoleBackgroundColor:(NSString *)consoleBackgroundColor {
     [self propertyWillChange];
-    NSData *colorData = [NSKeyedArchiver archivedDataWithRootObject:consoleBackgroundColor requiringSecureCoding:YES error:nil];
-    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey] = colorData;
+    self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey] = consoleBackgroundColor;
 }
 
-- (PlatformColor *)consoleBackgroundColor {
-    NSData *colorData = self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey];
-    return [NSKeyedUnarchiver unarchivedObjectOfClass:[PlatformColor class] fromData:colorData error:nil];
+- (NSString *)consoleBackgroundColor {
+    return self.rootDict[kUTMConfigDisplayKey][kUTMConfigConsoleBackgroundColorKey];
 }
 
 - (void)setConsoleFont:(NSString *)consoleFont {

--- a/Platform/Shared/HTerm/terminal.js
+++ b/Platform/Shared/HTerm/terminal.js
@@ -210,6 +210,12 @@ function setupHterm() {
     window.term = term;
 };
 
+function changeColor(foregroundColor, backgroundColor) {
+    const term = new hterm.Terminal();
+    term.getPrefs().set('foreground-color', foregroundColor)
+    term.getPrefs().set('background-color', backgroundColor)
+}
+
 function changeFont(fontFamily, fontSize) {
     const term = new hterm.Terminal();
     term.getPrefs().set('font-family', fontFamily);

--- a/Platform/Shared/VMConfigDisplayConsoleView.swift
+++ b/Platform/Shared/VMConfigDisplayConsoleView.swift
@@ -20,18 +20,24 @@ import SwiftUI
 struct VMConfigDisplayConsoleView<Config: ObservableObject & UTMConfigurable>: View {
     @ObservedObject var config: Config
     
+    #if os(macOS)
+    typealias PlatformColor = NSColor
+    #else
+    typealias PlatformColor = UIColor
+    #endif
+    
     private var textColor: Binding<Color> {
         Binding<Color> {
             Color(config.consoleTextColor ?? .white)
         } set: { newValue in
-            config.consoleTextColor = NSColor(newValue)
+            config.consoleTextColor = PlatformColor(newValue)
         }
     }
     private var backgroundColor: Binding<Color> {
         Binding<Color> {
             Color(config.consoleBackgroundColor ?? .black)
         } set: { newValue in
-            config.consoleBackgroundColor = NSColor(newValue)
+            config.consoleBackgroundColor = PlatformColor(newValue)
         }
     }
         

--- a/Platform/Shared/VMConfigDisplayConsoleView.swift
+++ b/Platform/Shared/VMConfigDisplayConsoleView.swift
@@ -20,6 +20,21 @@ import SwiftUI
 struct VMConfigDisplayConsoleView<Config: ObservableObject & UTMConfigurable>: View {
     @ObservedObject var config: Config
     
+    private var textColor: Binding<Color> {
+        Binding<Color> {
+            Color(config.consoleTextColor ?? .white)
+        } set: { newValue in
+            config.consoleTextColor = NSColor(newValue)
+        }
+    }
+    private var backgroundColor: Binding<Color> {
+        Binding<Color> {
+            Color(config.consoleBackgroundColor ?? .black)
+        } set: { newValue in
+            config.consoleBackgroundColor = NSColor(newValue)
+        }
+    }
+        
     var body: some View {
         let fontSizeObserver = Binding<Int> {
             Int(truncating: config.consoleFontSize ?? 1)
@@ -28,6 +43,8 @@ struct VMConfigDisplayConsoleView<Config: ObservableObject & UTMConfigurable>: V
         }
         Section(header: Text("Style"), footer: EmptyView().padding(.bottom)) {
             VMConfigStringPicker(selection: $config.consoleTheme, label: Text("Theme"), rawValues: UTMQemuConfiguration.supportedConsoleThemes(), displayValues: UTMQemuConfiguration.supportedConsoleThemes())
+            ColorPicker("Text Color", selection: textColor)
+            ColorPicker("Background Color", selection: backgroundColor)
             VMConfigStringPicker(selection: $config.consoleFont, label: Text("Font"), rawValues: UTMQemuConfiguration.supportedConsoleFonts(), displayValues: UTMQemuConfiguration.supportedConsoleFonts())
             HStack {
                 Stepper(value: fontSizeObserver, in: 1...72) {

--- a/Platform/Shared/VMConfigDisplayConsoleView.swift
+++ b/Platform/Shared/VMConfigDisplayConsoleView.swift
@@ -28,16 +28,26 @@ struct VMConfigDisplayConsoleView<Config: ObservableObject & UTMConfigurable>: V
     
     private var textColor: Binding<Color> {
         Binding<Color> {
-            Color(config.consoleTextColor ?? .white)
+            if let consoleTextColor = config.consoleTextColor,
+               let color = Color(hexString: consoleTextColor) {
+                return color
+            } else {
+                return Color.white
+            }
         } set: { newValue in
-            config.consoleTextColor = PlatformColor(newValue)
+            config.consoleTextColor = PlatformColor(newValue).hexString
         }
     }
     private var backgroundColor: Binding<Color> {
         Binding<Color> {
-            Color(config.consoleBackgroundColor ?? .black)
+            if let consoleBackgroundColor = config.consoleBackgroundColor,
+               let color = Color(hexString: consoleBackgroundColor) {
+                return color
+            } else {
+                return Color.black
+            }
         } set: { newValue in
-            config.consoleBackgroundColor = PlatformColor(newValue)
+            config.consoleBackgroundColor = PlatformColor(newValue).hexString
         }
     }
         

--- a/Platform/Shared/VMConfigDisplayConsoleView.swift
+++ b/Platform/Shared/VMConfigDisplayConsoleView.swift
@@ -61,7 +61,7 @@ struct VMConfigDisplayConsoleView<Config: ObservableObject & UTMConfigurable>: V
             VMConfigStringPicker(selection: $config.consoleTheme, label: Text("Theme"), rawValues: UTMQemuConfiguration.supportedConsoleThemes(), displayValues: UTMQemuConfiguration.supportedConsoleThemes())
             ColorPicker("Text Color", selection: textColor)
             ColorPicker("Background Color", selection: backgroundColor)
-            VMConfigStringPicker(selection: $config.consoleFont, label: Text("Font"), rawValues: UTMQemuConfiguration.supportedConsoleFonts(), displayValues: UTMQemuConfiguration.supportedConsoleFonts())
+            VMConfigStringPicker(selection: $config.consoleFont, label: Text("Font"), rawValues: UTMQemuConfiguration.supportedConsoleFonts(), displayValues: UTMQemuConfiguration.supportedConsoleFontsPretty())
             HStack {
                 Stepper(value: fontSizeObserver, in: 1...72) {
                         Text("Font Size")

--- a/Platform/UTMExtensions.swift
+++ b/Platform/UTMExtensions.swift
@@ -169,6 +169,18 @@ extension NSImage {
     }
 }
 
+extension NSColor {
+    var hexString: String? {
+        guard let rgbColor = self.usingColorSpace(.sRGB) else {
+            return nil
+        }
+        let red = Int(round(rgbColor.redComponent * 0xFF))
+        let green = Int(round(rgbColor.greenComponent * 0xFF))
+        let blue = Int(round(rgbColor.blueComponent * 0xFF))
+        return String(format: "#%02X%02X%02X", red, green, blue)
+    }
+}
+
 @propertyWrapper
 struct Setting<T> {
     private(set) var keyName: String

--- a/Platform/UTMExtensions.swift
+++ b/Platform/UTMExtensions.swift
@@ -136,6 +136,19 @@ extension UIImage {
         }
     }
 }
+
+extension UIColor {
+    @objc var hexString: String? {
+        guard let rgbColor = self.cgColor.converted(to: .init(name: CGColorSpace.sRGB)!, intent: .defaultIntent, options: nil),
+              let components = rgbColor.components else {
+            return nil
+        }
+        let red = Int(round(components[0] * 0xFF))
+        let green = Int(round(components[1] * 0xFF))
+        let blue = Int(round(components[2] * 0xFF))
+        return String(format: "#%02X%02X%02X", red, green, blue)
+    }
+}
 #endif
 
 #if os(macOS)

--- a/Platform/UTMExtensions.swift
+++ b/Platform/UTMExtensions.swift
@@ -192,6 +192,27 @@ extension NSColor {
         let blue = Int(round(rgbColor.blueComponent * 0xFF))
         return String(format: "#%02X%02X%02X", red, green, blue)
     }
+    
+    convenience init?(hexString hex: String) {
+        if hex.count != 7 { // The '#' included
+            return nil
+        }
+            
+        let hexColor = String(hex.dropFirst())
+        
+        let scanner = Scanner(string: hexColor)
+        var hexNumber: UInt64 = 0
+        
+        if !scanner.scanHexInt64(&hexNumber) {
+            return nil
+        }
+        
+        let r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
+        let g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
+        let b = CGFloat(hexNumber & 0x0000ff) / 255
+        
+        self.init(red: r, green: g, blue: b, alpha: 1)
+    }
 }
 
 @propertyWrapper

--- a/Platform/UTMExtensions.swift
+++ b/Platform/UTMExtensions.swift
@@ -108,6 +108,30 @@ extension Sequence where Element: Hashable {
     }
 }
 
+@available(iOS 14, macOS 11, *)
+extension Color {
+    init?(hexString hex: String) {
+        if hex.count != 7 { // The '#' included
+            return nil
+        }
+            
+        let hexColor = String(hex.dropFirst())
+        
+        let scanner = Scanner(string: hexColor)
+        var hexNumber: UInt64 = 0
+        
+        if !scanner.scanHexInt64(&hexNumber) {
+            return nil
+        }
+        
+        let r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
+        let g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
+        let b = CGFloat(hexNumber & 0x0000ff) / 255
+        
+        self.init(.sRGB, red: r, green: g, blue: b, opacity: 1.0)
+    }
+}
+
 #if !os(macOS)
 @objc extension UIView {
     /// Adds constraints to this `UIView` instances `superview` object to make sure this always has the same size as the superview.
@@ -191,27 +215,6 @@ extension NSColor {
         let green = Int(round(rgbColor.greenComponent * 0xFF))
         let blue = Int(round(rgbColor.blueComponent * 0xFF))
         return String(format: "#%02X%02X%02X", red, green, blue)
-    }
-    
-    convenience init?(hexString hex: String) {
-        if hex.count != 7 { // The '#' included
-            return nil
-        }
-            
-        let hexColor = String(hex.dropFirst())
-        
-        let scanner = Scanner(string: hexColor)
-        var hexNumber: UInt64 = 0
-        
-        if !scanner.scanHexInt64(&hexNumber) {
-            return nil
-        }
-        
-        let r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
-        let g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
-        let b = CGFloat(hexNumber & 0x0000ff) / 255
-        
-        self.init(red: r, green: g, blue: b, alpha: 1)
     }
 }
 

--- a/Platform/iOS/Display/VMDisplayTerminalViewController.m
+++ b/Platform/iOS/Display/VMDisplayTerminalViewController.m
@@ -93,7 +93,7 @@ NSString* const kVMSendTerminalSizeHandler = @"UTMSendTerminalSize";
 }
 
 - (void)updateSettings {
-    [_webView evaluateJavaScript:[NSString stringWithFormat:@"changeColor('%@', '%@');", self.vmQemuConfig.consoleTextColor.hexString, self.vmQemuConfig.consoleBackgroundColor.hexString] completionHandler:^(id _Nullable _, NSError * _Nullable error) {
+    [_webView evaluateJavaScript:[NSString stringWithFormat:@"changeColor('%@', '%@');", self.vmQemuConfig.consoleTextColor, self.vmQemuConfig.consoleBackgroundColor] completionHandler:^(id _Nullable _, NSError * _Nullable error) {
         UTMLog(@"changeColor error: %@", error);
     }];
     [_webView evaluateJavaScript:[NSString stringWithFormat:@"changeFont('%@', %ld);", self.vmQemuConfig.consoleFont, self.vmQemuConfig.consoleFontSize.integerValue] completionHandler:^(id _Nullable _, NSError * _Nullable error) {

--- a/Platform/iOS/Display/VMDisplayTerminalViewController.m
+++ b/Platform/iOS/Display/VMDisplayTerminalViewController.m
@@ -93,6 +93,9 @@ NSString* const kVMSendTerminalSizeHandler = @"UTMSendTerminalSize";
 }
 
 - (void)updateSettings {
+    [_webView evaluateJavaScript:[NSString stringWithFormat:@"changeColor('%@', '%@');", self.vmQemuConfig.consoleTextColor.hexString, self.vmQemuConfig.consoleBackgroundColor.hexString] completionHandler:^(id _Nullable _, NSError * _Nullable error) {
+        UTMLog(@"changeColor error: %@", error);
+    }];
     [_webView evaluateJavaScript:[NSString stringWithFormat:@"changeFont('%@', %ld);", self.vmQemuConfig.consoleFont, self.vmQemuConfig.consoleFontSize.integerValue] completionHandler:^(id _Nullable _, NSError * _Nullable error) {
         UTMLog(@"changeFont error: %@", error);
     }];

--- a/Platform/macOS/Display/VMDisplayAppleWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayAppleWindowController.swift
@@ -16,6 +16,7 @@
 
 import Combine
 import SwiftTerm
+import SwiftUI
 import Virtualization
 
 @available(macOS 11, *)
@@ -134,9 +135,11 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
                 }
             }
             if let consoleTextColor = appleConfig.consoleTextColor,
-               let consoleBackgroundColor = appleConfig.consoleBackgroundColor {
-                terminalView.nativeForegroundColor = consoleTextColor
-                terminalView.nativeBackgroundColor = consoleBackgroundColor
+               let textColor = Color(hexString: consoleTextColor),
+               let consoleBackgroundColor = appleConfig.consoleBackgroundColor,
+               let backgroundColor = Color(hexString: consoleBackgroundColor) {
+                terminalView.nativeForegroundColor = NSColor(textColor)
+                terminalView.nativeBackgroundColor = NSColor(backgroundColor)
             }
             terminalView.getTerminal().resize(cols: 80, rows: 24)
             let size = window.frameRect(forContentRect: terminalView.getOptimalFrameSize()).size

--- a/Platform/macOS/Display/VMDisplayAppleWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayAppleWindowController.swift
@@ -122,10 +122,16 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
         }
         if let terminalView = terminalView {
             if let fontSize = appleConfig.consoleFontSize?.intValue {
-                //FIXME: support changing font
-                let orig = terminalView.font
-                let new = NSFont(descriptor: orig.fontDescriptor, size: CGFloat(fontSize)) ?? orig
-                terminalView.font = new
+                if let fontName = appleConfig.consoleFont,
+                   fontName != "" {
+                    let orig = terminalView.font
+                    let new = NSFont(name: fontName, size: CGFloat(fontSize)) ?? orig
+                    terminalView.font = new
+                } else {
+                    let orig = terminalView.font
+                    let new = NSFont(descriptor: orig.fontDescriptor, size: CGFloat(fontSize)) ?? orig
+                    terminalView.font = new
+                }
             }
             if let consoleTextColor = appleConfig.consoleTextColor,
                let consoleBackgroundColor = appleConfig.consoleBackgroundColor {

--- a/Platform/macOS/Display/VMDisplayAppleWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayAppleWindowController.swift
@@ -127,6 +127,11 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
                 let new = NSFont(descriptor: orig.fontDescriptor, size: CGFloat(fontSize)) ?? orig
                 terminalView.font = new
             }
+            if let consoleTextColor = appleConfig.consoleTextColor,
+               let consoleBackgroundColor = appleConfig.consoleBackgroundColor {
+                terminalView.nativeForegroundColor = consoleTextColor
+                terminalView.nativeBackgroundColor = consoleBackgroundColor
+            }
             terminalView.getTerminal().resize(cols: 80, rows: 24)
             let size = window.frameRect(forContentRect: terminalView.getOptimalFrameSize()).size
             let frame = CGRect(origin: window.frame.origin, size: size)

--- a/Platform/macOS/Display/VMDisplayTerminalWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayTerminalWindowController.swift
@@ -85,11 +85,8 @@ extension VMDisplayTerminalWindowController: WKNavigationDelegate {
     
     func updateSettings() {
         if let consoleTextColor = vmQemuConfig?.consoleTextColor,
-           let consoleBackgroundColor = vmQemuConfig?.consoleBackgroundColor,
-           // TODO: Should use default colors, or keep it as if let?
-           let consoleTextColorString = consoleTextColor.hexString,
-           let consoleBackgroundColorString = consoleBackgroundColor.hexString {
-            webView.evaluateJavaScript("changeColor('\(consoleTextColorString)', '\(consoleBackgroundColorString)');") { (_, err) in
+           let consoleBackgroundColor = vmQemuConfig?.consoleBackgroundColor {
+            webView.evaluateJavaScript("changeColor('\(consoleTextColor)', '\(consoleBackgroundColor)');") { (_, err) in
                 if let error = err {
                     logger.error("changeColor error: \(error)")
                 }

--- a/Platform/macOS/Display/VMDisplayTerminalWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayTerminalWindowController.swift
@@ -84,6 +84,17 @@ extension VMDisplayTerminalWindowController: WKNavigationDelegate {
     }
     
     func updateSettings() {
+        if let consoleTextColor = vmQemuConfig?.consoleTextColor,
+           let consoleBackgroundColor = vmQemuConfig?.consoleBackgroundColor,
+           // TODO: Should use default colors, or keep it as if let?
+           let consoleTextColorString = consoleTextColor.hexString,
+           let consoleBackgroundColorString = consoleBackgroundColor.hexString {
+            webView.evaluateJavaScript("changeColor('\(consoleTextColorString)', '\(consoleBackgroundColorString)');") { (_, err) in
+                if let error = err {
+                    logger.error("changeColor error: \(error)")
+                }
+            }
+        }
         if let consoleFont = vmQemuConfig?.consoleFont {
             let consoleFontSize = vmQemuConfig?.consoleFontSize?.intValue ?? 12
             webView.evaluateJavaScript("changeFont('\(consoleFont)', \(consoleFontSize));") { (_, err) in

--- a/Platform/macOS/VMAppleSettingsView.swift
+++ b/Platform/macOS/VMAppleSettingsView.swift
@@ -38,7 +38,7 @@ struct VMAppleSettingsView: View {
                 Label("Display", systemImage: "rectangle.on.rectangle")
             }
         } else {
-            NavigationLink(destination: VMConfigDisplayConsoleView(config: config).scrollable()) {
+            NavigationLink(destination: Form { VMConfigDisplayConsoleView(config: config) }.scrollable()) {
                 Label("Display", systemImage: "rectangle.on.rectangle")
             }
         }

--- a/Platform/macOS/VMAppleSettingsView.swift
+++ b/Platform/macOS/VMAppleSettingsView.swift
@@ -37,6 +37,10 @@ struct VMAppleSettingsView: View {
             NavigationLink(destination: VMConfigAppleDisplayView(config: config).scrollable()) {
                 Label("Display", systemImage: "rectangle.on.rectangle")
             }
+        } else {
+            NavigationLink(destination: VMConfigDisplayConsoleView(config: config).scrollable()) {
+                Label("Display", systemImage: "rectangle.on.rectangle")
+            }
         }
         NavigationLink(destination: VMConfigAppleNetworkingView(config: config).scrollable()) {
             Label("Network", systemImage: "network")


### PR DESCRIPTION
See the individual commit messages for more details, but here's an overview:
- Add `consoleTextColor` and `consoleBackgroundColor` values to `UTMConfigurable`, and implement the setters/getters in `UTMConfiguration+Display` that use a keyed archiver to convert the `NSColor` into `NSData` that can be stored in `config.plist`. (This is needed because if I just save the hex values, there is a lot of drift in the color picker because of the loss in converting to/from a hex string, and it's done on each color value change)
- Add `ColorPicker`s to the display console configuration.
- Add and call a Javascript method that sets the color values in the hterm prefs.
- Save the color settings as hex strings when using the apple virtualization backend. This is fine because the conversion is only done on load/save and not on every color change.
- Set the `consoleFontSize` to 12 by default if it's `nil` when using the apple backend.
- Change the `supportedConsoleFonts` method to list all the fonts in each family, to allow maximal customization.
- Implement `supportedConsoleFonts` for macOS (instead of just returning an empty array) to allow picking custom fonts.
- Set the font used in SwiftTerm based on the configuration for the apple backend.

<hr>

@osy Do you think I should squash the [`fix build on iOS`](https://github.com/utmapp/UTM/commit/111576cd781e3fe454d5f7e41de48260197b58a0) commit with the [first commit](https://github.com/utmapp/UTM/commit/18d9be4d702c89cb961fbe529f69428dee2d0078)? They're similar enough and the first one isn't really a 'working' commit because it can't build on iOS.

Also please take a look at the two `TODO`s (I'll post a comment on them since I want to ask a question about them), and remind me to remove them before you merge this.

<hr>

BTW, during my testing, more in the early stages of implementing this, I found that the VMs got reordered in the list, but I'm not sure if it might have been because it's debug builds etc. In the later parts of developing this PR I haven't found this problem any more, so I don't think it's an issue.