### PR TITLE
vm(qemu): allow virtio/9p without other sharing options

### DIFF
--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -688,26 +688,27 @@ extension UTMQemuConfiguration {
                 f("virtserialport,chardev=charchannel1,id=channel1,name=org.spice-space.webdav.0")
                 f("-chardev")
                 f("spiceport,name=org.spice-space.webdav.0,id=charchannel1")
-            } else if sharing.directoryShareMode == .virtfs, let url = sharing.directoryShareUrl {
-                f("-fsdev")
-                "local"
-                "id=virtfs0"
-                "path="
-                url
-                "security_model=mapped-xattr"
-                if sharing.isDirectoryShareReadOnly {
-                    "readonly=on"
-                }
-                f()
-                f("-device")
-                if system.architecture == .s390x {
-                    "virtio-9p-ccw"
-                } else {
-                    "virtio-9p-pci"
-                }
-                "fsdev=virtfs0"
-                "mount_tag=share"
             }
+        }
+        if sharing.directoryShareMode == .virtfs, let url = sharing.directoryShareUrl {
+            f("-fsdev")
+            "local"
+            "id=virtfs0"
+            "path="
+            url
+            "security_model=mapped-xattr"
+            if sharing.isDirectoryShareReadOnly {
+                "readonly=on"
+            }
+            f()
+            f("-device")
+            if system.architecture == .s390x {
+                "virtio-9p-ccw"
+            } else {
+                "virtio-9p-pci"
+            }
+            "fsdev=virtfs0"
+            "mount_tag=share"
         }
     }
     


### PR DESCRIPTION
This change allows directory sharing using virtio/9p without requiring other sharing options to be enabled.

Updates #2184
