### PR TITLE
WIP : Run as snapshot for macos "Apple Virtualisation"

### DIFF
--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -988,7 +988,8 @@ struct DiskImage: Codable, Hashable, Identifiable {
 
         // and make a copy of the provided imageURL
         if let snapshotURL = try snapshotURL(), let imageURL = imageURL {
-            // lets actually perform the path copy
+            // lets setup the snapshot file 
+            // (currently i have no idea if this optimizes when under APFS)
             try FileManager.default.copyItem( at: imageURL, to: snapshotURL )
         }
     }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -620,7 +620,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     func resetDriveSnapShot() throws {
         for i in diskImages.indices {
             if( diskImages[i].runAsSnapshot ) {
-                diskImages[i].resetDriveSnapShot()
+                try diskImages[i].resetDriveSnapShot()
             }
         }
     }
@@ -955,9 +955,9 @@ struct DiskImage: Codable, Hashable, Identifiable {
         }
     }
     
-    func snapshotURL() {
+    func snapshotURL() throws -> URL {
         let snapshotURL = imageURL
-        snapshotURL.appendingPathComponent(".snapshot")
+        snapshotURL = try snapshotURL.appendingPathComponent(".snapshot")
         return snapshotURL
     }
 

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -618,7 +618,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     }
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
-    func cleanupDriveSnapShot() {
+    func cleanupDriveSnapShot() throws {
         for i in diskImages.indices {
             diskImages[i].cleanupDriveSnapShot()
         }
@@ -973,7 +973,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     }
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
-    func cleanupDriveSnapShot() {
+    func cleanupDriveSnapShot() throws {
         if let snapshotURL = try snapshotURL() {
             // this is intentionally allowed to return false, as the file may not exists
             try FileManager.default.removeItem( at: snapshotURL )
@@ -989,7 +989,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         // and make a copy of the provided imageURL
         if let snapshotURL = try snapshotURL() {
             // lets actually perform the path copy
-            try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
+            try FileManager.default.copyItem( at: imageURL, to: snapshotURL )
         }
     }
 

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -966,16 +966,16 @@ struct DiskImage: Codable, Hashable, Identifiable {
     
     /// Returns the snapshot equivalent URL for the current image
     /// Does not actually prepare the snapshot (this is done via resetDriveSnapShot)
-    func snapshotURL() throws -> URL {
-        let snapshotURL = imageURL
-        snapshotURL = try snapshotURL.appendingPathComponent(".snapshot")
+    func snapshotURL() throws -> URL? {
+        var snapshotURL = imageURL
+        snapshotURL = try snapshotURL?.appendingPathComponent(".snapshot")
         return snapshotURL
     }
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapShot() {
         /// this is intentionally allowed to fail, as the file may not exists
-        FileManager.default.removeItem( self.snapshotURL() )
+        FileManager.default.removeItem( at: self.snapshotURL() )
     }
 
     /// Perform a snapshot clone of the current image URL to the snapshot URL
@@ -983,7 +983,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     func resetDriveSnapShot() throws {
         let snapshotURL = try self.snapshotURL();
         FileManager.default.removeItem( snapshotURL )
-        try FileManager.default.copyItem( imageURL, snapshotURL )
+        try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
     }
 
     /// Return the VZDiskImageStorageDeviceAttachment using the snapshotURL if runAsSnapshot is enabled

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -864,6 +864,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     var sizeMib: Int
     var isReadOnly: Bool
     var isExternal: Bool
+    var runAsSnapshot: Bool
     var imageURL: URL?
     private var uuid = UUID() // for identifiable
     
@@ -871,6 +872,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         case sizeMib
         case isReadOnly
         case isExternal
+        case runAsSnapshot
         case imagePath
         case imageBookmark
     }
@@ -891,12 +893,14 @@ struct DiskImage: Codable, Hashable, Identifiable {
         sizeMib = newSize
         isReadOnly = false
         isExternal = false
+        runAsSnapshot = false
     }
     
-    init(importImage url: URL, isReadOnly: Bool = false, isExternal: Bool = false) {
+    init(importImage url: URL, isReadOnly: Bool = false, isExternal: Bool = false, runAsSnapshot: Bool = false) {
         self.imageURL = url
         self.isReadOnly = isReadOnly
         self.isExternal = isExternal
+        self.runAsSnapshot = runAsSnapshot
         if let attributes = try? url.resourceValues(forKeys: [.fileSizeKey]), let fileSize = attributes.fileSize {
             sizeMib = fileSize / bytesInMib
         } else {
@@ -912,6 +916,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         sizeMib = try container.decode(Int.self, forKey: .sizeMib)
         isReadOnly = try container.decode(Bool.self, forKey: .isReadOnly)
         isExternal = try container.decode(Bool.self, forKey: .isExternal)
+        runAsSnapshot = try container.decode(Bool.self, forKey: .runAsSnapshot)
         if !isExternal, let imagePath = try container.decodeIfPresent(String.self, forKey: .imagePath) {
             imageURL = dataURL.appendingPathComponent(imagePath)
         } else if let bookmark = try container.decodeIfPresent(Data.self, forKey: .imageBookmark) {
@@ -925,6 +930,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         try container.encode(sizeMib, forKey: .sizeMib)
         try container.encode(isReadOnly, forKey: .isReadOnly)
         try container.encode(isExternal, forKey: .isExternal)
+        try container.encode(runAsSnapshot, forKey: .runAsSnapshot)
         if !isExternal {
             try container.encodeIfPresent(imageURL?.lastPathComponent, forKey: .imagePath)
         } else {
@@ -942,6 +948,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     }
     
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
+        // @TODO : Support runAsSnapshot logic
         if let imageURL = imageURL {
             return try VZDiskImageStorageDeviceAttachment(url: imageURL, readOnly: isReadOnly)
         } else {

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -976,9 +976,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     func cleanupDriveSnapShot() {
         if let snapshotURL = snapshotURL() {
             // this is intentionally allowed to return false, as the file may not exists
-            if try? FileManager.default.removeItem( at: snapshotURL ) {
-                // does nothing
-            }
+            try FileManager.default.removeItem( at: snapshotURL )
         }
     }
 
@@ -989,7 +987,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         cleanupDriveSnapShot()
 
         // and make a copy of the provided imageURL
-        if let snapshotURL = snapshotURL() {
+        if try let snapshotURL = snapshotURL() {
             // lets actually perform the path copy
             try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
         }
@@ -998,7 +996,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     /// Return the VZDiskImageStorageDeviceAttachment using the snapshotURL if runAsSnapshot is enabled
     /// else returns using the imageURL if its configured.
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
-        if runAsSnapshot, let snapshotURL = snapshotURL() {
+        if runAsSnapshot, try let snapshotURL = snapshotURL() {
             return try VZDiskImageStorageDeviceAttachment(url: snapshotURL, readOnly: isReadOnly)
         } else {
             return nil

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -968,22 +968,28 @@ struct DiskImage: Codable, Hashable, Identifiable {
     /// Does not actually prepare the snapshot (this is done via resetDriveSnapShot)
     func snapshotURL() throws -> URL? {
         var snapshotURL = imageURL
-        snapshotURL = try snapshotURL?.appendingPathComponent(".snapshot")
+        snapshotURL = snapshotURL?.appendingPathComponent(".snapshot")
         return snapshotURL
     }
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapShot() {
-        /// this is intentionally allowed to fail, as the file may not exists
-        FileManager.default.removeItem( at: self.snapshotURL() )
+        if let snapshotURL = try snapshotURL() {
+            // this is intentionally allowed to return false, as the file may not exists
+            FileManager.default.removeItem( at: snapshotURL )
+        }
     }
 
     /// Perform a snapshot clone of the current image URL to the snapshot URL
     /// this is required for the snapshotURL image to "work"
     func resetDriveSnapShot() throws {
-        let snapshotURL = try self.snapshotURL();
-        FileManager.default.removeItem( snapshotURL )
-        try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
+       if  let snapshotURL = try self.snapshotURL() {
+            // this is intentionally allowed to return false, as the file may not exists
+            FileManager.default.removeItem( at: snapshotURL )
+
+            // lets actually perform the path copy
+            try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
+       }
     }
 
     /// Return the VZDiskImageStorageDeviceAttachment using the snapshotURL if runAsSnapshot is enabled

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -974,7 +974,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapShot() {
-        if let snapshotURL = snapshotURL() {
+        if let snapshotURL = try snapshotURL() {
             // this is intentionally allowed to return false, as the file may not exists
             try FileManager.default.removeItem( at: snapshotURL )
         }
@@ -987,7 +987,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
         cleanupDriveSnapShot()
 
         // and make a copy of the provided imageURL
-        if try let snapshotURL = snapshotURL() {
+        if let snapshotURL = try snapshotURL() {
             // lets actually perform the path copy
             try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
         }
@@ -996,7 +996,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
     /// Return the VZDiskImageStorageDeviceAttachment using the snapshotURL if runAsSnapshot is enabled
     /// else returns using the imageURL if its configured.
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
-        if runAsSnapshot, try let snapshotURL = snapshotURL() {
+        if runAsSnapshot, let snapshotURL = try snapshotURL() {
             return try VZDiskImageStorageDeviceAttachment(url: snapshotURL, readOnly: isReadOnly)
         } else {
             return nil

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -620,7 +620,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapShot() throws {
         for i in diskImages.indices {
-            diskImages[i].cleanupDriveSnapShot()
+            try diskImages[i].cleanupDriveSnapShot()
         }
     }
 
@@ -984,10 +984,10 @@ struct DiskImage: Codable, Hashable, Identifiable {
     /// this is required for the snapshotURL image to "work"
     func resetDriveSnapShot() throws {
         // Perform any needed cleanup first
-        cleanupDriveSnapShot()
+        try cleanupDriveSnapShot()
 
         // and make a copy of the provided imageURL
-        if let snapshotURL = try snapshotURL() {
+        if let snapshotURL = try snapshotURL(), let imageURL = imageURL {
             // lets actually perform the path copy
             try FileManager.default.copyItem( at: imageURL, to: snapshotURL )
         }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -974,28 +974,31 @@ struct DiskImage: Codable, Hashable, Identifiable {
 
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapShot() {
-        if let snapshotURL = try snapshotURL() {
+        if let snapshotURL = snapshotURL() {
             // this is intentionally allowed to return false, as the file may not exists
-            FileManager.default.removeItem( at: snapshotURL )
+            if try? FileManager.default.removeItem( at: snapshotURL ) {
+                // does nothing
+            }
         }
     }
 
     /// Perform a snapshot clone of the current image URL to the snapshot URL
     /// this is required for the snapshotURL image to "work"
     func resetDriveSnapShot() throws {
-       if  let snapshotURL = try self.snapshotURL() {
-            // this is intentionally allowed to return false, as the file may not exists
-            FileManager.default.removeItem( at: snapshotURL )
+        // Perform any needed cleanup first
+        cleanupDriveSnapShot()
 
+        // and make a copy of the provided imageURL
+        if let snapshotURL = snapshotURL() {
             // lets actually perform the path copy
             try FileManager.default.copyItem( atPath: imageURL, toPath: snapshotURL )
-       }
+        }
     }
 
     /// Return the VZDiskImageStorageDeviceAttachment using the snapshotURL if runAsSnapshot is enabled
     /// else returns using the imageURL if its configured.
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
-        if runAsSnapshot, let snapshotURL = try self.snapshotURL() {
+        if runAsSnapshot, let snapshotURL = snapshotURL() {
             return try VZDiskImageStorageDeviceAttachment(url: snapshotURL, readOnly: isReadOnly)
         } else {
             return nil

--- a/Managers/UTMAppleVirtualMachine.swift
+++ b/Managers/UTMAppleVirtualMachine.swift
@@ -323,6 +323,8 @@ import Virtualization
                 }
                 fsConfig.share = self?.makeDirectoryShare(from: newShares)
             }
+
+            try appleConfig.resetDriveSnapShot()
         }
         apple = VZVirtualMachine(configuration: appleConfig.apple, queue: vmQueue)
         apple.delegate = self

--- a/Platform/macOS/VMConfigAppleDriveDetailsView.swift
+++ b/Platform/macOS/VMConfigAppleDriveDetailsView.swift
@@ -25,6 +25,7 @@ struct VMConfigAppleDriveDetailsView: View {
             TextField("Name", text: .constant(diskImage.imageURL?.lastPathComponent ?? NSLocalizedString("(New Drive)", comment: "VMConfigAppleDriveDetailsView")))
                 .disabled(true)
             Toggle("Read Only?", isOn: $diskImage.isReadOnly)
+            Toggle("Run using a snapshot? (similar to qemu --snapshot)", isOn: $diskImage.runAsSnapshot)
             Button(action: onDelete) {
                 Label("Delete Drive", systemImage: "externaldrive.badge.minus")
                     .foregroundColor(.red)


### PR DESCRIPTION
https://github.com/utmapp/UTM/issues/2688

The QEMU counterpart is

https://github.com/utmapp/UTM/pull/3067

The general idea is to do a APFS clone (Meaning it will only require the delta additional space, and make no changes on the original) on VM startup. ie. `cp -c` command. This allows us to mimic a `qemu <disk> --snapshot` like behaviour.

However, while I have coded in C, i'm pretty much a swift noob, and is learning on the fly here. And would want feedback regarding this pull request. The code done here, has not been tested either, as I could not get it built on my machine, due to the lack of an apple developer account (unless i missed something else)