### PR TITLE
Add image of UTM running on macOS to en-US README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,11 @@
 
 UTM is a full featured system emulator and virtual machine host for iOS and macOS. It is based off of QEMU. In short, it allows you to run Windows, Linux, and more on your Mac, iPhone, and iPad. More information at https://getutm.app/ and https://mac.getutm.app/
 
-![Screenshot of UTM running on iPhone][2]
+<p align="center">
+  <img width="450px" alt="UTM running on an iPhone" src="screen.png">
+  <br>
+  <img width="450px" alt="UTM running on a MacBook" src="screenmac.png">
+</p>
 
 ## Features
 


### PR DESCRIPTION
## Overview
This commit achieves the following:
- [x] Add image of macOS to the en-US README
  - I will not be doing this for the simplified or traditional Chinese READMEs as the author of those appears to be using their own hosting provider for the images, so they can grab the new image and translate the alt text to the respective Chinese if they wish.
- [x] Center the images
- [x] Put each image on its own line

## Preview:
On a desktop browser:
<img width="935" alt="Screenshot of the changed README on a desktop browser" src="https://user-images.githubusercontent.com/10524728/175183232-6e308f36-c5d8-4bed-9c77-6900b60a6563.png">

----

On a mobile phone:
<img width="450" alt="Screenshot of the changed README on a mobile phone" src="https://user-images.githubusercontent.com/10524728/175183314-87cde5d9-72b9-4084-b151-091748e99f11.png">
