### PR TITLE
Fixed MacDevelopment.md shell commands formatting.

### DIFF
--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -31,12 +31,14 @@ If you want to build the dependencies yourself, it is highly recommended that yo
     ```sh
     pip3 install six pyparsing
     ```
-   Make sure to add `bison` to your `$PATH` environment variable!
-	```sh
+    
+    Make sure to add `bison` to your `$PATH` environment variable!
+    
+    ```sh
     export PATH=/usr/local/opt/bison/bin:/opt/homebrew/opt/bison/bin:$PATH
     ```
 3. Run
-    ```
+    ```sh
     ./scripts/build_dependencies.sh -p macos -a ARCH
     ```
     where `ARCH` is either `arm64` or `x86_64`.

--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -78,8 +78,7 @@ This builds `UTM.dmg` in `/path/to/output` which can be installed to `/Applicati
 #### Signed packages
 
 ```sh
-./scripts/package_mac.sh developer-id /path/to/UTM.xcarchive /path/to/output TEAM_ID 
-PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
+./scripts/package_mac.sh developer-id /path/to/UTM.xcarchive /path/to/output TEAM_ID PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
 ```
 
 To build a signed package, you need to be a registered Apple Developer. From the developer portal, create a certificate for "Developer ID Application" (and install it into your Keychain). Also create three provisioning profiles with that certificate with Hypervisor entitlements (you need to manually request these entitlements and be approved by Apple) for UTM, QEMUHelper, and QEMULauncher. `TEAM_ID` should be the same as in the certificate, `PROFILE_UUID` should be the UUID of the profile installed by Xcode (open the profile in Xcode), and `HELPER_PROFILE_UUID` is the UUID of a separate profile for the XPC helper. `LAUNCHER_PROFILE_UUID` is the UUID of a profile for the launcher.
@@ -89,8 +88,7 @@ Once properly signed, you can ask Apple to notarize the DMG.
 #### Mac App Store
 
 ```sh
-./scripts/package_mac.sh app-store /path/to/UTM.xcarchive /path/to/output TEAM_ID 
-PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
+./scripts/package_mac.sh app-store /path/to/UTM.xcarchive /path/to/output TEAM_ID PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
 ```
 
 Similar to the above but builds a `UTM.pkg` for submission to the Mac App Store. You need a certificate for "Apple Distribution" and a certificate for "Mac App Distribution" as well as a provisioning profile with the right entitlements.

--- a/Documentation/MacDevelopment.md
+++ b/Documentation/MacDevelopment.md
@@ -5,11 +5,14 @@ Because UTM is a sand-boxed Mac app, there are a few extra steps needed for a pr
 ## Getting the Source
 
 Make sure you perform a recursive clone to get all the submodules:
-```
+```sh
 git clone --recursive https://github.com/utmapp/UTM.git
 ```
 
-Alternatively, run `git submodule update --init --recursive` after cloning if you did not do a recursive clone.
+Alternatively, run the following after cloning if you did not do a recursive clone.
+```sh
+git submodule update --init --recursive
+```
 
 ## Dependencies
 
@@ -21,15 +24,26 @@ If you want to build the dependencies yourself, it is highly recommended that yo
 
 1. Install Xcode command line and [Homebrew][1]
 2. Install the following build prerequisites
-    `brew install bison pkg-config gettext glib-utils libgpg-error nasm meson`
-    `pip3 install six pyparsing`
+    ```sh
+    brew install bison pkg-config gettext glib-utils libgpg-error nasm meson
+    ```
+    
+    ```sh
+    pip3 install six pyparsing
+    ```
    Make sure to add `bison` to your `$PATH` environment variable!
-	`export PATH=/usr/local/opt/bison/bin:/opt/homebrew/opt/bison/bin:$PATH`
-3. Run `./scripts/build_dependencies.sh -p macos -a ARCH` where `ARCH` is either `arm64` or `x86_64`.
+	```sh
+    export PATH=/usr/local/opt/bison/bin:/opt/homebrew/opt/bison/bin:$PATH
+    ```
+3. Run
+    ```
+    ./scripts/build_dependencies.sh -p macos -a ARCH
+    ```
+    where `ARCH` is either `arm64` or `x86_64`.
 
 If you want to build universal binaries, you need to run `build_dependencies.sh` for both `arm64` and `x86_64` and then run
 
-```
+```sh
 ./scripts/pack_dependencies.sh . macos arm64 x86_64
 ```
 
@@ -41,7 +55,7 @@ If you are developing QEMU and wish to pass in a custom path to QEMU, you can us
 
 You can build UTM with the script:
 
-```
+```sh
 ./scripts/build_utm.sh -t TEAMID -p macos -a ARCH -o /path/to/output/directory
 ```
 
@@ -55,7 +69,7 @@ Artifacts built with `build_utm.sh` (includes GitHub Actions artifacts) must be 
 
 #### Unsigned packages
 
-```
+```sh
 ./scripts/package_mac.sh unsigned /path/to/UTM.xcarchive /path/to/output
 ```
 
@@ -63,8 +77,9 @@ This builds `UTM.dmg` in `/path/to/output` which can be installed to `/Applicati
 
 #### Signed packages
 
-```
-./scripts/package_mac.sh developer-id /path/to/UTM.xcarchive /path/to/output TEAM_ID PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
+```sh
+./scripts/package_mac.sh developer-id /path/to/UTM.xcarchive /path/to/output TEAM_ID 
+PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
 ```
 
 To build a signed package, you need to be a registered Apple Developer. From the developer portal, create a certificate for "Developer ID Application" (and install it into your Keychain). Also create three provisioning profiles with that certificate with Hypervisor entitlements (you need to manually request these entitlements and be approved by Apple) for UTM, QEMUHelper, and QEMULauncher. `TEAM_ID` should be the same as in the certificate, `PROFILE_UUID` should be the UUID of the profile installed by Xcode (open the profile in Xcode), and `HELPER_PROFILE_UUID` is the UUID of a separate profile for the XPC helper. `LAUNCHER_PROFILE_UUID` is the UUID of a profile for the launcher.
@@ -73,8 +88,9 @@ Once properly signed, you can ask Apple to notarize the DMG.
 
 #### Mac App Store
 
-```
-./scripts/package_mac.sh app-store /path/to/UTM.xcarchive /path/to/output TEAM_ID PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
+```sh
+./scripts/package_mac.sh app-store /path/to/UTM.xcarchive /path/to/output TEAM_ID 
+PROFILE_UUID HELPER_PROFILE_UUID LAUNCHER_PROFILE_UUID
 ```
 
 Similar to the above but builds a `UTM.pkg` for submission to the Mac App Store. You need a certificate for "Apple Distribution" and a certificate for "Mac App Distribution" as well as a provisioning profile with the right entitlements.


### PR DESCRIPTION
Quick fix for formatting and making the commands directly copyable.

Fixes #4606