### PR TITLE
Support drive resizing

### DIFF
--- a/Managers/UTMLogToMemory.swift
+++ b/Managers/UTMLogToMemory.swift
@@ -1,0 +1,32 @@
+//
+// Copyright © 2022 Stewart Smith. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@available(iOS 13, macOS 11, *)
+@objc class UTMLogToMemory: UTMLogging {
+    
+    func logToMemory() {
+        let outputStream = OutputStream(toMemory: ())
+        outputStream.open()
+        self.fileOutputStream = outputStream
+    }
+    
+    func getLog() -> Data {
+        let outputData = self.fileOutputStream?.property(forKey: Stream.PropertyKey.dataWrittenToMemoryStreamKey) as! Data
+        return outputData
+    }
+}

--- a/Managers/UTMLogging.h
+++ b/Managers/UTMLogging.h
@@ -25,6 +25,7 @@ void UTMLog(NSString *format, ...) NS_FORMAT_FUNCTION(1,2) NS_NO_TAIL_CALL;
 @property (nonatomic, readonly) NSPipe *standardOutput;
 @property (nonatomic, readonly) NSPipe *standardError;
 @property (nonatomic) NSString *lastErrorLine;
+@property (nonatomic, nullable) NSOutputStream *fileOutputStream;
 
 + (UTMLogging *)sharedInstance;
 

--- a/Managers/UTMLogging.m
+++ b/Managers/UTMLogging.m
@@ -35,7 +35,6 @@ void UTMLog(NSString *format, ...) {
 
 @property (nonatomic, readwrite) NSPipe *standardOutput;
 @property (nonatomic, readwrite) NSPipe *standardError;
-@property (nonatomic, nullable) NSOutputStream *fileOutputStream;
 @property (nonatomic, nullable) NSFileHandle *originalStdoutWrite;
 @property (nonatomic, nullable) NSFileHandle *originalStderrWrite;
 

--- a/Managers/UTMQemu.h
+++ b/Managers/UTMQemu.h
@@ -36,7 +36,8 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) UTMLogging *logging;
 
 - (instancetype)init;
-- (instancetype)initWithArgv:(NSArray<NSString *> *)argv NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithArgv:(NSArray<NSString *> *)argv;
+- (instancetype)initWithArgv:(NSArray<NSString *> *)argv  printArgv:(bool)printArgv NS_DESIGNATED_INITIALIZER;
 - (void)pushArgv:(nullable NSString *)arg;
 - (void)clearArgv;
 - (void)startQemu:(nonnull NSString *)name completion:(void(^)(BOOL,NSString * _Nullable))completion;

--- a/Managers/UTMQemu.m
+++ b/Managers/UTMQemu.m
@@ -24,6 +24,7 @@
     NSMutableArray<NSString *> *_argv;
     NSMutableArray<NSURL *> *_urls;
     NSXPCConnection *_connection;
+    bool _printArgv;
 }
 
 #pragma mark - Properties
@@ -48,12 +49,17 @@
 }
 
 - (instancetype)initWithArgv:(NSArray<NSString *> *)argv {
+    return [self initWithArgv:argv printArgv:false];
+}
+
+- (instancetype)initWithArgv:(NSArray<NSString *> *)argv printArgv:(bool)printArgv {
     if (self = [super init]) {
         _argv = [argv mutableCopy];
         _urls = [NSMutableArray<NSURL *> array];
         if (![self setupXpc]) {
             return nil;
         }
+        _printArgv = printArgv;
     }
     return self;
 }
@@ -184,7 +190,7 @@
 }
 
 - (void)startQemu:(nonnull NSString *)name completion:(void(^)(BOOL,NSString * _Nullable))completion {
-    [self printArgv];
+    if (_printArgv) [self printArgv];
 #if TARGET_OS_IPHONE
     NSString *base = @"";
 #else

--- a/Managers/UTMQemuImage.swift
+++ b/Managers/UTMQemuImage.swift
@@ -1,5 +1,6 @@
 //
 // Copyright © 2022 osy. All rights reserved.
+// Copyright © 2022 Stewart Smith
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +20,7 @@ import Foundation
 @available(iOS 13, macOS 11, *)
 @objc class UTMQemuImage: UTMQemu {
     private init() {
-        super.init(argv: [])
+        super.init(argv: [], printArgv: false)
     }
     
     static func convert(from url: URL, toQcow2 dest: URL, withCompression compressed: Bool = false) async throws {
@@ -36,6 +37,98 @@ import Foundation
         qemuImg.pushArgv(url.path)
         qemuImg.accessData(withBookmark: dstBookmark)
         qemuImg.pushArgv(dest.path)
+        let logging = UTMLogging()
+        qemuImg.logging = logging
+        try await Task.detached {
+            let (success, message) = await qemuImg.start("qemu-img")
+            if !success, let message = message {
+                throw message
+            }
+        }.value
+    }
+    
+    /*
+     
+     The info format looks like:
+     
+     $ qemu-img info foo.img --output=json
+     {
+         "virtual-size": 20971520,
+         "filename": "foo.img",
+         "cluster-size": 65536,
+         "format": "qcow2",
+         "actual-size": 200704,
+         "format-specific": {
+             "type": "qcow2",
+             "data": {
+                 "compat": "1.1",
+                 "compression-type": "zlib",
+                 "lazy-refcounts": false,
+                 "refcount-bits": 16,
+                 "corrupt": false,
+                 "extended-l2": false
+             }
+         },
+         "dirty-flag": false
+     }
+     */
+    
+    struct QemuImageInfo : Codable {
+        let virtualSize : Int64
+        let filename : String
+        let clusterSize : Int32
+        let format : String
+        let actualSize : Int64
+        let dirtyFlag : Bool
+        
+        private enum CodingKeys: String, CodingKey {
+            case virtualSize = "virtual-size"
+            case filename
+            case clusterSize = "cluster-size"
+            case format
+            case actualSize = "actual-size"
+            case dirtyFlag = "dirty-flag"
+        }
+    }
+    
+    static func size(image url: URL) async throws -> Int64{
+        let qemuImg = UTMQemuImage()
+        let srcBookmark = try url.bookmarkData()
+        qemuImg.pushArgv("info")
+        qemuImg.pushArgv("--output=json")
+        qemuImg.accessData(withBookmark: srcBookmark)
+        qemuImg.pushArgv(url.path)
+        let logging = UTMLogToMemory()
+        logging.logToMemory()
+        qemuImg.logging = logging
+        try await Task.detached {
+            let (success, message) = await qemuImg.start("qemu-img")
+            if !success, let message = message {
+                throw message
+            }
+        }.value
+        
+        let data = logging.getLog()
+        let str = String(decoding: data, as: UTF8.self)
+        print(str)
+        
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        
+        let image_info: QemuImageInfo = try! decoder.decode(QemuImageInfo.self, from: data)
+
+        return image_info.virtualSize
+    }
+        
+    static func resize(image url: URL, size : UInt64) async throws {
+        let qemuImg = UTMQemuImage()
+        let srcBookmark = try url.bookmarkData()
+        qemuImg.pushArgv("resize")
+        qemuImg.pushArgv("-f")
+        qemuImg.pushArgv("qcow2")
+        qemuImg.accessData(withBookmark: srcBookmark)
+        qemuImg.pushArgv(url.path)
+        qemuImg.pushArgv(String(size))
         let logging = UTMLogging()
         qemuImg.logging = logging
         try await Task.detached {

--- a/Platform/Shared/VMConfigDriveDetailsView.swift
+++ b/Platform/Shared/VMConfigDriveDetailsView.swift
@@ -1,5 +1,6 @@
 //
 // Copyright © 2020 osy. All rights reserved.
+// Copyright © 2020 Stewart Smith
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,17 +19,25 @@ import SwiftUI
 
 @available(iOS 14, macOS 11, *)
 struct VMConfigDriveDetailsView: View {
+    private let mibToGib = 1024
     @EnvironmentObject private var data: UTMData
     @ObservedObject private var config: UTMQemuConfiguration
     @Binding private var removable: Bool
     @Binding private var name: String?
     @Binding private var imageTypeString: String?
     @Binding private var interface: String?
+    @State private var virtualSize : Int = 0
+    @State private var origVirtualSize : Int = 0
+    @State private var isGiB: Bool = true
     let onDelete: (() -> Void)?
     
     let helpMessage: LocalizedStringKey = "Reclaim disk space by re-converting the disk image."
     let confirmMessage: LocalizedStringKey = "Would you like to re-convert this disk image to reclaim unused space? Note this will require enough temporary space to perform the conversion. You are strongly encouraged to back-up this VM before proceeding."
     @State private var isConfirmConvertShown: Bool = false
+    
+    let resizeHelpMessage: LocalizedStringKey = "Resize disk image"
+    let resizeConfirmMessage: LocalizedStringKey = "Would you like to resize the image? If shrinking you WILL LOSE DATA if you have not used OS tools to resize the disks appropriately."
+    @State private var isConfirmResizeShown: Bool = false
     
     var imageType: UTMDiskImageType {
         get {
@@ -87,9 +96,42 @@ struct VMConfigDriveDetailsView: View {
             if imageType == .disk || imageType == .CD {
                 VMConfigStringPicker("Interface", selection: $interface, rawValues: UTMQemuConfiguration.supportedDriveInterfaces(), displayValues: UTMQemuConfiguration.supportedDriveInterfacesPretty())
             }
-            
             if let name = name, let imageUrl = config.imagesPath.appendingPathComponent(name), let fileSize = data.computeSize(for: imageUrl) {
-                DefaultTextField("Size", text: .constant(ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file))).disabled(true)
+                VStack {
+                    HStack {
+                        NumberTextField("Size", number: Binding<NSNumber?>(get: {
+                            NSNumber(value: convertToDisplay(fromSizeMib: virtualSize))
+                        }, set: {
+                            virtualSize = convertToMib(fromSize: $0?.intValue ?? 0)
+                        }), onEditingChanged: validateSize).onAppear {
+                            Task {
+                                origVirtualSize = Int(await data.driveSize(for: imageUrl)/(1024*1024))
+                                virtualSize = origVirtualSize
+                            }
+                        }
+                        Button(action: { isGiB.toggle() }, label: {
+                            Text(isGiB ? "GB" : "MB")
+                                .foregroundColor(.blue)
+                        }).buttonStyle(.plain)
+                        if #available(macOS 12, *) {
+                            Button(action: { isConfirmResizeShown.toggle() }) {
+                                Label("Resize", systemImage: "arrow.3.trianglepath")
+                            }.help(resizeHelpMessage)
+                                .alert(resizeConfirmMessage, isPresented: $isConfirmResizeShown) {
+                                    Button("Cancel", role: .cancel) {}
+                                    Button("Resize", role: .destructive) { resizeDrive(for: imageUrl, sizeInMib: virtualSize) }
+                                }
+                        } else {
+                            Button(action: { isConfirmResizeShown.toggle() }) {
+                                Label("Resize", systemImage: "arrow.3.trianglepath")
+                            }.help(resizeHelpMessage)
+                                .alert(isPresented: $isConfirmResizeShown) {
+                                    Alert(title: Text(resizeConfirmMessage), primaryButton: .cancel(), secondaryButton: .destructive(Text("Resize")) { resizeDrive(for: imageUrl, sizeInMib: virtualSize) })
+                                }
+                        }
+                    }
+                    DefaultTextField("Size on disk", text: .constant(ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file))).disabled(true)
+                }
             }
 
             HStack {
@@ -124,6 +166,18 @@ struct VMConfigDriveDetailsView: View {
             }
         }
     }
+
+    private func driveSize(for driveUrl: URL, sizeInMib: Int) {
+        data.busyWorkAsync {
+            try await data.driveSize(for: driveUrl)
+        }
+    }
+    
+    private func resizeDrive(for driveUrl: URL, sizeInMib: Int) {
+        data.busyWorkAsync {
+            try await data.resizeDrive(for: driveUrl, sizeInMib: sizeInMib)
+        }
+    }
     
     #if os(macOS)
     private func reclaimSpace(for driveUrl: URL, withCompression isCompressed: Bool) {
@@ -132,4 +186,29 @@ struct VMConfigDriveDetailsView: View {
         }
     }
     #endif
+    
+    private func validateSize(editing: Bool) {
+        guard !editing else {
+            return
+        }
+        if virtualSize < origVirtualSize {
+            virtualSize = origVirtualSize
+        }
+    }
+    
+    private func convertToMib(fromSize size: Int) -> Int {
+        if isGiB {
+            return size * mibToGib
+        } else {
+            return size
+        }
+    }
+    
+    private func convertToDisplay(fromSizeMib sizeMib: Int) -> Int {
+        if isGiB {
+            return sizeMib / mibToGib
+        } else {
+            return sizeMib
+        }
+    }
 }

--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -889,6 +889,18 @@ class UTMData: ObservableObject {
     }
     #endif
     
+    func driveSize(for driveUrl: URL) async -> Int64 {
+        let r = Task {
+            return try? await UTMQemuImage.size(image: driveUrl)
+        }
+        do { return await r.value ?? 0 } catch { return 0 }
+    }
+    
+    func resizeDrive(for driveUrl: URL, sizeInMib: Int) async throws {
+        let bytesinMib = 1048576
+        try await UTMQemuImage.resize(image: driveUrl, size: UInt64(sizeInMib * bytesinMib))
+    }
+    
     // MARK: - Other utility functions
     
     /// In some regions, iOS will prompt the user for network access

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -123,6 +123,9 @@
 		85EC516427CC8D0F004A51DE /* VMConfigAdvancedNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC516327CC8C98004A51DE /* VMConfigAdvancedNetworkView.swift */; };
 		85EC516527CC8D0F004A51DE /* VMConfigAdvancedNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC516327CC8C98004A51DE /* VMConfigAdvancedNetworkView.swift */; };
 		85EC516627CC8D10004A51DE /* VMConfigAdvancedNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC516327CC8C98004A51DE /* VMConfigAdvancedNetworkView.swift */; };
+		8D4D587D28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4D587C28485B8900BB55C2 /* UTMLogToMemory.swift */; };
+		8D4D587E28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4D587C28485B8900BB55C2 /* UTMLogToMemory.swift */; };
+		8D4D587F28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D4D587C28485B8900BB55C2 /* UTMLogToMemory.swift */; };
 		B329049C270FE136002707AC /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = B329049B270FE136002707AC /* AltKit */; };
 		B3DDF57226E9BBA300CE47F0 /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = B3DDF57126E9BBA300CE47F0 /* AltKit */; };
 		CE020BA324AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
@@ -1590,6 +1593,7 @@
 		84FCABB9268CE05E0036196C /* UTMQemuVirtualMachine.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = UTMQemuVirtualMachine.m; sourceTree = "<group>"; };
 		84FCABBD268CE4080036196C /* UTMVirtualMachine-Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "UTMVirtualMachine-Private.h"; sourceTree = "<group>"; };
 		85EC516327CC8C98004A51DE /* VMConfigAdvancedNetworkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMConfigAdvancedNetworkView.swift; sourceTree = "<group>"; };
+		8D4D587C28485B8900BB55C2 /* UTMLogToMemory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMLogToMemory.swift; sourceTree = "<group>"; };
 		C03453AD2709E35100AD51AD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C03453AE2709E35100AD51AD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C03453AF2709E35100AD51AD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -2990,6 +2994,7 @@
 				CE36B27E227665B7004A1435 /* UTMJSONStreamDelegate.h */,
 				CE6EDCE0241DA0E900A719DC /* UTMLogging.h */,
 				CE6EDCE1241DA0E900A719DC /* UTMLogging.m */,
+				8D4D587C28485B8900BB55C2 /* UTMLogToMemory.swift */,
 				CEDF83F8258AE24E0030E4AC /* UTMPasteboard.swift */,
 				2C6D9E122571AFE5003298E6 /* UTMQcow2.h */,
 				2C6D9E132571AFE5003298E6 /* UTMQcow2.c */,
@@ -3704,6 +3709,7 @@
 				CEB63A9224F46E6E00CAF323 /* VMConfigInputViewController.m in Sources */,
 				CE4EF2702506DBFD00E9D33B /* VMRemovableDrivesViewController.swift in Sources */,
 				83034C0726AB630F006B4BAF /* UTMPendingVMView.swift in Sources */,
+				8D4D587D28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */,
 				CE2D92AA24AD46670059923A /* UTMSpiceIO.m in Sources */,
 				84909A9127CADAE0005605F1 /* UTMUnavailableVMView.swift in Sources */,
 				CE2D92AB24AD46670059923A /* qapi-events-machine-target.c in Sources */,
@@ -4109,6 +4115,7 @@
 				8453DCB6278CE5410037A0DA /* UTMQemuImage.swift in Sources */,
 				CEDF83FA258AE24E0030E4AC /* UTMPasteboard.swift in Sources */,
 				848F71EE277A2F47006A0240 /* UTMSerialPortDelegate.swift in Sources */,
+				8D4D587F28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */,
 				CE0B6D1124AD57C700FE012D /* qapi-builtin-visit.c in Sources */,
 				CE0B6D3F24AD584C00FE012D /* qapi-visit-qom.c in Sources */,
 				CE2D958A24AD4F990059923A /* VMConfigSystemView.swift in Sources */,
@@ -4399,6 +4406,7 @@
 				CEA45F02263519B5002FA97D /* qapi-commands-ui.c in Sources */,
 				CEA45F03263519B5002FA97D /* qapi-events-authz.c in Sources */,
 				CEA45F04263519B5002FA97D /* qapi-commands-block-core.c in Sources */,
+				8D4D587E28485B8900BB55C2 /* UTMLogToMemory.swift in Sources */,
 				CEA45F05263519B5002FA97D /* qapi-types-authz.c in Sources */,
 				CEA45F06263519B5002FA97D /* qapi-types-qdev.c in Sources */,
 				CEF0305C26A2AFDF00667B63 /* VMWizardOSOtherView.swift in Sources */,


### PR DESCRIPTION
Add UTMLogToMemory to capture output of "qemu-img info", which we can parse the JSON output of in order to determine the virtual size of the drive.

Use the same widget style for resizing as we do for creating a drive (GB/MB), although require clicking "Resize" to do the resize itself.

Currently doesn't warn about having not clicked "resize" though.

Fair warning: I'm pretty sure this is the first time in nearly 20 years I've looked at Objective-C code, and my Swift knowledge is sketchy at best.

<img width="638" alt="Screen Shot 2022-06-01 at 22 58 28" src="https://user-images.githubusercontent.com/611883/171562913-7072a4de-a0ad-41de-b4c8-7f789188ee30.png">
