### PR TITLE
Added Hyper-V Enlightenments for x86_64 and i386

### DIFF
--- a/Configuration/QEMUConstant.swift
+++ b/Configuration/QEMUConstant.swift
@@ -124,6 +124,10 @@ protocol QEMUCPUFlag: QEMUConstant {}
 
 extension AnyQEMUConstant: QEMUCPUFlag {}
 
+protocol QEMUCPUHyperV: QEMUConstant {}
+
+extension AnyQEMUConstant: QEMUCPUHyperV {}
+
 protocol QEMUDisplayDevice: QEMUConstant {}
 
 extension AnyQEMUConstant: QEMUDisplayDevice {}

--- a/Configuration/QEMUConstantGenerated.swift
+++ b/Configuration/QEMUConstantGenerated.swift
@@ -5262,6 +5262,124 @@ typealias QEMUCPUFlag_xtensa = AnyQEMUConstant
 
 typealias QEMUCPUFlag_xtensaeb = AnyQEMUConstant
 
+typealias QEMUCPUHyperV_alpha = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_arm = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_aarch64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_avr = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_cris = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_hppa = AnyQEMUConstant
+
+enum QEMUCPUHyperV_i386: String, CaseIterable, QEMUCPUHyperV {
+    case hv_avic = "hv-avic"
+    case hv_apicv = "hv-apicv"
+    case hv_crash = "hv-crash"
+    case hv_frequencies = "hv-frequencies"
+    case hv_relaxed = "hv-relaxed"
+    case hv_reset = "hv-reset"
+    case hv_runtime = "hv-runtime"
+    case hv_spinlocks = "hv-spinlocks=0x1fff"
+    case hv_time = "hv-time"
+    case hv_vapic = "hv-vapic"
+    case hv_xmm_input = "hv-xmm-input"
+    
+    var prettyValue: String {
+        switch self {
+        case .hv_avic: return "hv-apic"
+        case .hv_apicv: return "hv-apicv"
+        case .hv_crash: return "hv-crash"
+        case .hv_frequencies: return "hv-frequencies"
+        case .hv_relaxed: return "hv-relaxed"
+        case .hv_reset: return "hv-reset"
+        case .hv_runtime: return "hv-runtime"
+        case .hv_spinlocks: return "hv-spinlocks"
+        case .hv_time: return "hv-time"
+        case .hv_vapic: return "hv-vapic"
+        case .hv_xmm_input: return "hv-xmm-input"
+        }
+    }
+}
+
+typealias QEMUCPUHyperV_loongarch64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_m68k = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_microblaze = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_microblazeel = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_mips = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_mipsel = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_mips64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_mips64el = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_nios2 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_or1k = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_ppc = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_ppc64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_riscv32 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_riscv64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_rx = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_s390x = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_sh4 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_sh4eb = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_sparc = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_sparc64 = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_tricore = AnyQEMUConstant
+
+enum QEMUCPUHyperV_x86_64: String, CaseIterable, QEMUCPUHyperV {
+    case hv_avic = "hv-avic"
+    case hv_apicv = "hv-apicv"
+    case hv_crash = "hv-crash"
+    case hv_frequencies = "hv-frequencies"
+    case hv_relaxed = "hv-relaxed"
+    case hv_reset = "hv-reset"
+    case hv_runtime = "hv-runtime"
+    case hv_spinlocks = "hv-spinlocks=0x1fff"
+    case hv_time = "hv-time"
+    case hv_vapic = "hv-vapic"
+    case hv_xmm_input = "hv-xmm-input"
+    
+    var prettyValue: String {
+        switch self {
+        case .hv_avic: return "hv-apic"
+        case .hv_apicv: return "hv-apicv"
+        case .hv_crash: return "hv-crash"
+        case .hv_frequencies: return "hv-frequencies"
+        case .hv_relaxed: return "hv-relaxed"
+        case .hv_reset: return "hv-reset"
+        case .hv_runtime: return "hv-runtime"
+        case .hv_spinlocks: return "hv-spinlocks"
+        case .hv_time: return "hv-time"
+        case .hv_vapic: return "hv-vapic"
+        case .hv_xmm_input: return "hv-xmm-input"
+        }
+    }
+}
+
+typealias QEMUCPUHyperV_xtensa = AnyQEMUConstant
+
+typealias QEMUCPUHyperV_xtensaeb = AnyQEMUConstant
+
 enum QEMUTarget_alpha: String, CaseIterable, QEMUTarget {
     case clipper
     case none
@@ -10089,6 +10207,43 @@ extension QEMUArchitecture {
         }
     }
 
+    var cpuHyperVType: any QEMUCPUHyperV.Type {
+        switch self {
+        case .alpha: return QEMUCPUHyperV_alpha.self
+        case .arm: return QEMUCPUHyperV_arm.self
+        case .aarch64: return QEMUCPUHyperV_aarch64.self
+        case .avr: return QEMUCPUHyperV_avr.self
+        case .cris: return QEMUCPUHyperV_cris.self
+        case .hppa: return QEMUCPUHyperV_hppa.self
+        case .i386: return QEMUCPUHyperV_i386.self
+        case .loongarch64: return QEMUCPUHyperV_loongarch64.self
+        case .m68k: return QEMUCPUHyperV_m68k.self
+        case .microblaze: return QEMUCPUHyperV_microblaze.self
+        case .microblazeel: return QEMUCPUHyperV_microblazeel.self
+        case .mips: return QEMUCPUHyperV_mips.self
+        case .mipsel: return QEMUCPUHyperV_mipsel.self
+        case .mips64: return QEMUCPUHyperV_mips64.self
+        case .mips64el: return QEMUCPUHyperV_mips64el.self
+        case .nios2: return QEMUCPUHyperV_nios2.self
+        case .or1k: return QEMUCPUHyperV_or1k.self
+        case .ppc: return QEMUCPUHyperV_ppc.self
+        case .ppc64: return QEMUCPUHyperV_ppc64.self
+        case .riscv32: return QEMUCPUHyperV_riscv32.self
+        case .riscv64: return QEMUCPUHyperV_riscv64.self
+        case .rx: return QEMUCPUHyperV_rx.self
+        case .s390x: return QEMUCPUHyperV_s390x.self
+        case .sh4: return QEMUCPUHyperV_sh4.self
+        case .sh4eb: return QEMUCPUHyperV_sh4eb.self
+        case .sparc: return QEMUCPUHyperV_sparc.self
+        case .sparc64: return QEMUCPUHyperV_sparc64.self
+        case .tricore: return QEMUCPUHyperV_tricore.self
+        case .x86_64: return QEMUCPUHyperV_x86_64.self
+        case .xtensa: return QEMUCPUHyperV_xtensa.self
+        case .xtensaeb: return QEMUCPUHyperV_xtensaeb.self
+    }
+}
+
+    
     var targetType: any QEMUTarget.Type {
         switch self {
         case .alpha: return QEMUTarget_alpha.self

--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -211,6 +211,9 @@ import Foundation
         } else {
             f("-cpu")
             system.cpu
+            for enlightenment in system.cpuHyperV {
+                "\(enlightenment.rawValue)"
+            }
             for flag in system.cpuFlagsAdd {
                 "+\(flag.rawValue)"
             }

--- a/Configuration/UTMQemuConfigurationSystem.swift
+++ b/Configuration/UTMQemuConfigurationSystem.swift
@@ -27,6 +27,9 @@ struct UTMQemuConfigurationSystem: Codable {
     /// The QEMU CPU to emulate. Note that `default` will use the default CPU for the architecture.
     var cpu: any QEMUCPU = QEMUCPU_x86_64.default
     
+    /// Optional list of Hyper-V Enlightenments to enable on i386 & x86_64 CPUs.
+    var cpuHyperV: [any QEMUCPUHyperV] = []
+    
     /// Optional list of CPU flags to add to the target CPU.
     var cpuFlagsAdd: [any QEMUCPUFlag] = []
     
@@ -49,6 +52,7 @@ struct UTMQemuConfigurationSystem: Codable {
         case architecture = "Architecture"
         case target = "Target"
         case cpu = "CPU"
+        case cpuHyperV = "CPUHyperV"
         case cpuFlagsAdd = "CPUFlagsAdd"
         case cpuFlagsRemove = "CPUFlagsRemove"
         case cpuCount = "CPUCount"
@@ -65,6 +69,7 @@ struct UTMQemuConfigurationSystem: Codable {
         architecture = try values.decode(QEMUArchitecture.self, forKey: .architecture)
         target = try values.decode(architecture.targetType, forKey: .target)
         cpu = try values.decode(architecture.cpuType, forKey: .cpu)
+        cpuHyperV = try values.decode([AnyQEMUConstant].self, forKey: .cpuHyperV)
         cpuFlagsAdd = try values.decode([AnyQEMUConstant].self, forKey: .cpuFlagsAdd)
         cpuFlagsRemove = try values.decode([AnyQEMUConstant].self, forKey: .cpuFlagsRemove)
         cpuCount = try values.decode(Int.self, forKey: .cpuCount)
@@ -78,6 +83,7 @@ struct UTMQemuConfigurationSystem: Codable {
         try container.encode(architecture, forKey: .architecture)
         try container.encode(target.asAnyQEMUConstant(), forKey: .target)
         try container.encode(cpu.asAnyQEMUConstant(), forKey: .cpu)
+        try container.encode(cpuHyperV.map({ enlightenment in enlightenment.asAnyQEMUConstant() }), forKey: .cpuHyperV)
         try container.encode(cpuFlagsAdd.map({ flag in flag.asAnyQEMUConstant() }), forKey: .cpuFlagsAdd)
         try container.encode(cpuFlagsRemove.map({ flag in flag.asAnyQEMUConstant() }), forKey: .cpuFlagsRemove)
         try container.encode(cpuCount, forKey: .cpuCount)


### PR DESCRIPTION
I added some Hyper-V Enlightenments [1] to the UI. Non of them are active by default.

Enlightenments that require 'hv-vpindex' are omitted, since this enlightenment is currently not available on macOS.

Also, Enlightenments that are used for nesting e.g. 'hv-evmcs', or only change the Hyper-V Version ID 'hv_version-id-*' are omitted, as well.

Enlightenment 'hv-spinlocks' requires a parameter, currently 0x1fff is hardcoded since this seems to be a sane value. [2]

This commit partially addresses #4914 but also suffers from issue #4940.

Currently this only works for newly created VMs.

[1] https://www.qemu.org/docs/master/system/i386/hyperv.html
[2] https://leduccc.medium.com/improving-the-performance-of-a-windows-10-guest-on-qemu-a5b3f54d9cf5#c5b9