### PR TITLE
When downloading macOS IPSW: Check if "Caches" folder exists and create it if not

### DIFF
--- a/Platform/Shared/UTMDownloadIPSWTask.swift
+++ b/Platform/Shared/UTMDownloadIPSWTask.swift
@@ -33,6 +33,10 @@ class UTMDownloadIPSWTask: UTMDownloadTask {
     }
     
     override func processCompletedDownload(at location: URL) async throws -> UTMVirtualMachine {
+        if !fileManager.fileExists(atPath: cacheUrl.path) {
+            try fileManager.createDirectory(at: cacheUrl, withIntermediateDirectories: false)
+        }
+        
         let cacheIpsw = cacheUrl.appendingPathComponent(url.lastPathComponent)
         if fileManager.fileExists(atPath: cacheIpsw.path) {
             try fileManager.removeItem(at: cacheIpsw)


### PR DESCRIPTION
Fix for #4141 
Just checking if the folder exists and create it if not. The problem with #4141 was a missing "Caches" folder.