### PR TITLE
WIP : Run as snapshot for apple vm

### DIFF
--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -1010,6 +1010,8 @@ struct DiskImage: Codable, Hashable, Identifiable {
             //
             // apperantly despite documentation saying it will return false.
             // it will return with an error if removal fails (does not exist,etc)
+            //
+            // try? surpresses and ignores the error
             try? FileManager.default.removeItem(at: snapshotURL)
         }
     }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -275,7 +275,8 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
     
     @Published var isSerialEnabled: Bool
     @Published var isConsoleDisplay: Bool
-    
+    @Published var isRunAsSnapshot: Bool
+
     @available(macOS 12, *)
     var isKeyboardEnabled: Bool {
         get {
@@ -335,6 +336,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         case isEntropyEnabled
         case isSerialEnabled
         case isConsoleDisplay
+        case isRunAsSnapshot
         case isKeyboardEnabled
         case isPointingEnabled
     }
@@ -357,6 +359,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         isAppleVirtualization = true
         isSerialEnabled = false
         isConsoleDisplay = false
+        isRunAsSnapshot = false
         memorySize = 4 * 1024 * 1024 * 1024
         cpuCount = 4
     }
@@ -398,6 +401,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         isEntropyEnabled = try values.decode(Bool.self, forKey: .isEntropyEnabled)
         isSerialEnabled = try values.decode(Bool.self, forKey: .isSerialEnabled)
         isConsoleDisplay = try values.decode(Bool.self, forKey: .isConsoleDisplay)
+        isRunAsSnapshot = try values.decodeIfPresent(Bool.self, forKey: .isRunAsSnapshot) ?? false
         name = try values.decode(String.self, forKey: .name)
         architecture = try values.decode(String.self, forKey: .architecture)
         icon = try values.decodeIfPresent(String.self, forKey: .icon)
@@ -435,6 +439,7 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         try container.encode(isEntropyEnabled, forKey: .isEntropyEnabled)
         try container.encode(isSerialEnabled, forKey: .isSerialEnabled)
         try container.encode(isConsoleDisplay, forKey: .isConsoleDisplay)
+        try container.encode(isRunAsSnapshot, forKey: .isRunAsSnapshot)
         try container.encode(name, forKey: .name)
         try container.encode(architecture, forKey: .architecture)
         try container.encodeIfPresent(icon, forKey: .icon)

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -621,6 +621,14 @@ final class UTMAppleConfiguration: UTMConfigurable, Codable, ObservableObject {
         }
         return urls
     }
+
+    /// Remove the snapshot URL image's that were previously genereated, 
+    /// this should be done as part of a VM cleanup.
+    func cleanupDriveSnapshot() throws {
+        for i in diskImages.indices {
+            try diskImages[i].cleanupDriveSnapshot()
+        }
+    }
 }
 
 struct Bootloader: Codable {
@@ -955,6 +963,20 @@ struct DiskImage: Codable, Hashable, Identifiable {
         }
     }
     
+    /// Returns the snapshot equivalent URL for the current image
+    /// Does not actually prepare the snapshot (this is done via setupDriveSnapshot)
+    func snapshotURL() throws -> URL? {
+        return imageURL?.appendingPathComponent(".snapshot")
+    }
+
+    /// Remove the snapshot URL image, this can be done as part of VM cleanup
+    func cleanupDriveSnapshot() throws {
+        if let snapshotURL = try snapshotURL() {
+            // The file may not exists, if so nothing should happens
+            try FileManager.default.removeItem(at: snapshotURL)
+        }
+    }
+
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
         if let imageURL = imageURL {
             return try VZDiskImageStorageDeviceAttachment(url: imageURL, readOnly: isReadOnly)

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -1006,9 +1006,8 @@ struct DiskImage: Codable, Hashable, Identifiable {
     /// Remove the snapshot URL image, this can be done as part of VM cleanup
     func cleanupDriveSnapshot() throws {
         if let snapshotURL = try snapshotURL() {
-            // The file may not exists, if so nothing should happens
-            //
-            // apperantly despite documentation saying it will return false.
+            // The file may not exists, if so nothing should happens. Also,
+            // despite documentation saying "removeItem" will return false.
             // it will return with an error if removal fails (does not exist,etc)
             //
             // try? surpresses and ignores the error

--- a/Managers/UTMAppleVirtualMachine.swift
+++ b/Managers/UTMAppleVirtualMachine.swift
@@ -190,6 +190,10 @@ import Virtualization
                 }
             }
         }
+
+        // This perform any cleanup for the "--snapshot" feature, 
+        // if it was initialized previously
+        try appleConfig.cleanupDriveSnapshot()
     }
     
     override func vmStop(force: Bool) async throws {

--- a/Managers/UTMAppleVirtualMachine.swift
+++ b/Managers/UTMAppleVirtualMachine.swift
@@ -328,6 +328,16 @@ import Virtualization
                 fsConfig.share = self?.makeDirectoryShare(from: newShares)
             }
         }
+
+        // This perform any reset's needed for the 
+        // "--snapshot" feature (if its in use)
+        // 
+        // The "runAsSnapshot" is meant to be used with the 
+        // "runAsSnapshot" context menu feature, which would perform   
+        // the snapshot run "on demand" without config change
+        // - when said context menu feature is implemented.
+        try appleConfig.setupDriveSnapshot(runAsSnapshot: false)
+
         apple = VZVirtualMachine(configuration: appleConfig.apple, queue: vmQueue)
         apple.delegate = self
     }

--- a/Platform/macOS/VMConfigAppleDriveDetailsView.swift
+++ b/Platform/macOS/VMConfigAppleDriveDetailsView.swift
@@ -25,6 +25,7 @@ struct VMConfigAppleDriveDetailsView: View {
             TextField("Name", text: .constant(diskImage.imageURL?.lastPathComponent ?? NSLocalizedString("(New Drive)", comment: "VMConfigAppleDriveDetailsView")))
                 .disabled(true)
             Toggle("Read Only?", isOn: $diskImage.isReadOnly)
+            Toggle("Run using a snapshot? (similar to qemu --snapshot)", isOn: $diskImage.isRunAsSnapshot)
             Button(action: onDelete) {
                 Label("Delete Drive", systemImage: "externaldrive.badge.minus")
                     .foregroundColor(.red)

--- a/Platform/macOS/VMConfigAppleSystemView.swift
+++ b/Platform/macOS/VMConfigAppleSystemView.swift
@@ -75,6 +75,7 @@ struct VMConfigAppleSystemView: View {
                         Toggle("Enable Keyboard", isOn: $config.isKeyboardEnabled)
                         Toggle("Enable Pointer", isOn: $config.isPointingEnabled)
                     }
+                    Toggle("Enable 'Run using a snapshot' on all drives", isOn: $config.isRunAsSnapshot)
                 }
             }
         }


### PR DESCRIPTION
Note: This is the "redone" version of a previous WIP PR - https://github.com/utmapp/UTM/pull/3792

---

https://github.com/utmapp/UTM/issues/2688

The QEMU counterpart is

https://github.com/utmapp/UTM/pull/3067

The general idea is to do an APFS clone (Meaning it will only require the delta additional space, and make no changes on the original) on VM startup. ie. `cp -c` command. This allows us to mimic a `qemu <disk> --snapshot` like behaviour.

The goal is to support the disposable VM workflow (not so much on the snapshot management)