### PR TITLE
vm(apple): support dynamic display resolution

### DIFF
--- a/Configuration/UTMAppleConfigurationDisplay.swift
+++ b/Configuration/UTMAppleConfigurationDisplay.swift
@@ -27,21 +27,25 @@ struct UTMAppleConfigurationDisplay: Codable, Identifiable {
     
     var pixelsPerInch: Int = 80
     
+    var isDynamicResolution: Bool = true
+
     let id = UUID()
     
     enum CodingKeys: String, CodingKey {
         case widthInPixels = "WidthPixels"
         case heightInPixels = "HeightPixels"
         case pixelsPerInch = "PixelsPerInch"
+        case isDynamicResolution = "DynamicResolution"
     }
     
     init() {
     }
     
-    init(width: Int, height: Int, ppi: Int = 80) {
+    init(width: Int, height: Int, ppi: Int = 80, dynamicResolution: Bool = true) {
         widthInPixels = width
         heightInPixels = height
         pixelsPerInch = ppi
+        isDynamicResolution = dynamicResolution
     }
     
     init(from decoder: Decoder) throws {
@@ -49,6 +53,7 @@ struct UTMAppleConfigurationDisplay: Codable, Identifiable {
         widthInPixels = try values.decode(Int.self, forKey: .widthInPixels)
         heightInPixels = try values.decode(Int.self, forKey: .heightInPixels)
         pixelsPerInch = try values.decode(Int.self, forKey: .pixelsPerInch)
+        isDynamicResolution = try values.decodeIfPresent(Bool.self, forKey: .isDynamicResolution) ?? false
     }
     
     func encode(to encoder: Encoder) throws {
@@ -56,6 +61,7 @@ struct UTMAppleConfigurationDisplay: Codable, Identifiable {
         try container.encode(widthInPixels, forKey: .widthInPixels)
         try container.encode(heightInPixels, forKey: .heightInPixels)
         try container.encode(pixelsPerInch, forKey: .pixelsPerInch)
+        try container.encode(isDynamicResolution, forKey: .isDynamicResolution)
     }
     
     #if arch(arm64)

--- a/Platform/macOS/Display/VMDisplayAppleDisplayWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayAppleDisplayWindowController.swift
@@ -54,6 +54,9 @@ class VMDisplayAppleDisplayWindowController: VMDisplayAppleWindowController {
         guard let primaryDisplay = appleConfig.displays.first else {
             return //FIXME: add multiple displays
         }
+        if #available(macOS 14.0, *) {
+            appleView.automaticallyReconfiguresDisplay = primaryDisplay.isDynamicResolution
+        }
         let size = windowSize(for: primaryDisplay)
         let frame = window.frameRect(forContentRect: CGRect(origin: window.frame.origin, size: size))
         window.contentAspectRatio = size

--- a/Platform/macOS/VMConfigAppleDisplayView.swift
+++ b/Platform/macOS/VMConfigAppleDisplayView.swift
@@ -149,6 +149,14 @@ struct VMConfigAppleDisplayView: View {
         }
     }
     
+    private var isDynamicResolution: Binding<Bool> {
+        Binding<Bool> {
+            return config.isDynamicResolution
+        } set: { newValue in
+            config.isDynamicResolution = newValue
+        }
+    }
+
     var body: some View {
         Form {
             Picker("Resolution", selection: displayResolution) {
@@ -156,13 +164,15 @@ struct VMConfigAppleDisplayView: View {
                     Text(item.name)
                         .tag(item)
                 }
-            }
+            }.disabled(isDynamicResolution.wrappedValue)
             if displayResolution.wrappedValue == customResolution {
                 NumberTextField("Width", number: $config.widthInPixels)
                 NumberTextField("Height", number: $config.heightInPixels)
             }
             Toggle("HiDPI (Retina)", isOn: isHidpi)
                 .help("Only available on macOS virtual machines.")
+            Toggle("Dynamic Resolution", isOn: isDynamicResolution)
+                .help("Autoscale display resolution to window.")
         }
     }
 }


### PR DESCRIPTION
Support dynamic display resolution in UTM via support within Virtualization Framework. This is supported from MacOS sonoma onward.

Fixes #5421

This is the first time fiddling around with Swift for me. Please let me know if I totally screwed something up or if this does not align with the project itself. I will try to update the PR to meet the project standards.