### PR TITLE
Fix call of usage when packing dependencies for one architecture only

### DIFF
--- a/scripts/pack_dependencies.sh
+++ b/scripts/pack_dependencies.sh
@@ -11,7 +11,7 @@ usage () {
     exit 1
 }
 
-if [ $# -lt 4 ]; then
+if [ $# -lt 3 ]; then
     usage
 fi
 


### PR DESCRIPTION
The doc stated to run `./scripts/pack_dependencies.sh . macos arm64 x86_64` to pack dependencies for universal binaries.

However, if you just want to build it for running it locally with the command `./scripts/pack_dependencies.sh . macOS arm64`, the `usage()` method will get called.

This fix let you pack dependencies for one architecture only.