### PR TITLE
Localization for zh-Hans updated.

### DIFF
--- a/Platform/Shared/VMWizardOSWindowsView.swift
+++ b/Platform/Shared/VMWizardOSWindowsView.swift
@@ -76,7 +76,7 @@ struct VMWizardOSWindowsView: View {
                 Text("File Imported")
             } footer: {
                 if #available(iOS 15, macOS 12, *) {
-                    Text(try! AttributedString(markdown: "Hint: For the best Windows experience, make sure to download and install the latest [SPICE tools and QEMU drivers](https://mac.getutm.app/support/)."))
+                    Text("Hint: For the best Windows experience, make sure to download and install the latest [SPICE tools and QEMU drivers](https://mac.getutm.app/support/).")
                 }
             }
         }

--- a/Platform/iOS/Settings.bundle/zh-Hans.lproj/Root.strings
+++ b/Platform/iOS/Settings.bundle/zh-Hans.lproj/Root.strings
@@ -152,3 +152,5 @@
 "Idle" = "闲置时";
 
 "Devices" = "设备";
+
+"Cursor - Drag Speed" = "拖动光标时的速度";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -880,7 +880,7 @@
 "I want to..." = "我想...";
 "Virtualize" = "虚拟化";
 "Faster, but can only run the native CPU architecture." = "速度更快，但只适用于运行与本机CPU架构相同的虚拟机";
-"Virtualization is not supported on your system." = "您的操作系统不支持虚拟化";
+"Virtualization is not supported on your system." = "您的操作系统不支持虚拟化，原因是苹果未向iOS系统提供虚拟化支持。";
 "Emulate" = "模拟";
 "Slower, but can run other CPU architectures." = "速度较慢，但虚拟机的CPU架构不受限制";
 "Download prebuilt from UTM Gallery..." = "从UTM库下载预配置文件（可能需要手动导入安装镜像）";
@@ -949,27 +949,36 @@
 
 //Display
 "Emulated Display Card" = "虚拟显卡";
-"AUTO RESOLUTION" = "自动调整";
+"Auto Resolution" = "自动调整";
 "Resize display to screen size automatically" = "自动调整屏幕尺寸";
 
 //Settings
-"DEVICES" = "设备";
+"Devices" = "设备";
 "Disable screen dimming when idle" = "在idle模式下禁用屏幕亮度调节";
 "Do not show prompt when USB device is plugged in" = "插入USB设备时不要显示提示";
 
-//Sharing
 "USB not supported in this build of UTM." = "此版本的UTM不支持USB共享";
 "USB SHARING" = "USB共享";
 "USB 3.0 (XHCI) Support" = "支持 USB 3.0 (XHCI)";
 "Maximum Shared USB Devices" = "最大共享USB设备数";
+"USB Support" = "USB支持选项";
+"If enabled, the default input devices will be emulated on the USB bus." = "如果启用，默认输入设备将在USB总线上模拟。";
+"USB sharing not supported in this build of UTM." = "此UTM版本不支持USB共享。（需要越狱）";
+"Share USB devices from host" = "连接本机的USB设备至虚拟机";
 
 //System
 "UEFI Boot" = "UEFI启动";
 "RNG Device" = "RNG设备";
+"Default is 1/4 of the RAM size (above). The JIT cache size is additive to the RAM size in the total memory usage!" = "默认为上面设置内存大小的1/4。虚拟机在此设备上总占用内存为JIT缓存与上方设置的内存之和。";
+"Force multicore may improve speed of emulation but also might result in unstable and incorrect emulation." = "强制多核可能提升模拟的速度，但也可能导致虚拟机运行不稳定和出现模拟错误。";
 
 //QEMU
 "Use Hypervisor" = "使用Hypervisor";
 "Do not generate any arguments based on current configuration" = "不要根据当前配置生成任何参数";
+"Use local time for base clock" = "使用本地时间作为基准时钟。";
+"These are advanced settings affecting QEMU which should be kept default unless you are running into issues." = "这些选项是高级设置，会直接影响QEMU的行为。如非遇到问题，您不应该更改此处的设置。";
+"Force PS/2 controller" = "强制使用PS/2控制器";
+"This is appended to the -machine argument." = "这里是添加至 -machine 后面的参数";
 
 //VM Creating Page
 "Open VM Settings" = "打开VM设置";
@@ -1033,6 +1042,7 @@
 "Hint: For the best Windows experience, make sure to download and install the latest [SPICE tools and QEMU drivers](https://mac.getutm.app/support/)." = "提示：为获得最佳 Windows 体验，请确保下载并安装最新的 [SPICE 工具 和 QEMU 驱动程序](https://mac.getutm.app/support/)";
 
 //WizardUI
+"Start" = "开始";
 "Specify the size of the drive where data will be stored into." = "指定存储驱动器的大小";
 "Hardware OpenGL Acceleration" = "OpenGL硬件加速";
 "Virtualization Engine" = "虚拟引擎";
@@ -1041,3 +1051,7 @@
 "Preconfigured" = "预配置";
 "Prebuilt" = "预构建";
 "Some older systems do not support UEFI boot, such as Windows 7 and below." = "一些古老的操作系统不支持UEFI启动,比如Windows7及之前的操作系统";
+"Open..." = "从本地导入";
+"Existing" = "导入UTM文档";
+"Advanced" = "高级";
+"Skip ISO boot" = "暂不导入光盘镜像";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -1055,3 +1055,13 @@
 "Existing" = "导入UTM文档";
 "Advanced" = "高级";
 "Skip ISO boot" = "暂不导入光盘镜像";
+
+//VM Status
+"Stopped" = "已停止";
+"Suspended" = "已挂起";
+"Starting" = "启动中";
+"Started" = "运行中";
+"Pausing" = "暂停中";
+"Paused" = "已暂停";
+"Resuming" = "恢复中";
+"Stopping" = "停止中";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -579,7 +579,7 @@
 "Requires SPICE guest agent tools to be installed." = "需要安装SPICE代理工具";
 
 /* No comment provided by engineer. */
-"Requires SPICE guest agent tools to be installed. Retina Mode is recommended only if the guest OS supports HiDPI." = "需要安装SPICE来宾代理工具。只有当来宾操作系统支持HiDPI时，才建议使用Retina模式";
+"Requires SPICE guest agent tools to be installed. Retina Mode is recommended only if the guest OS supports HiDPI." = "需要安装Spice guest tool。只有当来宾操作系统支持HiDPI时，才建议使用高分辨率模式";
 
 /* No comment provided by engineer. */
 "Requires SPICE WebDAV service to be installed." = "需要安装SPICE WebDAV服务";
@@ -591,7 +591,7 @@
 "Resolution" = "分辨率";
 
 /* No comment provided by engineer. */
-"Retina Mode" = "可视模式";
+"Retina Mode" = "高分辨率模式";
 
 /* VMDisplayViewController */
 "Running low on memory! UTM might soon be killed by iOS. You can prevent this by decreasing the amount of memory and/or JIT cache assigned to this VM" = "内存不足！ UTM可能很快会被iOS强制终止 您可以通过减少给该虚拟机分配的内存或JIT缓存来防止这种情况";
@@ -859,7 +859,7 @@
 "Stop" = "终止";
 
 /* No comment provided by engineer. */
-"Do you want to force stop this VM and lose all unsaved data?" = "您是否想强制停止此VM并放弃所有未保存的数据?";
+"Do you want to force stop this VM and lose all unsaved data?" = "您是否想强制停止此虚拟机并放弃所有未保存的数据?";
 
 /* No comment provided by engineer. */
 "Export Debug Log" = "导出日志";
@@ -944,7 +944,7 @@
 "Size" = "大小";
 
 //Drive
-"Note: Boot order is as listed." = "注意: 下面列表顺序即为启动顺序.";
+"Note: Boot order is as listed." = "注意: 列表顺序即为启动顺序.";
 "Removable" = "可移除";
 
 //Display
@@ -954,7 +954,7 @@
 
 //Settings
 "Devices" = "设备";
-"Disable screen dimming when idle" = "在idle模式下禁用屏幕亮度调节";
+"Disable screen dimming when idle" = "闲置时不自动锁屏";
 "Do not show prompt when USB device is plugged in" = "插入USB设备时不要显示提示";
 
 "USB not supported in this build of UTM." = "此版本的UTM不支持USB共享";


### PR DESCRIPTION
It seems markdown text in TextView without using AttributedString(markdown:) works fine in iOS 15 and macOS 12. The link is still clickable. I changed this for localization.
![IMG_CA262C44AF85-1](https://user-images.githubusercontent.com/9637998/157268452-a808ff42-e097-4e79-94af-62c5c085c38e.jpeg)
