### PR TITLE
Removed incorrect "Shared directories" warning message

### DIFF
--- a/Platform/de.lproj/Localizable.strings
+++ b/Platform/de.lproj/Localizable.strings
@@ -575,9 +575,6 @@
 "None (Advanced)" = "Keine (erweitert)";
 
 /* No comment provided by engineer. */
-"Note: Shared directories will not be saved and will be reset when UTM quits." = "Hinweis: freigegebene Ordner werden nicht gespeichert und beim Beenden von UTM zurückgesetzt.";
-
-/* No comment provided by engineer. */
 "Notes" = "Notizen";
 
 /* UTMQemuConstants */

--- a/Platform/es-419.lproj/Localizable.strings
+++ b/Platform/es-419.lproj/Localizable.strings
@@ -575,9 +575,6 @@
 "None (Advanced)" = "Ninguno (avanzado)";
 
 /* No comment provided by engineer. */
-"Note: Shared directories will not be saved and will be reset when UTM quits." = "Nota: Los directorios compartidos no serán guardados y se restablecerán cuando UTM se cierre.";
-
-/* No comment provided by engineer. */
 "Notes" = "Notas";
 
 /* UTMQemuConstants */

--- a/Platform/fr.lproj/Localizable.strings
+++ b/Platform/fr.lproj/Localizable.strings
@@ -337,7 +337,6 @@
 // VMConfigAppleSerialView.swift
 "Connection" = "Connection";
 "Mode" = "Mode";
-"Note: Shared directories will not be saved and will be reset when UTM quits." = "Note : les dossiers partagés ne seront pas sauvegardés et seront réinitialisés lorsque vous quitterez UTM.";
 "Shared Path" = "Chemin partagé";
 "Add" = "Ajouter";
 "This directory is already being shared." = "Ce dossier est déjà partagé.";

--- a/Platform/ja.lproj/Localizable.strings
+++ b/Platform/ja.lproj/Localizable.strings
@@ -340,7 +340,6 @@
 // VMConfigAppleSerialView.swift
 "Connection" = "接続";
 "Mode" = "モード";
-"Note: Shared directories will not be saved and will be reset when UTM quits." = "注意: 共有ディレクトリは保存されず、UTMを終了するとリセットされます。";
 "Shared Path" = "共有パス";
 "Add" = "追加";
 "This directory is already being shared." = "このディレクトリはすでに共有されています。";

--- a/Platform/macOS/VMConfigAppleSharingView.swift
+++ b/Platform/macOS/VMConfigAppleSharingView.swift
@@ -26,7 +26,6 @@ struct VMConfigAppleSharingView: View {
     
     var body: some View {
         Form {
-            Text("Note: Shared directories will not be saved and will be reset when UTM quits.")
             Table(config.sharedDirectories, selection: $selectedID) {
                 TableColumn("Shared Path") { share in
                     Text(share.directoryURL?.path ?? "")


### PR DESCRIPTION
- Per ktprograms in Discord, permissions to access paths are now present in 4.x and this warning is no longer needed as files are no longer deleted