### PR TITLE
Fix MacOS build instructions

### DIFF
--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -23,8 +23,9 @@ If you want to build the dependencies yourself, it is highly recommended that yo
 2. Install the following build prerequisites
     `brew install bison pkg-config gettext glib libgpg-error nasm make meson`
    Make sure to add `bison` and `gettext` to your `$PATH` environment variable!
-	`export PATH=/opt/homebrew/bin:/opt/homebrew/opt:$PATH`
-3. Run `./scripts/build_dependencies.sh -p macos -a ARCH` where `ARCH` is either `arm64` or `x86_64`.
+	`export PATH=/opt/homebrew/bin:$PATH`
+3. Install `six` python package: `pip3 install six`
+4. Run `./scripts/build_dependencies.sh -p macos -a ARCH` where `ARCH` is either `arm64` or `x86_64`.
 
 If you want to build universal binaries, you need to run `build_dependencies.sh` for both `arm64` and `x86_64` and then run
 

--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -23,7 +23,7 @@ If you want to build the dependencies yourself, it is highly recommended that yo
 2. Install the following build prerequisites
     `brew install bison pkg-config gettext glib libgpg-error nasm make meson`
    Make sure to add `bison` and `gettext` to your `$PATH` environment variable!
-	`export PATH=/usr/local/opt/bison/bin:/usr/local/opt/gettext/bin:$PATH`
+	`export PATH=/opt/homebrew/bin:/opt/homebrew/opt:$PATH`
 3. Run `./scripts/build_dependencies.sh -p macos -a ARCH` where `ARCH` is either `arm64` or `x86_64`.
 
 If you want to build universal binaries, you need to run `build_dependencies.sh` for both `arm64` and `x86_64` and then run

--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -23,7 +23,7 @@ If you want to build the dependencies yourself, it is highly recommended that yo
 2. Install the following build prerequisites
     `brew install bison pkg-config gettext glib libgpg-error nasm make meson`
    Make sure to add `bison` and `gettext` to your `$PATH` environment variable!
-	`export PATH=/opt/homebrew/bin:$PATH`
+	`export PATH="/opt/homebrew/opt/bison/bin:/opt/homebrew/opt/gettext/bin:$PATH"`
 3. Install `six` python package: `pip3 install six`
 4. Run `./scripts/build_dependencies.sh -p macos -a ARCH` where `ARCH` is either `arm64` or `x86_64`.
 


### PR DESCRIPTION
It seems that homebrew now installs to `/opt/homebrew`