### PR TITLE
Apple Pencil tap while using server cursor mode

### DIFF
--- a/Platform/iOS/Display/VMDisplayMetalViewController+Touch.m
+++ b/Platform/iOS/Display/VMDisplayMetalViewController+Touch.m
@@ -74,6 +74,10 @@ const CGFloat kScrollResistance = 10.0f;
     _tap.delegate = self;
     _tap.allowedTouchTypes = @[ @(UITouchTypeDirect) ];
     _tap.cancelsTouchesInView = NO;
+    _tapPencil = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(gestureTapPencil:)];
+    _tapPencil.delegate = self;
+    _tapPencil.allowedTouchTypes = @[ @(UITouchTypePencil) ];
+    _tapPencil.cancelsTouchesInView = NO;
     _twoTap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(gestureTwoTap:)];
     _twoTap.numberOfTouchesRequired = 2;
     _twoTap.delegate = self;
@@ -91,6 +95,7 @@ const CGFloat kScrollResistance = 10.0f;
     [self.mtkView addGestureRecognizer:_twoPan];
     [self.mtkView addGestureRecognizer:_threePan];
     [self.mtkView addGestureRecognizer:_tap];
+    [self.mtkView addGestureRecognizer:_tapPencil];
     [self.mtkView addGestureRecognizer:_twoTap];
     [self.mtkView addGestureRecognizer:_longPress];
     [self.mtkView addGestureRecognizer:_pinch];
@@ -417,6 +422,23 @@ static CGFloat CGPointToPixel(CGFloat point) {
     }
 }
 
+- (IBAction)gestureTapPencil:(UITapGestureRecognizer *)sender {
+    if (sender.state == UIGestureRecognizerStateEnded &&
+        self.serverModeCursor) { // otherwise we handle in touchesBegan
+        
+        CSInputButton button = kCSInputButtonLeft;
+        
+        if (@available(iOS 12.1, *)) {
+            if (_pencilForceRightClickOnce) {
+                button = kCSInputButtonRight;
+                _pencilForceRightClickOnce = false;
+            }
+        }
+        
+        [self mouseClick:button location:[sender locationInView:sender.view]];
+    }
+}
+
 - (IBAction)gestureTwoTap:(UITapGestureRecognizer *)sender {
     if (sender.state == UIGestureRecognizerStateEnded &&
         self.twoFingerTapType == VMGestureTypeRightClick) {
@@ -502,7 +524,13 @@ static CGFloat CGPointToPixel(CGFloat point) {
     if (gestureRecognizer == _tap && otherGestureRecognizer == _twoTap) {
         return YES;
     }
+    if (gestureRecognizer == _tapPencil && otherGestureRecognizer == _twoTap) {
+        return YES;
+    }
     if (gestureRecognizer == _longPress && otherGestureRecognizer == _tap) {
+        return YES;
+    }
+    if (gestureRecognizer == _longPress && otherGestureRecognizer == _tapPencil) {
         return YES;
     }
     if (gestureRecognizer == _longPress && otherGestureRecognizer == _twoTap) {

--- a/Platform/iOS/Display/VMDisplayMetalViewController.h
+++ b/Platform/iOS/Display/VMDisplayMetalViewController.h
@@ -48,6 +48,7 @@ NS_ASSUME_NONNULL_BEGIN
     UIPanGestureRecognizer *_twoPan;
     UIPanGestureRecognizer *_threePan;
     UITapGestureRecognizer *_tap;
+    UITapGestureRecognizer *_tapPencil;
     UITapGestureRecognizer *_twoTap;
     UILongPressGestureRecognizer *_longPress;
     UIPinchGestureRecognizer *_pinch;


### PR DESCRIPTION
When a VM is running with a cursor in server mode, it is possible via `gesturePan:` to drag the Apple Pencil across the screen which moves the mouse cursor in the VM. As a result, it seemed intuitive that tapping the pencil would generate a click event.

Since the logic that currently handles this in `touchesBegan:` can only be reached while the input mode is non-legacy and the cursor is in client mode, and `gestureTap:`'s recogniser is filtered to only accept direct input, touching the pencil on the screen in other conditions goes unhandled, meanwhile `gesturePan:`'s recogniser does not filter the input source so cursor movements still function.

Here, another gesture recogniser is added exclusively to handle pencil taps on the screen, so as to enable the expected click behaviour and to also enable right-clicking using the existing `UIPencilInteractionDelegate` in VMDisplayMetalViewController+Pencil.m.