### PR TITLE
data: support sparse copy across volumes

### DIFF
--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -456,7 +456,7 @@ class UTMData: ObservableObject {
         let newName: String = newDefaultVMName(base: vm.detailsTitleLabel)
         let newPath = UTMVirtualMachine.virtualMachinePath(newName, inParentURL: documentsURL)
         
-        try fileManager.copyItem(at: vm.path, to: newPath)
+        try copyItemWithCopyfile(at: vm.path, to: newPath)
         guard let newVM = UTMVirtualMachine(url: newPath) else {
             throw NSLocalizedString("Failed to clone VM.", comment: "UTMData")
         }
@@ -479,7 +479,7 @@ class UTMData: ObservableObject {
         if fileManager.fileExists(atPath: url.path) {
             try fileManager.removeItem(at: url)
         }
-        try fileManager.copyItem(at: sourceUrl, to: url)
+        try copyItemWithCopyfile(at: sourceUrl, to: url)
     }
     
     /// Save a copy of the VM and all data to arbitary location and delete the original data
@@ -626,6 +626,15 @@ class UTMData: ObservableObject {
         }
         await listAdd(vm: vm)
         await listSelect(vm: vm)
+    }
+
+    func copyItemWithCopyfile(at srcURL: URL, to dstURL: URL) throws {
+//        let state = copyfile_state_alloc()
+        let status = copyfile(srcURL.path, dstURL.path, nil, copyfile_flags_t(COPYFILE_ALL | COPYFILE_RECURSIVE | COPYFILE_CLONE | COPYFILE_DATA_SPARSE))
+//        copyfile_state_free(state)
+        if status < 0 {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
     }
     
     // MARK: - Downloading VMs


### PR DESCRIPTION
Use `copyfile(3)` with `COPYFILE_DATA_SPARSE` flag which attempts to preserve sparseness when copying across different volumes, which `FileManger.copyItem(at:, to:)` doesn't. Cloning behaviour from `FileManger.copyItem(at:, to:)` is preserved with the `COPYFILE_CLONE` flag.

@osy I don't have the hardware to test this on iOS/iPadOS, could you please help me to test it? In theory it should Just Work.
Also, please see my message in the DIscord's #general about whether the sparse copy is needed for importing drives.

~~Also, I'm not sure if the alloc and free of `copyfile_state_t` is necessary, some code has it and some don't. It seems to work the same either way.~~ Edit: According to the manpage, it can be `NULL`/`nil`:

If the state parameter is the return value from copyfile_state_alloc(), then copyfile() and fcopyfile() will use the information from the state object; if it is NULL, then both functions will work normally, but less control will be available to the caller.