### PR TITLE
Add SwiftLint

### DIFF
--- a/.github/workflows/swiftlint.yml
+++ b/.github/workflows/swiftlint.yml
@@ -1,0 +1,16 @@
+name: SwiftLint
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  SwiftLint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,2 @@
+opt_in_rules:
+  - force_unwrapping

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -2,6 +2,8 @@ disabled_rules:
   - identifier_name
   - type_name
   - file_length
+  - type_body_length
+  - line_length
 
 excluded:
   - .build

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,2 +1,7 @@
-opt_in_rules:
-  - force_unwrapping
+disabled_rules:
+  - identifier_name
+  - type_name
+  - file_length
+
+excluded:
+  - .build

--- a/Configuration/Legacy/UTMLegacyAppleConfiguration.swift
+++ b/Configuration/Legacy/UTMLegacyAppleConfiguration.swift
@@ -20,39 +20,39 @@ import Foundation
 @available(macOS 11, *)
 final class UTMLegacyAppleConfiguration: Codable {
     private let currentVersion = 3
-    
+
     var version: Int
-    
+
     var isAppleVirtualization: Bool
-    
+
     var name: String
-    
+
     var architecture: String
-    
+
     var iconBasePath: URL?
-    
+
     var selectedCustomIconPath: URL?
-    
+
     var icon: String?
-    
+
     var iconCustom: Bool
-    
+
     var notes: String?
-    
+
     var consoleTheme: String?
-    
+
     var consoleTextColor: String?
-    
+
     var consoleBackgroundColor: String?
-    
+
     var consoleFont: String?
-    
+
     var consoleFontSize: NSNumber?
-    
+
     var consoleCursorBlink: Bool
-    
+
     var consoleResizeCommand: String?
-    
+
     var iconUrl: URL? {
         if self.iconCustom {
             if let current = self.selectedCustomIconPath {
@@ -72,39 +72,39 @@ final class UTMLegacyAppleConfiguration: Codable {
             return Bundle.main.url(forResource: icon, withExtension: "png", subdirectory: "Icons")
         }
     }
-    
+
     var cpuCount: Int
-    
+
     var memorySize: UInt64
-    
+
     var bootLoader: Bootloader?
-    
+
     var macPlatform: MacPlatform?
-    
+
     var macRecoveryIpswURL: URL?
-    
+
     var networkDevices: [Network]
-    
+
     var displays: [Display]
-    
+
     var diskImages: [DiskImage] = []
-    
+
     var sharedDirectories: [SharedDirectory] = []
-    
+
     var isAudioEnabled: Bool
-    
+
     var isBalloonEnabled: Bool
-    
+
     var isEntropyEnabled: Bool
-    
+
     var isSerialEnabled: Bool
-    
+
     var isConsoleDisplay: Bool
-    
+
     var isKeyboardEnabled: Bool
-    
+
     var isPointingEnabled: Bool
-    
+
     enum CodingKeys: String, CodingKey {
         case version
         case isAppleVirtualization
@@ -135,7 +135,7 @@ final class UTMLegacyAppleConfiguration: Codable {
         case isKeyboardEnabled
         case isPointingEnabled
     }
-    
+
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         version = try values.decodeIfPresent(Int.self, forKey: .version) ?? 0
@@ -174,7 +174,7 @@ final class UTMLegacyAppleConfiguration: Codable {
         consoleCursorBlink = try values.decode(Bool.self, forKey: .consoleCursorBlink)
         consoleResizeCommand = try values.decodeIfPresent(String.self, forKey: .consoleResizeCommand)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(version, forKey: .version)
@@ -220,19 +220,19 @@ struct Bootloader: Codable {
         case Linux
         case macOS
     }
-    
+
     var operatingSystem: OperatingSystem
     var linuxKernelURL: URL?
     var linuxCommandLine: String?
     var linuxInitialRamdiskURL: URL?
-    
+
     private enum CodingKeys: String, CodingKey {
         case operatingSystem
         case linuxKernelPath
         case linuxCommandLine
         case linuxInitialRamdiskPath
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -247,7 +247,7 @@ struct Bootloader: Codable {
             linuxInitialRamdiskURL = dataURL.appendingPathComponent(linuxInitialRamdiskPath)
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(operatingSystem, forKey: .operatingSystem)
@@ -265,7 +265,7 @@ struct Network: Codable {
         case Shared
         case Bridged
     }
-    
+
     var networkMode: NetworkMode
     var bridgeInterfaceIdentifier: String?
     var macAddress: String
@@ -281,13 +281,13 @@ struct MacPlatform: Codable {
     var hardwareModel: Data
     var machineIdentifier: Data
     var auxiliaryStorageURL: URL?
-    
+
     private enum CodingKeys: String, CodingKey {
         case hardwareModel
         case machineIdentifier
         case auxiliaryStoragePath
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -299,7 +299,7 @@ struct MacPlatform: Codable {
             auxiliaryStorageURL = dataURL.appendingPathComponent(auxiliaryStoragePath)
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hardwareModel, forKey: .hardwareModel)
@@ -310,13 +310,13 @@ struct MacPlatform: Codable {
 
 struct DiskImage: Codable, Hashable, Identifiable {
     private let bytesInMib = 1048576
-    
+
     var sizeMib: Int
     var isReadOnly: Bool
     var isExternal: Bool
     var imageURL: URL?
     private var uuid = UUID() // for identifiable
-    
+
     private enum CodingKeys: String, CodingKey {
         case sizeMib
         case isReadOnly
@@ -324,19 +324,19 @@ struct DiskImage: Codable, Hashable, Identifiable {
         case imagePath
         case imageBookmark
     }
-    
+
     var id: Int {
         hashValue
     }
-    
+
     var sizeBytes: Int64 {
         Int64(sizeMib) * Int64(bytesInMib)
     }
-    
+
     var sizeString: String {
         ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .file)
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -352,7 +352,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
             imageURL = try? URL(resolvingBookmarkData: bookmark, options: .withSecurityScope, bookmarkDataIsStale: &stale)
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(sizeMib, forKey: .sizeMib)
@@ -373,7 +373,7 @@ struct DiskImage: Codable, Hashable, Identifiable {
             try container.encodeIfPresent(bookmark, forKey: .imageBookmark)
         }
     }
-    
+
     func hash(into hasher: inout Hasher) {
         if let imageURL = imageURL {
             imageURL.lastPathComponent.hash(into: &hasher)
@@ -386,16 +386,16 @@ struct DiskImage: Codable, Hashable, Identifiable {
 struct SharedDirectory: Codable, Hashable, Identifiable {
     var directoryURL: URL?
     var isReadOnly: Bool
-    
+
     var id: SharedDirectory {
         self
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case directoryBookmark
         case isReadOnly
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         isReadOnly = try container.decode(Bool.self, forKey: .isReadOnly)
@@ -403,7 +403,7 @@ struct SharedDirectory: Codable, Hashable, Identifiable {
         var stale: Bool = false
         directoryURL = try? URL(resolvingBookmarkData: bookmark, options: .withSecurityScope, bookmarkDataIsStale: &stale)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(isReadOnly, forKey: .isReadOnly)
@@ -418,7 +418,7 @@ struct SharedDirectory: Codable, Hashable, Identifiable {
         let bookmark = try directoryURL?.bookmarkData(options: options)
         try container.encodeIfPresent(bookmark, forKey: .directoryBookmark)
     }
-    
+
     func hash(into hasher: inout Hasher) {
         directoryURL.hash(into: &hasher)
     }

--- a/Configuration/QEMUArgument.swift
+++ b/Configuration/QEMUArgument.swift
@@ -19,29 +19,29 @@ import Foundation
 struct QEMUArgument: Hashable, Identifiable, Codable {
     /// Argument string passed to QEMU
     var string: String
-    
+
     /// Optional URL resource that must be accessed
     var fileUrls: [URL]?
-    
+
     let id = UUID()
-    
+
     init(_ string: String) {
         self.string = string
     }
-    
+
     init(from fragment: QEMUArgumentFragment) {
         string = fragment.string
         fileUrls = fragment.fileUrls
     }
-    
+
     init(from decoder: Decoder) throws {
         string = try String(from: decoder)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         try string.encode(to: encoder)
     }
-    
+
     func hash(into hasher: inout Hasher) {
         id.hash(into: &hasher)
     }
@@ -50,38 +50,38 @@ struct QEMUArgument: Hashable, Identifiable, Codable {
 struct QEMUArgumentFragment: Hashable {
     /// String representing this fragment
     var string: String
-    
+
     /// Optional URL resource(s) that must be accessed
     var fileUrls: [URL]?
-    
+
     /// If false, this fragment will be merged with the preceding one
     var isFinal: Bool
-    
+
     /// Separate the previous fragment if non-empty
     var seperator: String = ","
-    
+
     init(_ fragment: String = "") {
         string = fragment
         isFinal = false
     }
-    
+
     init(final fragment: String) {
         string = fragment
         isFinal = true
     }
-    
+
     init(from argument: QEMUArgument) {
         string = argument.string
         fileUrls = argument.fileUrls
         isFinal = true
     }
-    
+
     func hash(into hasher: inout Hasher) {
         string.hash(into: &hasher)
         fileUrls?.hash(into: &hasher)
         isFinal.hash(into: &hasher)
     }
-    
+
     mutating func merge(_ other: QEMUArgumentFragment) {
         if self.string.count > 0 && other.string.count > 0 {
             self.string += other.seperator

--- a/Configuration/QEMUArgumentBuilder.swift
+++ b/Configuration/QEMUArgumentBuilder.swift
@@ -34,58 +34,58 @@ struct QEMUArgumentBuilder {
         }
         return combined
     }
-    
+
     static func buildExpression(_ fragment: QEMUArgumentFragment) -> [QEMUArgumentFragment] {
         [fragment]
     }
-    
+
     static func buildExpression(_ fragments: [QEMUArgumentFragment]) -> [QEMUArgumentFragment] {
         fragments
     }
-    
+
     static func buildExpression(_ arguments: [QEMUArgument]) -> [QEMUArgumentFragment] {
         arguments.map { QEMUArgumentFragment(from: $0) }
     }
-    
+
     static func buildExpression(_ string: String) -> [QEMUArgumentFragment] {
         [.init(string)]
     }
-    
+
     static func buildExpression(_ constant: any QEMUConstant) -> [QEMUArgumentFragment] {
         [.init(constant.rawValue)]
     }
-    
+
     static func buildExpression(_ assignment: ()) -> [QEMUArgumentFragment] {
         []
     }
-    
+
     static func buildExpression(_ url: URL) -> [QEMUArgumentFragment] {
         var arg = QEMUArgumentFragment(url.path)
         arg.fileUrls = [url]
         arg.seperator = ""
         return [arg]
     }
-    
+
     static func buildExpression<I: FixedWidthInteger>(_ int: I) -> [QEMUArgumentFragment] {
         [.init("\(int)")]
     }
-    
+
     static func buildEither(first component: [QEMUArgumentFragment]) -> [QEMUArgumentFragment] {
         component
     }
-    
+
     static func buildEither(second component: [QEMUArgumentFragment]) -> [QEMUArgumentFragment] {
         component
     }
-    
+
     static func buildArray(_ components: [[QEMUArgumentFragment]]) -> [QEMUArgumentFragment] {
         components.flatMap { $0 }
     }
-    
+
     static func buildOptional(_ component: [QEMUArgumentFragment]?) -> [QEMUArgumentFragment] {
         component ?? []
     }
-    
+
     static func buildFinalResult(_ component: [QEMUArgumentFragment]) -> [QEMUArgument] {
         component.map { QEMUArgument(from: $0) }
     }

--- a/Configuration/QEMUConstant.swift
+++ b/Configuration/QEMUConstant.swift
@@ -25,7 +25,7 @@ protocol QEMUConstant: Codable, RawRepresentable, CaseIterable where RawValue ==
     static var allPrettyValues: [String] { get }
     var prettyValue: String { get }
     var rawValue: String { get }
-    
+
     init?(rawValue: String)
 }
 
@@ -33,7 +33,7 @@ extension QEMUConstant where Self: CaseIterable, AllCases == [Self] {
     static var allRawValues: [String] {
         allCases.map { value in value.rawValue }
     }
-    
+
     static var allPrettyValues: [String] {
         allCases.map { value in value.prettyValue }
     }
@@ -47,7 +47,7 @@ extension QEMUConstant where Self: RawRepresentable, RawValue == String {
         }
         self = representedValue
     }
-    
+
     func encode(to encoder: Encoder) throws {
         try rawValue.encode(to: encoder)
     }
@@ -66,7 +66,7 @@ extension Optional where Wrapped: QEMUDefaultConstant {
             self = newValue
         }
     }
-    
+
     var bound: Wrapped {
         get {
             return _bound ?? Wrapped.default
@@ -80,19 +80,19 @@ extension Optional where Wrapped: QEMUDefaultConstant {
 /// Type erasure for a QEMU constant useful for serialization/deserialization
 struct AnyQEMUConstant: QEMUConstant, RawRepresentable {
     static var allRawValues: [String] { [] }
-    
+
     static var allPrettyValues: [String] { [] }
-    
+
     static var allCases: [AnyQEMUConstant] { [] }
-    
+
     var prettyValue: String { rawValue }
-    
+
     let rawValue: String
-    
-    init<C>(_ base: C) where C : QEMUConstant {
+
+    init<C>(_ base: C) where C: QEMUConstant {
         self.rawValue = base.rawValue
     }
-    
+
     init?(rawValue: String) {
         self.rawValue = rawValue
     }
@@ -145,14 +145,14 @@ extension AnyQEMUConstant: QEMUSerialDevice {}
 enum QEMUScaler: String, CaseIterable, QEMUConstant {
     case linear = "Linear"
     case nearest = "Nearest"
-    
+
     var prettyValue: String {
         switch self {
         case .linear: return NSLocalizedString("Linear", comment: "UTMQemuConstants")
         case .nearest: return NSLocalizedString("Nearest Neighbor", comment: "UTMQemuConstants")
         }
     }
-    
+
     var metalSamplerMinMagFilter: MTLSamplerMinMagFilter {
         switch self {
         case .linear: return .linear
@@ -167,7 +167,7 @@ enum QEMUUSBBus: String, CaseIterable, QEMUConstant {
     case disabled = "Disabled"
     case usb2_0 = "2.0"
     case usb3_0 = "3.0"
-    
+
     var prettyValue: String {
         switch self {
         case .disabled: return NSLocalizedString("Disabled", comment: "UTMQemuConstants")
@@ -184,7 +184,7 @@ enum QEMUNetworkMode: String, CaseIterable, QEMUConstant {
     case shared = "Shared"
     case host = "Host"
     case bridged = "Bridged"
-    
+
     var prettyValue: String {
         switch self {
         case .emulated: return NSLocalizedString("Emulated VLAN", comment: "UTMQemuConstants")
@@ -198,7 +198,7 @@ enum QEMUNetworkMode: String, CaseIterable, QEMUConstant {
 enum QEMUNetworkProtocol: String, CaseIterable, QEMUConstant {
     case tcp = "TCP"
     case udp = "UDP"
-    
+
     var prettyValue: String {
         switch self {
         case .tcp: return NSLocalizedString("TCP", comment: "UTMQemuConstants")
@@ -211,7 +211,7 @@ enum QEMUNetworkProtocol: String, CaseIterable, QEMUConstant {
 
 enum QEMUTerminalTheme: String, CaseIterable, QEMUDefaultConstant {
     case `default` = "Default"
-    
+
     var prettyValue: String {
         switch self {
         case .`default`: return NSLocalizedString("Default", comment: "UTMQemuConstants")
@@ -224,7 +224,7 @@ struct QEMUTerminalFont: QEMUConstant {
     static var allRawValues: [String] = {
         NSFontManager.shared.availableFontNames(with: .fixedPitchFontMask) ?? []
     }()
-    
+
     static var allPrettyValues: [String] = {
         allRawValues.map { name in
             NSFont(name: name, size: 1)?.displayName ?? name
@@ -243,7 +243,7 @@ struct QEMUTerminalFont: QEMUConstant {
             }
         }
     }()
-    
+
     static var allPrettyValues: [String] = {
         allRawValues.map { name in
             guard let font = UIFont(name: name, size: 1) else {
@@ -264,18 +264,18 @@ struct QEMUTerminalFont: QEMUConstant {
         }
     }()
     #endif
-    
+
     static var allCases: [QEMUTerminalFont] {
         Self.allRawValues.map { Self(rawValue: $0) }
     }
-    
+
     var prettyValue: String {
         guard let index = Self.allRawValues.firstIndex(of: rawValue) else {
             return rawValue
         }
         return Self.allPrettyValues[index]
     }
-    
+
     let rawValue: String
 }
 
@@ -286,7 +286,7 @@ enum QEMUSerialMode: String, CaseIterable, QEMUConstant {
     #if os(macOS)
     case ptty = "Ptty"
     #endif
-    
+
     var prettyValue: String {
         switch self {
         case .builtin: return NSLocalizedString("Built-in Terminal", comment: "UTMQemuConstants")
@@ -304,7 +304,7 @@ enum QEMUSerialTarget: String, CaseIterable, QEMUConstant {
     case manualDevice = "Manual"
     case gdb = "GDB"
     case monitor = "Monitor"
-    
+
     var prettyValue: String {
         switch self {
         case .autoDevice: return NSLocalizedString("Automatic Serial Device (max 4)", comment: "UTMQemuConstants")
@@ -325,7 +325,7 @@ enum QEMUDriveImageType: String, CaseIterable, QEMUConstant {
     case linuxKernel = "LinuxKernel"
     case linuxInitrd = "LinuxInitrd"
     case linuxDtb = "LinuxDTB"
-    
+
     var prettyValue: String {
         switch self {
         case .none: return NSLocalizedString("None", comment: "UTMQemuConstants")
@@ -350,7 +350,7 @@ enum QEMUDriveInterface: String, CaseIterable, QEMUConstant {
     case virtio = "VirtIO"
     case nvme = "NVMe"
     case usb = "USB"
-    
+
     var prettyValue: String {
         switch self {
         case .none: return NSLocalizedString("None (Advanced)", comment: "UTMQemuConstants")
@@ -373,7 +373,7 @@ enum QEMUFileShareMode: String, CaseIterable, QEMUConstant {
     case none = "None"
     case webdav = "WebDAV"
     case virtfs = "VirtFS"
-    
+
     var prettyValue: String {
         switch self {
         case .none: return NSLocalizedString("None", comment: "UTMQemuConstants")
@@ -409,14 +409,14 @@ extension QEMUArchitecture {
         default: return true
         }
     }
-    
+
     var hasSharingSupport: Bool {
         switch self {
         case .sparc, .sparc64: return false
         default: return true
         }
     }
-    
+
     var hasUsbSupport: Bool {
         switch self {
         case .s390x: return false
@@ -424,7 +424,7 @@ extension QEMUArchitecture {
         default: return true
         }
     }
-    
+
     var hasHypervisorSupport: Bool {
         guard jb_has_hypervisor() else {
             return false
@@ -437,7 +437,7 @@ extension QEMUArchitecture {
         return false
         #endif
     }
-    
+
     /// TSO is supported on jailbroken iOS devices with Hypervisor support
     var hasTSOSupport: Bool {
         #if os(iOS) || os(visionOS)
@@ -446,7 +446,7 @@ extension QEMUArchitecture {
         return false
         #endif
     }
-    
+
     var hasSecureBootSupport: Bool {
         switch self {
         case .x86_64, .i386: return true
@@ -463,14 +463,14 @@ extension QEMUTarget {
         default: return true
         }
     }
-    
+
     var hasAgentSupport: Bool {
         switch self.rawValue {
         case "isapc": return false
         default: return true
         }
     }
-    
+
     var hasSecureBootSupport: Bool {
         switch self.rawValue {
         case "microvm": return false

--- a/Configuration/QEMUConstantGenerated.swift
+++ b/Configuration/QEMUConstantGenerated.swift
@@ -10274,5 +10274,3 @@ extension QEMUArchitecture {
     }
 
 }
-
-

--- a/Configuration/QEMUConstantGenerated.swift
+++ b/Configuration/QEMUConstantGenerated.swift
@@ -10272,5 +10272,4 @@ extension QEMUArchitecture {
         case .xtensaeb: return QEMUSerialDevice_xtensaeb.self
         }
     }
-
 }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -22,25 +22,25 @@ import Virtualization
 final class UTMAppleConfiguration: UTMConfiguration {
     /// Basic information and icon
     @Published var _information: UTMConfigurationInfo = .init()
-    
+
     @Published private var _system: UTMAppleConfigurationSystem = .init()
-    
+
     @Published private var _virtualization: UTMAppleConfigurationVirtualization = .init()
-    
+
     @Published private var _sharedDirectories: [UTMAppleConfigurationSharedDirectory] = []
-    
+
     @Published private var _displays: [UTMAppleConfigurationDisplay] = []
-    
+
     @Published private var _drives: [UTMAppleConfigurationDrive] = []
-    
+
     @Published private var _networks: [UTMAppleConfigurationNetwork] = [.init()]
-    
+
     @Published private var _serials: [UTMAppleConfigurationSerial] = []
-    
+
     var backend: UTMBackend {
         .apple
     }
-    
+
     enum CodingKeys: String, CodingKey {
         case information = "Information"
         case system = "System"
@@ -53,10 +53,10 @@ final class UTMAppleConfiguration: UTMConfiguration {
         case backend = "Backend"
         case configurationVersion = "ConfigurationVersion"
     }
-    
+
     init() {
     }
-    
+
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         let backend = try values.decodeIfPresent(UTMBackend.self, forKey: .backend) ?? .unknown
@@ -79,7 +79,7 @@ final class UTMAppleConfiguration: UTMConfiguration {
         _networks = try values.decode([UTMAppleConfigurationNetwork].self, forKey: .networks)
         _serials = try values.decode([UTMAppleConfigurationSerial].self, forKey: .serials)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(_information, forKey: .information)
@@ -129,83 +129,81 @@ extension UTMAppleConfigurationError: LocalizedError {
         get {
             _information
         }
-        
+
         set {
             _information = newValue
         }
     }
-    
+
     var system: UTMAppleConfigurationSystem {
         get {
             _system
         }
-        
+
         set {
             _system = newValue
         }
     }
-    
+
     var virtualization: UTMAppleConfigurationVirtualization {
         get {
             _virtualization
         }
-        
+
         set {
             _virtualization = newValue
         }
     }
-    
+
     var sharedDirectories: [UTMAppleConfigurationSharedDirectory] {
         get {
             _sharedDirectories
         }
-        
+
         set {
             _sharedDirectories = newValue
         }
     }
-    
+
     var sharedDirectoriesPublisher: Published<[UTMAppleConfigurationSharedDirectory]>.Publisher {
-        get {
-            $_sharedDirectories
-        }
+        $_sharedDirectories
     }
-    
+
     var displays: [UTMAppleConfigurationDisplay] {
         get {
             _displays
         }
-        
+
         set {
             _displays = newValue
         }
     }
-    
+
     var drives: [UTMAppleConfigurationDrive] {
         get {
             _drives
         }
-        
+
         set {
             _drives = newValue
         }
     }
-    
+
     var networks: [UTMAppleConfigurationNetwork] {
         get {
             _networks
         }
-        
+
         set {
             _networks = newValue
         }
     }
-    
+
     var serials: [UTMAppleConfigurationSerial] {
         get {
             _serials
         }
-        
+
         set {
             _serials = newValue
         }

--- a/Configuration/UTMAppleConfiguration.swift
+++ b/Configuration/UTMAppleConfiguration.swift
@@ -311,12 +311,12 @@ extension UTMAppleConfiguration {
     func prepareSave(for packageURL: URL) async throws {
         try await virtualization.prepareSave(for: packageURL)
     }
-    
+
     func saveData(to dataURL: URL) async throws -> [URL] {
         var existingDataURLs = [URL]()
         existingDataURLs += try await _information.saveData(to: dataURL)
         existingDataURLs += try await _system.boot.saveData(to: dataURL)
-        
+
         #if arch(arm64)
         if #available(macOS 12, *), system.macPlatform != nil {
             existingDataURLs += try await _system.macPlatform!.saveData(to: dataURL)
@@ -329,7 +329,7 @@ extension UTMAppleConfiguration {
         for i in 0..<drives.count {
             existingDataURLs += try await _drives[i].saveData(to: dataURL)
         }
-        
+
         return existingDataURLs
     }
 }

--- a/Configuration/UTMAppleConfigurationBoot.swift
+++ b/Configuration/UTMAppleConfigurationBoot.swift
@@ -24,7 +24,7 @@ struct UTMAppleConfigurationBoot: Codable {
         case none = "None"
         case linux = "Linux"
         case macOS = "macOS"
-        
+
         var prettyValue: String {
             switch self {
             case .none: return NSLocalizedString("None", comment: "UTMAppleConfigurationBoot")
@@ -33,7 +33,7 @@ struct UTMAppleConfigurationBoot: Codable {
             }
         }
     }
-    
+
     var operatingSystem: OperatingSystem
     var linuxKernelURL: URL?
     var linuxCommandLine: String?
@@ -41,10 +41,10 @@ struct UTMAppleConfigurationBoot: Codable {
     var efiVariableStorageURL: URL?
     var vmSavedStateURL: URL?
     var hasUefiBoot: Bool = false
-    
+
     /// IPSW for installing macOS. Not saved.
     var macRecoveryIpswURL: URL?
-    
+
     private enum CodingKeys: String, CodingKey {
         case operatingSystem = "OperatingSystem"
         case linuxKernelPath = "LinuxKernelPath"
@@ -53,7 +53,7 @@ struct UTMAppleConfigurationBoot: Codable {
         case efiVariableStoragePath = "EfiVariableStoragePath"
         case hasUefiBoot = "UEFIBoot"
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -81,7 +81,7 @@ struct UTMAppleConfigurationBoot: Codable {
         }
         vmSavedStateURL = dataURL.appendingPathComponent(QEMUPackageFileName.vmState.rawValue)
     }
-    
+
     init(for operatingSystem: OperatingSystem, linuxKernelURL: URL? = nil) throws {
         self.operatingSystem = operatingSystem
         self.linuxKernelURL = linuxKernelURL
@@ -89,14 +89,14 @@ struct UTMAppleConfigurationBoot: Codable {
             self.hasUefiBoot = true
         }
     }
-    
+
     init(from linux: VZLinuxBootLoader) {
         self.operatingSystem = .linux
         self.linuxKernelURL = linux.kernelURL
         self.linuxCommandLine = linux.commandLine
         self.linuxInitialRamdiskURL = linux.initialRamdiskURL
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(operatingSystem, forKey: .operatingSystem)
@@ -108,7 +108,7 @@ struct UTMAppleConfigurationBoot: Codable {
             try container.encodeIfPresent(efiVariableStorageURL?.lastPathComponent, forKey: .efiVariableStoragePath)
         }
     }
-    
+
     func vzBootloader() -> VZBootLoader? {
         switch operatingSystem {
         case .none:

--- a/Configuration/UTMAppleConfigurationDisplay.swift
+++ b/Configuration/UTMAppleConfigurationDisplay.swift
@@ -20,44 +20,44 @@ import Virtualization
 @available(iOS, unavailable, message: "Apple Virtualization not available on iOS")
 @available(macOS 11, *)
 struct UTMAppleConfigurationDisplay: Codable, Identifiable {
-    
+
     var widthInPixels: Int = 1920
-    
+
     var heightInPixels: Int = 1200
-    
+
     var pixelsPerInch: Int = 80
-    
+
     let id = UUID()
-    
+
     enum CodingKeys: String, CodingKey {
         case widthInPixels = "WidthPixels"
         case heightInPixels = "HeightPixels"
         case pixelsPerInch = "PixelsPerInch"
     }
-    
+
     init() {
     }
-    
+
     init(width: Int, height: Int, ppi: Int = 80) {
         widthInPixels = width
         heightInPixels = height
         pixelsPerInch = ppi
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         widthInPixels = try values.decode(Int.self, forKey: .widthInPixels)
         heightInPixels = try values.decode(Int.self, forKey: .heightInPixels)
         pixelsPerInch = try values.decode(Int.self, forKey: .pixelsPerInch)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(widthInPixels, forKey: .widthInPixels)
         try container.encode(heightInPixels, forKey: .heightInPixels)
         try container.encode(pixelsPerInch, forKey: .pixelsPerInch)
     }
-    
+
     #if arch(arm64)
     @available(macOS 12, *)
     init(from config: VZMacGraphicsDisplayConfiguration) {
@@ -65,7 +65,7 @@ struct UTMAppleConfigurationDisplay: Codable, Identifiable {
         heightInPixels = config.heightInPixels
         pixelsPerInch = config.pixelsPerInch
     }
-    
+
     @available(macOS 12, *)
     func vzMacDisplay() -> VZMacGraphicsDisplayConfiguration {
         VZMacGraphicsDisplayConfiguration(widthInPixels: widthInPixels,
@@ -73,7 +73,7 @@ struct UTMAppleConfigurationDisplay: Codable, Identifiable {
                                           pixelsPerInch: pixelsPerInch)
     }
     #endif
-    
+
     @available(macOS 13, *)
     func vzVirtioDisplay() -> VZVirtioGraphicsScanoutConfiguration {
         VZVirtioGraphicsScanoutConfiguration(widthInPixels: widthInPixels,

--- a/Configuration/UTMAppleConfigurationDrive.swift
+++ b/Configuration/UTMAppleConfigurationDrive.swift
@@ -21,26 +21,26 @@ import Virtualization
 @available(macOS 11, *)
 struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
     private let bytesInMib = 1048576
-    
+
     var sizeMib: Int = 0
     var isReadOnly: Bool
     var isExternal: Bool
     var imageURL: URL?
     var imageName: String?
-    
+
     private(set) var id = UUID().uuidString
-    
+
     var isRawImage: Bool {
         true // always true for Apple VMs
     }
-    
+
     private enum CodingKeys: String, CodingKey {
         case isReadOnly = "ReadOnly"
         case imageName = "ImageName"
         case bookmark = "Bookmark" // legacy only
         case identifier = "Identifier"
     }
-    
+
     var sizeString: String {
         let sizeBytes: Int64
         if let attributes = try? imageURL?.resourceValues(forKeys: [.fileSizeKey]), let fileSize = attributes.fileSize {
@@ -50,19 +50,19 @@ struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
         }
         return ByteCountFormatter.string(fromByteCount: sizeBytes, countStyle: .binary)
     }
-    
+
     init(newSize: Int) {
         sizeMib = newSize
         isReadOnly = false
         isExternal = false
     }
-    
+
     init(existingURL url: URL?, isExternal: Bool = false) {
         self.imageURL = url
         self.isReadOnly = isExternal
         self.isExternal = isExternal
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -85,7 +85,7 @@ struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
         isReadOnly = try container.decodeIfPresent(Bool.self, forKey: .isReadOnly) ?? isExternal
         id = try container.decode(String.self, forKey: .identifier)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if !isExternal {
@@ -94,7 +94,7 @@ struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
         try container.encode(isReadOnly, forKey: .isReadOnly)
         try container.encode(id, forKey: .identifier)
     }
-    
+
     func vzDiskImage() throws -> VZDiskImageStorageDeviceAttachment? {
         if let imageURL = imageURL {
             return try VZDiskImageStorageDeviceAttachment(url: imageURL, readOnly: isReadOnly)
@@ -102,7 +102,7 @@ struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
             return nil
         }
     }
-    
+
     func hash(into hasher: inout Hasher) {
         imageName?.hash(into: &hasher)
         sizeMib.hash(into: &hasher)
@@ -110,7 +110,7 @@ struct UTMAppleConfigurationDrive: UTMConfigurationDrive {
         isExternal.hash(into: &hasher)
         id.hash(into: &hasher)
     }
-    
+
     func clone() -> UTMAppleConfigurationDrive {
         var cloned = self
         cloned.id = UUID().uuidString

--- a/Configuration/UTMAppleConfigurationGenericPlatform.swift
+++ b/Configuration/UTMAppleConfigurationGenericPlatform.swift
@@ -21,27 +21,27 @@ import Virtualization
 @available(macOS 11, *)
 struct UTMAppleConfigurationGenericPlatform: Codable {
     var machineIdentifier: Data?
-    
+
     private enum CodingKeys: String, CodingKey {
         case machineIdentifier
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         machineIdentifier = try container.decodeIfPresent(Data.self, forKey: .machineIdentifier)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(machineIdentifier, forKey: .machineIdentifier)
     }
-    
+
     init() {
         if #available(macOS 13, *) {
             machineIdentifier = VZGenericMachineIdentifier().dataRepresentation
         }
     }
-    
+
     @available(macOS 12, *)
     func vzGenericPlatform() -> VZGenericPlatformConfiguration? {
         let config = VZGenericPlatformConfiguration()

--- a/Configuration/UTMAppleConfigurationMacPlatform.swift
+++ b/Configuration/UTMAppleConfigurationMacPlatform.swift
@@ -23,13 +23,13 @@ struct UTMAppleConfigurationMacPlatform: Codable {
     var hardwareModel: Data
     var machineIdentifier: Data
     var auxiliaryStorageURL: URL?
-    
+
     private enum CodingKeys: String, CodingKey {
         case hardwareModel = "HardwareModel"
         case machineIdentifier = "MachineIdentifier"
         case auxiliaryStoragePath = "AuxiliaryStoragePath"
     }
-    
+
     init(from decoder: Decoder) throws {
         guard let dataURL = decoder.userInfo[.dataURL] as? URL else {
             throw UTMConfigurationError.invalidDataURL
@@ -41,28 +41,28 @@ struct UTMAppleConfigurationMacPlatform: Codable {
             auxiliaryStorageURL = dataURL.appendingPathComponent(auxiliaryStoragePath)
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hardwareModel, forKey: .hardwareModel)
         try container.encode(machineIdentifier, forKey: .machineIdentifier)
         try container.encodeIfPresent(auxiliaryStorageURL?.lastPathComponent, forKey: .auxiliaryStoragePath)
     }
-    
+
     #if arch(arm64)
     @available(macOS 12, *)
     init(newHardware: VZMacHardwareModel) {
         hardwareModel = newHardware.dataRepresentation
         machineIdentifier = VZMacMachineIdentifier().dataRepresentation
     }
-    
+
     @available(macOS 12, *)
     init(from config: VZMacPlatformConfiguration) {
         hardwareModel = config.hardwareModel.dataRepresentation
         machineIdentifier = config.machineIdentifier.dataRepresentation
         auxiliaryStorageURL = config.auxiliaryStorage?.url
     }
-    
+
     @available(macOS 12, *)
     func vzMacPlatform() -> VZMacPlatformConfiguration? {
         guard let vzHardwareModel = VZMacHardwareModel(dataRepresentation: hardwareModel) else {

--- a/Configuration/UTMAppleConfigurationSerial.swift
+++ b/Configuration/UTMAppleConfigurationSerial.swift
@@ -23,7 +23,7 @@ struct UTMAppleConfigurationSerial: Codable, Identifiable {
     enum SerialMode: String, CaseIterable, QEMUConstant {
         case builtin = "Terminal"
         case ptty = "Ptty"
-        
+
         var prettyValue: String {
             switch self {
             case .builtin: return NSLocalizedString("Built-in Terminal", comment: "UTMAppleConfigurationTerminal")
@@ -31,37 +31,37 @@ struct UTMAppleConfigurationSerial: Codable, Identifiable {
             }
         }
     }
-    
+
     var mode: SerialMode = .builtin
-    
+
     /// Terminal settings for built-in mode.
     var terminal: UTMConfigurationTerminal? = .init()
-    
+
     /// Set to read handle before starting VM. Not saved.
     var fileHandleForReading: FileHandle?
-    
+
     /// Set to write handle before starting VM. Not saved.
     var fileHandleForWriting: FileHandle?
-    
+
     /// Serial interface used by the VM. Not saved.
     var interface: UTMSerialPort?
-    
+
     let id = UUID()
-    
+
     enum CodingKeys: String, CodingKey {
         case mode = "Mode"
         case terminal = "Terminal"
     }
-    
+
     init() {
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         mode = try values.decode(SerialMode.self, forKey: .mode)
         terminal = try values.decodeIfPresent(UTMConfigurationTerminal.self, forKey: .terminal)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(mode, forKey: .mode)
@@ -73,7 +73,7 @@ struct UTMAppleConfigurationSerial: Codable, Identifiable {
             break
         }
     }
-    
+
     func vzSerial() -> VZSerialPortConfiguration? {
         guard let fileHandleForReading = fileHandleForReading, let fileHandleForWriting = fileHandleForWriting else {
             return nil

--- a/Configuration/UTMAppleConfigurationSharedDirectory.swift
+++ b/Configuration/UTMAppleConfigurationSharedDirectory.swift
@@ -23,25 +23,25 @@ import Virtualization
 struct UTMAppleConfigurationSharedDirectory: Codable, Hashable, Identifiable {
     var directoryURL: URL?
     var isReadOnly: Bool
-    
+
     let id = UUID()
-    
+
     private enum CodingKeys: String, CodingKey {
         case bookmark = "Bookmark"
         case isReadOnly = "ReadOnly"
     }
-    
+
     init(directoryURL: URL?, isReadOnly: Bool = false) {
         self.directoryURL = directoryURL
         self.isReadOnly = isReadOnly
     }
-    
+
     @available(macOS 12, *)
     init(from config: VZSharedDirectory) {
         self.isReadOnly = config.isReadOnly
         self.directoryURL = config.url
     }
-    
+
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         isReadOnly = try container.decode(Bool.self, forKey: .isReadOnly)
@@ -49,7 +49,7 @@ struct UTMAppleConfigurationSharedDirectory: Codable, Hashable, Identifiable {
         var stale: Bool = false
         directoryURL = try? URL(resolvingBookmarkData: bookmark, options: .withSecurityScope, bookmarkDataIsStale: &stale)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(isReadOnly, forKey: .isReadOnly)
@@ -64,7 +64,7 @@ struct UTMAppleConfigurationSharedDirectory: Codable, Hashable, Identifiable {
         let bookmark = try directoryURL?.bookmarkData(options: options)
         try container.encodeIfPresent(bookmark, forKey: .bookmark)
     }
-    
+
     @available(macOS 12, *)
     func vzSharedDirectory() -> VZSharedDirectory? {
         if let directoryURL = directoryURL {
@@ -73,7 +73,7 @@ struct UTMAppleConfigurationSharedDirectory: Codable, Hashable, Identifiable {
             return nil
         }
     }
-    
+
     @available(macOS 12, *)
     static func makeDirectoryShare(from sharedDirectories: [UTMAppleConfigurationSharedDirectory]) -> VZDirectoryShare {
         let vzSharedDirectories = sharedDirectories.compactMap { sharedDirectory in

--- a/Configuration/UTMAppleConfigurationSystem.swift
+++ b/Configuration/UTMAppleConfigurationSystem.swift
@@ -143,7 +143,7 @@ extension UTMAppleConfigurationSystem {
             vzconfig.platform = platform
         }
     }
-    
+
     private static func sysctlIntRead(_ name: String) -> UInt64 {
         var value: UInt64 = 0
         var size = MemoryLayout<UInt64>.size

--- a/Configuration/UTMAppleConfigurationSystem.swift
+++ b/Configuration/UTMAppleConfigurationSystem.swift
@@ -22,7 +22,7 @@ import Virtualization
 @available(macOS 11, *)
 struct UTMAppleConfigurationSystem: Codable {
     private let bytesInMib = UInt64(1048576)
-    
+
     static var currentArchitecture: String {
         #if arch(arm64)
         "aarch64"
@@ -32,21 +32,21 @@ struct UTMAppleConfigurationSystem: Codable {
         #error("Unsupported architecture.")
         #endif
     }
-    
+
     var architecture: String = Self.currentArchitecture
-    
+
     /// Number of CPU cores to emulate. Set to 0 to match the number of available cores on the host.
     var cpuCount: Int = 0
-    
+
     /// The RAM of the guest in MiB.
     var memorySize: Int = 4096
-    
+
     var boot: UTMAppleConfigurationBoot = try! .init(for: .none)
-    
+
     var macPlatform: UTMAppleConfigurationMacPlatform?
-    
+
     var genericPlatform: UTMAppleConfigurationGenericPlatform?
-    
+
     enum CodingKeys: String, CodingKey {
         case architecture = "Architecture"
         case cpuCount = "CPUCount"
@@ -55,10 +55,10 @@ struct UTMAppleConfigurationSystem: Codable {
         case macPlatform = "MacPlatform"
         case genericPlatform = "GenericPlatform"
     }
-    
+
     init() {
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         architecture = try values.decode(String.self, forKey: .architecture)
@@ -68,7 +68,7 @@ struct UTMAppleConfigurationSystem: Codable {
         macPlatform = try values.decodeIfPresent(UTMAppleConfigurationMacPlatform.self, forKey: .macPlatform)
         genericPlatform = try values.decodeIfPresent(UTMAppleConfigurationGenericPlatform.self, forKey: .genericPlatform)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(architecture, forKey: .architecture)

--- a/Configuration/UTMAppleConfigurationVirtualization.swift
+++ b/Configuration/UTMAppleConfigurationVirtualization.swift
@@ -25,7 +25,7 @@ struct UTMAppleConfigurationVirtualization: Codable {
         case disabled = "Disabled"
         case mouse = "Mouse"
         case trackpad = "Trackpad"
-        
+
         var prettyValue: String {
             switch self {
             case .disabled: return NSLocalizedString("Disabled", comment: "UTMAppleConfigurationDevices")
@@ -34,23 +34,23 @@ struct UTMAppleConfigurationVirtualization: Codable {
             }
         }
     }
-    
+
     var hasAudio: Bool = false
-    
+
     var hasBalloon: Bool = true
-    
+
     var hasEntropy: Bool = true
-    
+
     var hasKeyboard: Bool = false
-    
+
     var hasPointer: Bool = false
-    
+
     var hasTrackpad: Bool = false
-    
+
     var hasRosetta: Bool?
-    
+
     var hasClipboardSharing: Bool = false
-    
+
     enum CodingKeys: String, CodingKey {
         case hasAudio = "Audio"
         case hasBalloon = "Balloon"
@@ -61,10 +61,10 @@ struct UTMAppleConfigurationVirtualization: Codable {
         case rosetta = "Rosetta"
         case hasClipboardSharing = "ClipboardSharing"
     }
-    
+
     init() {
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         hasAudio = try values.decode(Bool.self, forKey: .hasAudio)
@@ -83,7 +83,7 @@ struct UTMAppleConfigurationVirtualization: Codable {
             hasClipboardSharing = try values.decodeIfPresent(Bool.self, forKey: .hasClipboardSharing) ?? false
         }
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(hasAudio, forKey: .hasAudio)
@@ -203,7 +203,7 @@ extension UTMAppleConfigurationVirtualization {
             try await installRosetta()
         }
     }
-    
+
     @available(macOS 13, *)
     private func installRosetta() async throws {
         #if arch(arm64)

--- a/Configuration/UTMConfiguration.swift
+++ b/Configuration/UTMConfiguration.swift
@@ -76,12 +76,12 @@ extension UTMConfigurationError: LocalizedError {
 private final class UTMConfigurationStub: Decodable {
     var backend: UTMBackend
     var configurationVersion: Int
-    
+
     enum CodingKeys: String, CodingKey {
         case backend = "Backend"
         case configurationVersion = "ConfigurationVersion"
     }
-    
+
     required init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         backend = try values.decodeIfPresent(UTMBackend.self, forKey: .backend) ?? .unknown
@@ -91,7 +91,7 @@ private final class UTMConfigurationStub: Decodable {
 
 extension UTMConfiguration {
     static var dataDirectoryName: String { "Data" }
-    
+
     static func load(from packageURL: URL) throws -> any UTMConfiguration {
         let scopedAccess = packageURL.startAccessingSecurityScopedResource()
         defer {

--- a/Configuration/UTMConfiguration.swift
+++ b/Configuration/UTMConfiguration.swift
@@ -119,7 +119,7 @@ extension UTMConfiguration {
             }
             #endif
             // is it a legacy QEMU config?
-            let dict = try NSDictionary(contentsOf: configURL, error: ()) as! [AnyHashable : Any]
+            let dict = try NSDictionary(contentsOf: configURL, error: ()) as! [AnyHashable: Any]
             let name = UTMQemuVirtualMachine.virtualMachineName(for: packageURL)
             let legacy = UTMLegacyQemuConfiguration(dictionary: dict, name: name, path: packageURL)
             return UTMQemuConfiguration(migrating: legacy)
@@ -137,7 +137,7 @@ extension UTMConfiguration {
             throw UTMConfigurationError.invalidBackend
         }
     }
-    
+
     func save(to packageURL: URL) async throws {
         let fileManager = FileManager.default
 
@@ -162,7 +162,7 @@ extension UTMConfiguration {
         let settingsData = try encoder.encode(self)
         try settingsData.write(to: packageURL.appendingPathComponent(kUTMBundleConfigFilename))
     }
-    
+
     /// Check if a file has changed and if so, copy the new file to the bundle
     /// - Parameters:
     ///   - sourceURL: File to copy
@@ -194,7 +194,7 @@ extension UTMConfiguration {
             return destURL
         }
     }
-    
+
     private static func cleanupAllFiles(at dataURL: URL, notIncluding urls: [URL]) async throws {
         let fileManager = FileManager.default
         let existingNames = urls.map { url in
@@ -202,10 +202,8 @@ extension UTMConfiguration {
         }
         let dataFileURLs = try fileManager.contentsOfDirectory(at: dataURL, includingPropertiesForKeys: nil)
         try await Task.detached {
-            for dataFileURL in dataFileURLs {
-                if !existingNames.contains(dataFileURL.lastPathComponent) {
-                    try FileManager.default.removeItem(at: dataFileURL)
-                }
+            for dataFileURL in dataFileURLs where !existingNames.contains(dataFileURL.lastPathComponent) {
+                try FileManager.default.removeItem(at: dataFileURL)
             }
         }.value
     }

--- a/Configuration/UTMConfigurationDrive.swift
+++ b/Configuration/UTMConfigurationDrive.swift
@@ -21,25 +21,25 @@ import QEMUKitInternal
 protocol UTMConfigurationDrive: Codable, Hashable, Identifiable {
     /// If not removable, this is the name of the file in the bundle.
     var imageName: String? { get set }
-    
+
     /// Size of the image when creating a new image (in MiB).
     var sizeMib: Int { get }
-    
+
     /// If true, the drive image will be mounted as read-only.
     var isReadOnly: Bool { get }
-    
+
     /// If true, a bookmark is stored in the package.
     var isExternal: Bool { get }
-    
+
     /// If true, the created image will be raw format and not QCOW2. Not saved.
     var isRawImage: Bool { get }
-    
+
     /// If valid, will point to the actual location of the drive image. Not saved.
     var imageURL: URL? { get set }
-    
+
     /// Unique identifier for this drive
     var id: String { get }
-    
+
     /// Create a new copy with a unique ID
     /// - Returns: Copy
     func clone() -> Self
@@ -55,7 +55,7 @@ extension UTMConfigurationDrive {
 
 extension UTMConfigurationDrive {
     private var bytesInMib: UInt64 { 1048576 }
-    
+
     @MainActor mutating func saveData(to dataURL: URL) async throws -> [URL] {
         guard !isExternal else {
             return [] // nothing to save
@@ -89,7 +89,7 @@ extension UTMConfigurationDrive {
             return [existingURL]
         }
     }
-    
+
     private func createRawImage(at newURL: URL, size sizeMib: Int) async throws {
         let size = UInt64(sizeMib) * bytesInMib
         try await Task.detached {
@@ -101,7 +101,7 @@ extension UTMConfigurationDrive {
             try handle.close()
         }.value
     }
-    
+
     private func createQcow2Image(at newURL: URL, size sizeMib: Int) async throws {
         try await Task.detached {
             if !QEMUGenerateDefaultQcow2File(newURL as CFURL, sizeMib) {
@@ -109,7 +109,7 @@ extension UTMConfigurationDrive {
             }
         }.value
     }
-    
+
     #if os(macOS)
     private func convertQcow2Image(at sourceURL: URL, to destFolderURL: URL) async throws -> URL {
         let destQcow2 = UTMData.newImage(from: sourceURL,

--- a/Configuration/UTMConfigurationInfo.swift
+++ b/Configuration/UTMConfigurationInfo.swift
@@ -20,19 +20,19 @@ import Foundation
 struct UTMConfigurationInfo: Codable {
     /// VM name displayed to user.
     var name: String = NSLocalizedString("Virtual Machine", comment: "UTMConfigurationInfo")
-    
+
     /// Path to the icon.
     var iconURL: URL?
-    
+
     /// If true, the icon is stored in the bundle. Otherwise, the icon is built-in.
     var isIconCustom: Bool = false
-    
+
     /// User specified notes to be displayed when the VM is selected.
     var notes: String?
-    
+
     /// Random identifier not accessible by the user.
     var uuid: UUID = UUID()
-    
+
     enum CodingKeys: String, CodingKey {
         case name = "Name"
         case icon = "Icon"
@@ -40,10 +40,10 @@ struct UTMConfigurationInfo: Codable {
         case notes = "Notes"
         case uuid = "UUID"
     }
-    
+
     init() {
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         name = try values.decode(String.self, forKey: .name)
@@ -60,7 +60,7 @@ struct UTMConfigurationInfo: Codable {
         notes = try values.decodeIfPresent(String.self, forKey: .notes)
         uuid = try values.decode(UUID.self, forKey: .uuid)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(name, forKey: .name)
@@ -76,7 +76,7 @@ struct UTMConfigurationInfo: Codable {
         try container.encodeIfPresent(notes, forKey: .notes)
         try container.encode(uuid, forKey: .uuid)
     }
-    
+
     static func builtinIcon(named name: String) -> URL? {
         Bundle.main.url(forResource: name, withExtension: "png", subdirectory: "Icons")
     }
@@ -104,7 +104,7 @@ extension UTMConfigurationInfo {
             iconURL = Self.builtinIcon(named: name)
         }
     }
-    
+
     #if os(macOS)
     init(migrating oldConfig: UTMLegacyAppleConfiguration, dataURL: URL) {
         self.init()

--- a/Configuration/UTMConfigurationTerminal.swift
+++ b/Configuration/UTMConfigurationTerminal.swift
@@ -20,27 +20,27 @@ import Foundation
 struct UTMConfigurationTerminal: Codable, Identifiable {
     /// Terminal color scheme. Mutually exclusive with foreground/background colors.
     var theme: QEMUTerminalTheme?
-    
+
     /// Terminal foreground color if a theme is not used.
     var foregroundColor: String? = "#ffffff"
-    
+
     /// Terminal background color if a theme is not used.
     var backgroundColor: String? = "#000000"
-    
+
     /// Terminal text font.
     var font: QEMUTerminalFont = .init(rawValue: "Menlo")
-    
+
     /// Terminal text font size.
     var fontSize: Int = 12
-    
+
     /// Command to send when the console is resized.
     var resizeCommand: String?
-    
+
     /// Terminal has a blinking cursor.
     var hasCursorBlink: Bool = true
-    
+
     let id = UUID()
-    
+
     enum CodingKeys: String, CodingKey {
         case theme = "Theme"
         case foregroundColor = "ForegroundColor"
@@ -50,10 +50,10 @@ struct UTMConfigurationTerminal: Codable, Identifiable {
         case resizeCommand = "ResizeCommand"
         case hasCursorBlink = "CursorBlink"
     }
-    
+
     init() {
     }
-    
+
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
         theme = try values.decodeIfPresent(QEMUTerminalTheme.self, forKey: .theme)
@@ -64,7 +64,7 @@ struct UTMConfigurationTerminal: Codable, Identifiable {
         resizeCommand = try values.decodeIfPresent(String.self, forKey: .resizeCommand)
         hasCursorBlink = try values.decodeIfPresent(Bool.self, forKey: .hasCursorBlink) ?? true
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         if let theme = theme {
@@ -96,7 +96,7 @@ extension UTMConfigurationTerminal {
         resizeCommand = oldConfig.consoleResizeCommand
         hasCursorBlink = oldConfig.consoleCursorBlink
     }
-    
+
     #if os(macOS)
     init(migrating oldConfig: UTMLegacyAppleConfiguration) {
         self.init()

--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -27,7 +27,7 @@ import Virtualization // for getting network interfaces
     private func f(_ string: String = "") -> QEMUArgumentFragment {
         QEMUArgumentFragment(final: string)
     }
-    
+
     /// Shared between helper and main process to store Unix sockets
     var socketURL: URL {
         #if os(iOS) || os(visionOS)
@@ -50,23 +50,23 @@ import Virtualization // for getting network interfaces
         return parentURL
         #endif
     }
-    
+
     /// Return the socket file for communicating with SPICE
     var spiceSocketURL: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("spice")
     }
-    
+
     /// Return the socket file for communicating with SWTPM
     var swtpmSocketURL: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("swtpm")
     }
-    
+
     /// Combined generated and user specified arguments.
     @QEMUArgumentBuilder var allArguments: [QEMUArgument] {
         generatedArguments
         userArguments
     }
-    
+
     /// Only UTM generated arguments.
     @QEMUArgumentBuilder var generatedArguments: [QEMUArgument] {
         f("-L")
@@ -106,7 +106,7 @@ import Virtualization // for getting network interfaces
             }
         }
     }
-    
+
     @QEMUArgumentBuilder private var spiceArguments: [QEMUArgument] {
         f("-spice")
         "unix=on"
@@ -129,7 +129,7 @@ import Virtualization // for getting network interfaces
             f("none")
         }
     }
-    
+
     @QEMUArgumentBuilder private var displayArguments: [QEMUArgument] {
         if displays.isEmpty {
             f("-nographic")
@@ -151,17 +151,17 @@ import Virtualization // for getting network interfaces
             }
         }
     }
-    
+
     private var isGLOn: Bool {
         displays.contains { display in
             display.hardware.rawValue.contains("-gl-") || display.hardware.rawValue.hasSuffix("-gl")
         }
     }
-    
+
     private var isSparc: Bool {
         system.architecture == .sparc || system.architecture == .sparc64
     }
-    
+
     @QEMUArgumentBuilder private var serialArguments: [QEMUArgument] {
         for i in serials.indices {
             f("-chardev")
@@ -204,7 +204,7 @@ import Virtualization // for getting network interfaces
             }
         }
     }
-    
+
     @QEMUArgumentBuilder private var cpuArguments: [QEMUArgument] {
         if system.cpu.rawValue == system.architecture.cpuType.default.rawValue {
             // if default and not hypervisor, we don't pass any -cpu argument for x86 and use host for ARM
@@ -241,14 +241,14 @@ import Virtualization // for getting network interfaces
         "threads=\(emulatedCpuCount.1/emulatedCpuCount.0)"
         f()
     }
-    
+
     private static func sysctlIntRead(_ name: String) -> UInt64 {
         var value: UInt64 = 0
         var size = MemoryLayout<UInt64>.size
         sysctlbyname(name, &value, &size, nil, 0)
         return value
     }
-    
+
     private var emulatedCpuCount: (Int, Int) {
         let singleCpu = (1, 1)
         let hostPhysicalCpu = Int(Self.sysctlIntRead("hw.physicalcpu"))
@@ -282,23 +282,23 @@ import Virtualization // for getting network interfaces
         return singleCpu
         #endif
     }
-    
+
     private var isHypervisorUsed: Bool {
         system.architecture.hasHypervisorSupport && qemu.hasHypervisor
     }
-    
+
     private var isTSOUsed: Bool {
         system.architecture.hasTSOSupport && qemu.hasTSO
     }
-    
+
     private var isUsbUsed: Bool {
         system.architecture.hasUsbSupport && system.target.hasUsbSupport && input.usbBusSupport != .disabled
     }
-    
+
     private var isSecureBootUsed: Bool {
         system.architecture.hasSecureBootSupport && system.target.hasSecureBootSupport && qemu.hasTPMDevice
     }
-    
+
     @QEMUArgumentBuilder private var machineArguments: [QEMUArgument] {
         f("-machine")
         system.target
@@ -327,7 +327,7 @@ import Virtualization // for getting network interfaces
             f()
         }
     }
-    
+
     private var machineProperties: String {
         let target = system.target.rawValue
         let architecture = system.architecture.rawValue
@@ -367,7 +367,7 @@ import Virtualization // for getting network interfaces
         }
         return properties
     }
-    
+
     @QEMUArgumentBuilder private var architectureArguments: [QEMUArgument] {
         if system.architecture == .x86_64 || system.architecture == .i386 {
             f("-global")
@@ -402,7 +402,7 @@ import Virtualization // for getting network interfaces
         system.memorySize
         f()
     }
-    
+
     private var hasCustomBios: Bool {
         for drive in drives {
             if drive.imageType == .disk || drive.imageType == .cd {
@@ -415,11 +415,11 @@ import Virtualization // for getting network interfaces
         }
         return false
     }
-    
+
     private var resourceURL: URL {
         Bundle.main.url(forResource: "qemu", withExtension: nil)!
     }
-    
+
     private var soundBackend: UTMQEMUSoundBackend {
         let value = UserDefaults.standard.integer(forKey: "QEMUSoundBackend")
         if let backend = UTMQEMUSoundBackend(rawValue: value), backend != .qemuSoundBackendMax {
@@ -428,7 +428,7 @@ import Virtualization // for getting network interfaces
             return .qemuSoundBackendDefault
         }
     }
-    
+
     private var useCoreAudioBackend: Bool {
         #if os(iOS) || os(visionOS)
         return false
@@ -444,7 +444,7 @@ import Virtualization // for getting network interfaces
         return false
         #endif
     }
-    
+
     @QEMUArgumentBuilder private var soundArguments: [QEMUArgument] {
         if useCoreAudioBackend {
             f("-audiodev")
@@ -478,7 +478,7 @@ import Virtualization // for getting network interfaces
             }
         }
     }
-    
+
     @QEMUArgumentBuilder private var drivesArguments: [QEMUArgument] {
         var busInterfaceMap: [String: Int] = [:]
         for drive in drives {
@@ -506,7 +506,7 @@ import Virtualization // for getting network interfaces
             }
         }
     }
-    
+
     /// These machines are hard coded to have one IDE unit per bus in QEMU
     private var isIdeInterfaceSingleUnit: Bool {
         system.target.rawValue.contains("q35") ||
@@ -516,7 +516,7 @@ import Virtualization // for getting network interfaces
         system.target.rawValue == "midway" ||
         system.target.rawValue == "xlnx_zcu102"
     }
-    
+
     @QEMUArgumentBuilder private func driveArgument(for drive: UTMQemuConfigurationDrive, busInterfaceMap: inout [String: Int]) -> [QEMUArgument] {
         let isRemovable = drive.imageType == .cd || drive.isExternal
         let isCd = drive.imageType == .cd && drive.interface != .floppy
@@ -657,7 +657,7 @@ import Virtualization // for getting network interfaces
         }
         f()
     }
-    
+
     @QEMUArgumentBuilder private var usbArguments: [QEMUArgument] {
         if system.target.rawValue.hasPrefix("virt") {
             f("-device")
@@ -704,7 +704,7 @@ import Virtualization // for getting network interfaces
         }
         #endif
     }
-    
+
     private func parseNetworkSubnet(from network: UTMQemuConfigurationNetwork) -> (start: String, end: String, mask: String)? {
         guard let net = network.vlanGuestAddress else {
             return nil
@@ -742,13 +742,13 @@ import Virtualization // for getting network interfaces
         let netmaskStr = String(cString: inet_ntoa(netmask))
         return (network.vlanDhcpStartAddress ?? firstAddrStr, network.vlanDhcpEndAddress ?? lastAddrStr, netmaskStr)
     }
-    
+
     #if os(macOS)
     private var defaultBridgedInterface: String {
         VZBridgedNetworkInterface.networkInterfaces.first?.identifier ?? "en0"
     }
     #endif
-    
+
     @QEMUArgumentBuilder private var networkArguments: [QEMUArgument] {
         for i in networks.indices {
             if isSparc {
@@ -844,14 +844,14 @@ import Virtualization // for getting network interfaces
             f("none")
         }
     }
-    
+
     private var isSpiceAgentUsed: Bool {
         guard system.architecture.hasAgentSupport && system.target.hasAgentSupport else {
             return false
         }
         return sharing.hasClipboardSharing || sharing.directoryShareMode == .webdav || displays.contains(where: { $0.isDynamicResolution })
     }
-    
+
     @QEMUArgumentBuilder private var sharingArguments: [QEMUArgument] {
         if system.architecture.hasAgentSupport && system.target.hasAgentSupport {
             f("-device")
@@ -894,14 +894,14 @@ import Virtualization // for getting network interfaces
             "mount_tag=share"
         }
     }
-    
+
     private func cleanupName(_ name: String) -> String {
         let allowedCharacterSet = CharacterSet.alphanumerics.union(.whitespaces)
         let filteredString = name.components(separatedBy: allowedCharacterSet.inverted)
                                  .joined(separator: "")
         return filteredString
     }
-    
+
     @QEMUArgumentBuilder private var miscArguments: [QEMUArgument] {
         f("-name")
         f(cleanupName(information.name))
@@ -926,7 +926,7 @@ import Virtualization // for getting network interfaces
             tpmArguments
         }
     }
-    
+
     @QEMUArgumentBuilder private var tpmArguments: [QEMUArgument] {
         f("-chardev")
         "socket"

--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -90,7 +90,7 @@ import Virtualization // for getting network interfaces
         sharingArguments
         miscArguments
     }
-    
+
     @QEMUArgumentBuilder private var userArguments: [QEMUArgument] {
         let regex = try! NSRegularExpression(pattern: "((?:[^\"\\s]*\"[^\"]*\"[^\"\\s]*)+|[^\"\\s]+)")
         for arg in qemu.additionalArguments {

--- a/Platform/Main.swift
+++ b/Platform/Main.swift
@@ -32,7 +32,7 @@ let logger = Logger(label: "com.utmapp.UTM") { label in
 @main
 class Main {
     static var jitAvailable = true
-    
+
     static func main() {
         #if (os(iOS) || os(visionOS)) && !WITH_QEMU_TCI
         // check if we have jailbreak
@@ -63,7 +63,7 @@ class Main {
         #endif
         UTMApp.main()
     }
-    
+
     // https://stackoverflow.com/a/44675628
     static private func registerDefaultsFromSettingsBundle() {
         let userDefaults = UserDefaults.standard
@@ -81,7 +81,7 @@ class Main {
                     logger.debug("registerDefaultsFromSettingsBundle: (\(key), \(value)) \(type(of: value))")
                 }
             }
-            
+
             // register version numbers
             if let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] {
                 userDefaults.set(version, forKey: "LastBootedVersion")

--- a/Platform/Shared/BigButtonStyle.swift
+++ b/Platform/Shared/BigButtonStyle.swift
@@ -19,13 +19,13 @@ import SwiftUI
 struct BigButtonStyle: ButtonStyle {
     let width: CGFloat
     let height: CGFloat
-    
+
     fileprivate struct BigButtonView: View {
         let width: CGFloat
         let height: CGFloat
         let configuration: BigButtonStyle.Configuration
         @Environment(\.isEnabled) private var isEnabled: Bool
-        
+
         #if os(macOS)
         let defaultColor = Color(NSColor.controlColor)
         let pressedColor = Color(NSColor.controlAccentColor)
@@ -39,7 +39,7 @@ struct BigButtonStyle: ButtonStyle {
         let foregroundDisabledColor = Color(UIColor.systemGray)
         let foregroundPressedColor = Color(UIColor.secondaryLabel)
         #endif
-        
+
         var body: some View {
             ZStack {
                 RoundedRectangle(cornerRadius: 10.0)
@@ -53,7 +53,7 @@ struct BigButtonStyle: ButtonStyle {
             }.frame(width: width, height: height)
         }
     }
-    
+
     func makeBody(configuration: Configuration) -> some View {
         BigButtonView(width: width, height: height, configuration: configuration)
     }

--- a/Platform/Shared/BusyOverlay.swift
+++ b/Platform/Shared/BusyOverlay.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct BusyOverlay: View {
     @EnvironmentObject private var data: UTMData
-    
+
     var body: some View {
         Group {
             if data.busy {

--- a/Platform/Shared/ContentView.swift
+++ b/Platform/Shared/ContentView.swift
@@ -33,7 +33,7 @@ struct ContentView: View {
     @State private var newPopupPresented = false
     @State private var openSheetPresented = false
     @Environment(\.openURL) var openURL
-    
+
     var body: some View {
         VMNavigationListView()
         .overlay(data.showSettingsModal ? AnyView(EmptyView()) : AnyView(BusyOverlay()))
@@ -104,7 +104,7 @@ struct ContentView: View {
             #endif
         }
     }
-    
+
     private func handleURL(url: URL) {
         data.busyWorkAsync {
             if url.isFileURL {
@@ -116,14 +116,14 @@ struct ContentView: View {
             }
         }
     }
-    
+
     private func importUTM(url: URL) async throws {
         guard url.isFileURL else {
             return // ignore
         }
         try await data.importUTM(from: url)
     }
-    
+
     private func selectImportedUTM(result: Result<[URL], Error>) {
         data.busyWorkAsync {
             let urls = try result.get()
@@ -132,7 +132,7 @@ struct ContentView: View {
             }
         }
     }
-    
+
     @MainActor private func handleUTMURL(with components: URLComponents) async throws {
         func findVM() -> VMData? {
             if let vmName = components.queryItems?.first(where: { $0.name == "name" })?.value {
@@ -141,25 +141,22 @@ struct ContentView: View {
                 return nil
             }
         }
-        
+
         if let action = components.host {
             switch action {
             case "start":
                 if let vm = findVM(), vm.state == .stopped {
                     data.run(vm: vm)
                 }
-                break
             case "stop":
                 if let vm = findVM(), vm.state == .started {
                     try await vm.wrapped!.stop(usingMethod: .force)
                     data.stop(vm: vm)
                 }
-                break
             case "restart":
                 if let vm = findVM(), vm.state == .started {
                     try await vm.wrapped!.restart()
                 }
-                break
             case "pause":
                 if let vm = findVM(), vm.state == .started {
                     let shouldSaveOnPause: Bool
@@ -177,20 +174,16 @@ struct ContentView: View {
                 if let vm = findVM(), vm.state == .paused {
                     try await vm.wrapped!.resume()
                 }
-                break
             case "sendText":
                 if let vm = findVM(), vm.state == .started {
                     data.automationSendText(to: vm, urlComponents: components)
                 }
-                break
             case "click":
                 if let vm = findVM(), vm.state == .started {
                     data.automationSendMouse(to: vm, urlComponents: components)
                 }
-                break
             case "downloadVM":
                 await data.downloadUTMZip(from: components)
-                break
             default:
                 return
             }
@@ -202,18 +195,17 @@ extension ContentView: DropDelegate {
     func validateDrop(info: DropInfo) -> Bool {
         !urlsFrom(info: info).isEmpty
     }
-    
+
     func performDrop(info: DropInfo) -> Bool {
         let urls = urlsFrom(info: info)
         data.busyWorkAsync {
             for url in urls {
-                
                 try await data.importUTM(from: url)
             }
         }
         return true
     }
-    
+
     private func urlsFrom(info: DropInfo) -> [URL] {
         let providers = info.itemProviders(for: [.fileURL])
 
@@ -230,7 +222,7 @@ extension ContentView: DropDelegate {
                 group.leave()
             }
         }
-        
+
         group.wait()
 
         return validURLs

--- a/Platform/Shared/DefaultTextField.swift
+++ b/Platform/Shared/DefaultTextField.swift
@@ -21,14 +21,14 @@ struct DefaultTextField: View {
     private let text: Binding<String>
     private let prompt: LocalizedStringKey
     private let onEditingChanged: (Bool) -> Void
-    
+
     init(_ titleKey: LocalizedStringKey, text: Binding<String>, prompt: LocalizedStringKey = "", onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         self.titleKey = titleKey
         self.text = text
         self.prompt = prompt
         self.onEditingChanged = onEditingChanged
     }
-    
+
     var body: some View {
         let stack = HStack {
             Text(titleKey)
@@ -56,18 +56,18 @@ struct DefaultTextFieldNew: View {
     private let prompt: LocalizedStringKey
     private let onEditingChanged: (Bool) -> Void
     @FocusState private var focused: Bool
-    
+
     init(_ titleKey: LocalizedStringKey, text: Binding<String>, prompt: LocalizedStringKey = "", onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         self.titleKey = titleKey
         self._text = text
         self.prompt = prompt
         self.onEditingChanged = onEditingChanged
     }
-    
+
     var body: some View {
         TextField(titleKey, text: $text, prompt: Text(prompt))
             .focused($focused)
-            .onChange(of: text) { newValue in
+            .onChange(of: text) { _ in
                 onEditingChanged(focused)
             }
             .onSubmit {

--- a/Platform/Shared/DestructiveButton.swift
+++ b/Platform/Shared/DestructiveButton.swift
@@ -16,20 +16,20 @@
 
 import SwiftUI
 
-struct DestructiveButton<Label>: View where Label : View {
+struct DestructiveButton<Label>: View where Label: View {
     private let action: () -> Void
     private let label: Label
-    
+
     init(action: @escaping () -> Void, label: () -> Label) {
         self.action = action
         self.label = label()
     }
-    
+
     init(_ titleKey: LocalizedStringKey, action: @escaping () -> Void) where Label == Text {
         self.action = action
         self.label = Text(titleKey)
     }
-    
+
     var body: some View {
         if #available(iOS 15, macOS 12, *) {
             #if os(iOS) || os(visionOS)
@@ -54,7 +54,7 @@ struct DestructiveButton<Label>: View where Label : View {
 struct DestructiveButton_Previews: PreviewProvider {
     static var previews: some View {
         DestructiveButton {
-            
+
         } label: {
             Text("Test")
         }

--- a/Platform/Shared/DetailedSection.swift
+++ b/Platform/Shared/DetailedSection.swift
@@ -20,13 +20,13 @@ struct DetailedSection<Content>: View where Content: View {
     private let titleKey: LocalizedStringKey
     private let description: LocalizedStringKey
     private let content: Content
-    
+
     init(_ titleKey: LocalizedStringKey, description: LocalizedStringKey = "", @ViewBuilder content: () -> Content) {
         self.titleKey = titleKey
         self.description = description
         self.content = content()
     }
-    
+
     var body: some View {
         #if os(macOS)
         Section(content: {

--- a/Platform/Shared/FileBrowseField.swift
+++ b/Platform/Shared/FileBrowseField.swift
@@ -22,7 +22,7 @@ struct FileBrowseField: View {
     @Binding var isFileImporterPresented: Bool
     let hasClearButton: Bool
     let onBrowse: () -> Void
-    
+
     init(_ titleKey: LocalizedStringKey = "Path", url: Binding<URL?>, isFileImporterPresented: Binding<Bool>, hasClearButton: Bool = true, onBrowse: @escaping () -> Void = {}) {
         self.titleKey = titleKey
         self._url = url
@@ -30,7 +30,7 @@ struct FileBrowseField: View {
         self.hasClearButton = hasClearButton
         self.onBrowse = onBrowse
     }
-    
+
     var body: some View {
         #if os(macOS)
         HStack {

--- a/Platform/Shared/GlobalFileImporter.swift
+++ b/Platform/Shared/GlobalFileImporter.swift
@@ -24,9 +24,9 @@ import UniformTypeIdentifiers
 /// and then add a .fileImporter() on its instance variables.
 class GlobalFileImporterShim: ObservableObject {
     @Published var isPresented: Bool = false
-    
+
     @Published var allowedContentTypes: [UTType] = []
-    
+
     @Published var onCompletion: (Result<URL, Error>) -> Void = { _ in }
 }
 
@@ -37,7 +37,7 @@ struct GlobalFileImporterViewModifier: ViewModifier {
     #if os(iOS) || os(visionOS)
     @EnvironmentObject private var globalFileImporterShim: GlobalFileImporterShim
     #endif
-    
+
     func body(content: Content) -> some View {
         #if os(iOS) || os(visionOS)
         content

--- a/Platform/Shared/InListButtonStyle.swift
+++ b/Platform/Shared/InListButtonStyle.swift
@@ -33,7 +33,7 @@ struct InListButtonStyle: ButtonStyle {
         let foregroundDisabledColor = Color(UIColor.systemGray)
         let foregroundPressedColor = Color(UIColor.secondaryLabel)
         #endif
-        
+
         var body: some View {
             #if os(macOS)
             ZStack {
@@ -45,8 +45,6 @@ struct InListButtonStyle: ButtonStyle {
                 configuration.label
                     .foregroundColor(isEnabled ? (configuration.isPressed ? foregroundPressedColor : foregroundColor) : foregroundDisabledColor)
             }
-            
-            
             #else
             HStack {
                 configuration.label
@@ -60,7 +58,7 @@ struct InListButtonStyle: ButtonStyle {
             #endif
         }
     }
-    
+
     func makeBody(configuration: Configuration) -> some View {
         InListButtonView(configuration: configuration)
     }

--- a/Platform/Shared/MenuLabel.swift
+++ b/Platform/Shared/MenuLabel.swift
@@ -18,15 +18,15 @@ import SwiftUI
 
 struct MenuLabel: View {
     private let label: Label<Text, Image>
-    
+
     init(_ titleKey: LocalizedStringKey, systemImage name: String) {
         label = Label(titleKey, systemImage: name)
     }
-    
-    init<S>(_ title: S, systemImage name: String) where S : StringProtocol {
+
+    init<S>(_ title: S, systemImage name: String) where S: StringProtocol {
         label = Label(title, systemImage: name)
     }
-    
+
     var body: some View {
         if #available(iOS 14.5, *) {
             label.labelStyle(.titleAndIcon)

--- a/Platform/Shared/NumberTextField.swift
+++ b/Platform/Shared/NumberTextField.swift
@@ -22,7 +22,7 @@ struct NumberTextFieldOld: View {
     private var promptKey: LocalizedStringKey
     private var onEditingChanged: (Bool) -> Void
     private let formatter: NumberFormatter
-    
+
     init(_ titleKey: LocalizedStringKey, number: Binding<NSNumber?>, prompt: LocalizedStringKey, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         self.titleKey = titleKey
         self._number = number
@@ -32,7 +32,7 @@ struct NumberTextFieldOld: View {
         self.formatter.usesSignificantDigits = false
         self.promptKey = prompt
     }
-    
+
     var body: some View {
         HStack {
             Text(titleKey)
@@ -58,18 +58,18 @@ struct NumberTextFieldNew: View {
     @Binding private var number: NSNumber?
     private var promptKey: LocalizedStringKey
     private var onEditingChanged: (Bool) -> Void
-    
+
     // Due to FB9581726 we cannot make `focused` available only on newer APIs.
     // Therefore we have to mark the availability on the entire struct.
     @FocusState private var focused: Bool
-    
+
     init(_ titleKey: LocalizedStringKey, number: Binding<NSNumber?>, prompt: LocalizedStringKey, onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         self.titleKey = titleKey
         self._number = number
         self.onEditingChanged = onEditingChanged
         self.promptKey = prompt
     }
-    
+
     var body: some View {
         Group {
             #if os(macOS)
@@ -100,14 +100,14 @@ struct NumberTextField: View {
     @Binding private var number: NSNumber?
     private var promptKey: LocalizedStringKey
     private var onEditingChanged: (Bool) -> Void
-    
+
     init(_ titleKey: LocalizedStringKey, number: Binding<NSNumber?>, prompt: LocalizedStringKey = "0", onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         self.titleKey = titleKey
         self._number = number
         self.onEditingChanged = onEditingChanged
         self.promptKey = prompt
     }
-    
+
     init(_ titleKey: LocalizedStringKey, number: Binding<Int>, prompt: LocalizedStringKey = "0", onEditingChanged: @escaping (Bool) -> Void = { _ in }) {
         let nsnumber = Binding<NSNumber?> {
             return number.wrappedValue as NSNumber
@@ -116,7 +116,7 @@ struct NumberTextField: View {
         }
         self.init(titleKey, number: nsnumber, prompt: prompt, onEditingChanged: onEditingChanged)
     }
-    
+
     var body: some View {
         if #available(iOS 15, macOS 12, *) {
             NumberTextFieldNew(titleKey, number: $number, prompt: promptKey, onEditingChanged: onEditingChanged)
@@ -132,7 +132,7 @@ extension NSNumber {
         var parseStrategy: StringParseStrategy {
             return StringParseStrategy()
         }
-        
+
         func format(_ value: NSNumber) -> String {
             let formatter = NumberFormatter()
             formatter.usesGroupingSeparator = false
@@ -141,7 +141,7 @@ extension NSNumber {
             return value.intValue == 0 ? "" : string
         }
     }
-    
+
     struct StringParseStrategy: ParseStrategy {
         func parse(_ value: String) throws -> NSNumber {
             let formatter = NumberFormatter()

--- a/Platform/Shared/RAMSlider.swift
+++ b/Platform/Shared/RAMSlider.swift
@@ -18,11 +18,11 @@ import SwiftUI
 
 struct RAMSlider: View {
     let validMemoryValues = [32, 64, 128, 256, 512, 768, 1024, 1536, 2048, 3072, 4096, 6144, 8192, 10240, 12288, 14336, 16384, 32768]
-    
+
     let validateMemorySize: (Bool) -> Void
     @Binding var systemMemory: NSNumber?
     @State private var memorySizeIndex: Float = 0
-    
+
     var memorySizeIndexObserver: Binding<Float> {
         Binding<Float>(
             get: {
@@ -33,12 +33,12 @@ struct RAMSlider: View {
             }
         )
     }
-    
+
     init(systemMemory: Binding<NSNumber?>, onValidate: @escaping (Bool) -> Void = { _ in }) {
         validateMemorySize = onValidate
         _systemMemory = systemMemory
     }
-    
+
     init<T: FixedWidthInteger>(systemMemory: Binding<T>, onValidate: @escaping (Bool) -> Void = { _ in }) {
         validateMemorySize = onValidate
         _systemMemory = Binding<NSNumber?>(get: {
@@ -47,9 +47,9 @@ struct RAMSlider: View {
             systemMemory.wrappedValue = T(newValue?.uint64Value ?? 0)
         })
     }
-    
+
     var body: some View {
-        GeometryReader { geo in
+        GeometryReader { _ in
             HStack {
                 Slider(value: memorySizeIndexObserver, in: 0...Float(validMemoryValues.count-1), step: 1) { start in
                     if !start {
@@ -64,19 +64,17 @@ struct RAMSlider: View {
             }
         }.frame(height: 30)
     }
-    
+
     func memorySizePickerIndex(size: NSNumber?) -> Float {
         guard let sizeUnwrap = size else {
             return 0
         }
-        for (i, s) in validMemoryValues.enumerated() {
-            if s >= Int(truncating: sizeUnwrap) {
-                return Float(i)
-            }
+        for (i, s) in validMemoryValues.enumerated() where s >= Int(truncating: sizeUnwrap) {
+            return Float(i)
         }
         return Float(validMemoryValues.count - 1)
     }
-    
+
     func memorySize(pickerIndex: Float) -> NSNumber {
         let i = Int(pickerIndex)
         guard i >= 0 && i < validMemoryValues.count else {
@@ -89,7 +87,7 @@ struct RAMSlider: View {
 struct RAMSlider_Previews: PreviewProvider {
     static var previews: some View {
         RAMSlider(systemMemory: .constant(1024)) { _ in
-            
+
         }
     }
 }

--- a/Platform/Shared/SizeTextField.swift
+++ b/Platform/Shared/SizeTextField.swift
@@ -19,15 +19,15 @@ import SwiftUI
 struct SizeTextField: View {
     @Binding var sizeMib: Int
     @State private var isGiB: Bool = true
-    
+
     private let mibToGib = 1024
     let minSizeMib: Int
-    
+
     init(_ sizeMib: Binding<Int>, minSizeMib: Int = 1) {
         _sizeMib = sizeMib
         self.minSizeMib = minSizeMib
     }
-    
+
     var body: some View {
         HStack {
             NumberTextField("Size", number: Binding<Int>(get: {
@@ -48,7 +48,7 @@ struct SizeTextField: View {
             }).buttonStyle(.plain)
         }
     }
-    
+
     private func validateSize(editing: Bool) {
         guard !editing else {
             return
@@ -57,7 +57,7 @@ struct SizeTextField: View {
             sizeMib = minSizeMib
         }
     }
-    
+
     private func convertToMib(fromSize size: Int) -> Int {
         if isGiB {
             return size * mibToGib
@@ -65,7 +65,7 @@ struct SizeTextField: View {
             return size
         }
     }
-    
+
     private func convertToDisplay(fromSizeMib sizeMib: Int) -> Int {
         if isGiB {
             return sizeMib / mibToGib

--- a/Platform/Shared/Spinner.swift
+++ b/Platform/Shared/Spinner.swift
@@ -22,14 +22,14 @@ struct Spinner: NSViewRepresentable {
     enum Size: RawRepresentable {
         case regular
         case large
-        
+
         var rawValue: NSControl.ControlSize {
             switch self {
             case .regular: return .regular
             case .large: return .large
             }
         }
-        
+
         init?(rawValue: NSControl.ControlSize) {
             switch rawValue {
             case .regular:
@@ -41,9 +41,9 @@ struct Spinner: NSViewRepresentable {
             }
         }
     }
-    
+
     let size: Size
-    
+
     func makeNSView(context: Context) -> NSProgressIndicator {
         let view = NSProgressIndicator()
         view.controlSize = size.rawValue
@@ -51,7 +51,7 @@ struct Spinner: NSViewRepresentable {
         view.startAnimation(self)
         return view
     }
-    
+
     func updateNSView(_ nsView: NSProgressIndicator, context: Context) {
     }
 }
@@ -60,14 +60,14 @@ struct Spinner: UIViewRepresentable {
     enum Size: RawRepresentable {
         case regular
         case large
-        
+
         var rawValue: UIActivityIndicatorView.Style {
             switch self {
             case .regular: return .medium
             case .large: return .large
             }
         }
-        
+
         init?(rawValue: UIActivityIndicatorView.Style) {
             switch rawValue {
             case .medium:
@@ -79,16 +79,16 @@ struct Spinner: UIViewRepresentable {
             }
         }
     }
-    
+
     let size: Size
-    
+
     func makeUIView(context: Context) -> UIActivityIndicatorView {
         let view = UIActivityIndicatorView(style: size.rawValue)
         view.color = .white
         view.startAnimating()
         return view
     }
-    
+
     func updateUIView(_ uiView: UIActivityIndicatorView, context: Context) {
     }
 }

--- a/Platform/Shared/VMConfigConstantPicker.swift
+++ b/Platform/Shared/VMConfigConstantPicker.swift
@@ -19,20 +19,20 @@ import SwiftUI
 struct VMConfigConstantPicker: View {
     private struct Identifier: Hashable {
         let string: String
-        
+
         init(_ string: String) {
             self.string = string
         }
-        
+
         func hash(into hasher: inout Hasher) {
             string.hash(into: &hasher)
         }
     }
-    
+
     @Binding private var selection: Identifier
     private let titleKey: LocalizedStringKey?
     private let type: any QEMUConstant.Type
-    
+
     init<T: QEMUConstant>(_ titleKey: LocalizedStringKey? = nil, selection: Binding<T>) {
         self._selection = Binding(get: {
             Identifier(selection.wrappedValue.rawValue)
@@ -42,7 +42,7 @@ struct VMConfigConstantPicker: View {
         self.titleKey = titleKey
         self.type = T.self
     }
-    
+
     init<S>(_ titleKey: LocalizedStringKey? = nil, selection: Binding<S>, type: any QEMUConstant.Type) {
         self._selection = Binding(get: {
             Identifier((selection.wrappedValue as! any QEMUConstant).rawValue)
@@ -52,7 +52,7 @@ struct VMConfigConstantPicker: View {
         self.titleKey = titleKey
         self.type = type
     }
-    
+
     var body: some View {
         Picker(titleKey ?? "", selection: $selection) {
             ForEach(type.allPrettyValues) { displayValue in
@@ -60,7 +60,7 @@ struct VMConfigConstantPicker: View {
             }
         }
     }
-    
+
     private nonmutating func identifier(for displayValue: String) -> Identifier {
         let index = type.allPrettyValues.firstIndex(of: displayValue)!
         return Identifier(type.allRawValues[index])
@@ -70,7 +70,7 @@ struct VMConfigConstantPicker: View {
 struct VMConfigConstantPicker_Previews: PreviewProvider {
     @State static private var fixedType: QEMUArchitecture = .aarch64
     @State static private var dynamicType: any QEMUCPU = QEMUCPU_aarch64.default
-    
+
     static var previews: some View {
         VStack {
             HStack {

--- a/Platform/Shared/VMContextMenuModifier.swift
+++ b/Platform/Shared/VMContextMenuModifier.swift
@@ -22,7 +22,7 @@ struct VMContextMenuModifier: ViewModifier {
     @State private var showSharePopup = false
     @State private var confirmAction: ConfirmAction?
     @State private var shareItem: VMShareItemModifier.ShareItem?
-    
+
     func body(content: Content) -> some View {
         #if os(macOS)
         if #unavailable(macOS 12) {
@@ -34,7 +34,7 @@ struct VMContextMenuModifier: ViewModifier {
         return bodyFull(content: content)
         #endif
     }
-    
+
     #if os(macOS)
     @ViewBuilder func bodyBigSur(content: Content) -> some View {
         content.contextMenu {
@@ -46,7 +46,7 @@ struct VMContextMenuModifier: ViewModifier {
         }
     }
     #endif
-    
+
     /// Full context menu for anything other than Big Sur
     /// - Parameter content: Content
     /// - Returns: View
@@ -82,13 +82,13 @@ struct VMContextMenuModifier: ViewModifier {
                 }.help("Resume running VM.")
             } else {
                 Divider()
-                
+
                 Button {
                     data.run(vm: vm)
                 } label: {
                     Label("Run", systemImage: "play")
                 }.help("Run the VM in the foreground.")
-                
+
                 #if os(macOS) && arch(arm64)
                 if #available(macOS 13, *), let appleConfig = vm.config as? UTMAppleConfiguration, appleConfig.system.boot.operatingSystem == .macOS {
                     Button {
@@ -98,15 +98,15 @@ struct VMContextMenuModifier: ViewModifier {
                     }.help("Boot into recovery mode.")
                 }
                 #endif
-                
-                if let _ = vm.wrapped as? UTMQemuVirtualMachine {
+
+                if vm.wrapped as? UTMQemuVirtualMachine != nil {
                     Button {
                         data.run(vm: vm, options: .bootDisposibleMode)
                     } label: {
                         Label("Run without saving changes", systemImage: "memories")
                     }.help("Run the VM in the foreground, without saving data changes to disk.")
                 }
-                
+
                 #if os(iOS) || os(visionOS)
                 if let qemuConfig = vm.config as? UTMQemuConfiguration {
                     Button {
@@ -117,7 +117,7 @@ struct VMContextMenuModifier: ViewModifier {
                     .disabled(qemuConfig.qemu.isGuestToolsInstallRequested)
                 }
                 #endif
-                
+
                 Divider()
             }
             Button {

--- a/Platform/Shared/VMDetailsView.swift
+++ b/Platform/Shared/VMDetailsView.swift
@@ -22,19 +22,19 @@ struct VMDetailsView: View {
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     #if !os(macOS)
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass: UserInterfaceSizeClass?
-    
+
     private var regularScreenSizeClass: Bool {
         horizontalSizeClass == .regular
     }
     #else
     private let regularScreenSizeClass: Bool = true
     #endif
-    
+
     private var sizeLabel: String {
         let size = data.computeSize(for: vm)
         return ByteCountFormatter.string(fromByteCount: size, countStyle: .binary)
     }
-    
+
     var body: some View {
         if vm.isDeleted {
             VStack {
@@ -116,7 +116,7 @@ struct VMDetailsView: View {
 /// Returns just the content under macOS but adds the title on iOS. #3099
 private struct VMOptionalNavigationTitleModifier: ViewModifier {
     @ObservedObject var vm: VMData
-    
+
     func body(content: Content) -> some View {
         #if os(macOS)
         return content.navigationSubtitle(vm.detailsTitleLabel)
@@ -130,7 +130,7 @@ struct Screenshot: View {
     @ObservedObject var vm: VMData
     let large: Bool
     @EnvironmentObject private var data: UTMData
-    
+
     var body: some View {
         ZStack {
             Rectangle()
@@ -185,7 +185,7 @@ struct Details: View {
     @ObservedObject var vm: VMData
     let sizeLabel: String
     @EnvironmentObject private var data: UTMData
-    
+
     var body: some View {
         VStack {
             if vm.isShortcut {
@@ -270,7 +270,7 @@ struct Details: View {
         }.lineLimit(1)
         .truncationMode(.tail)
     }
-    
+
     private func plainLabel(_ text: String, systemImage: String) -> some View {
         return Label {
             Text(LocalizedStringKey(text))
@@ -282,7 +282,7 @@ struct Details: View {
 
 struct DetailsLabelStyle: LabelStyle {
     var color: Color = .accentColor
-    
+
     func makeBody(configuration: Configuration) -> some View {
         Label(
             title: { configuration.title.font(.headline) },
@@ -299,11 +299,11 @@ struct DetailsLabelStyle: LabelStyle {
 
 private struct OptionalSelectableText: View {
     var content: String?
-    
+
     init(_ content: String?) {
         self.content = content
     }
-    
+
     var body: some View {
         if #available(iOS 15, macOS 12, *) {
             (content.map { Text($0) } ?? Text("Inactive", comment: "VMDetailsView"))
@@ -318,7 +318,7 @@ private struct OptionalSelectableText: View {
 
 struct VMDetailsView_Previews: PreviewProvider {
     @State static private var config = UTMQemuConfiguration()
-    
+
     static var previews: some View {
         VMDetailsView(vm: VMData(from: .empty))
         .onAppear {

--- a/Platform/Shared/VMToolbarModifier.swift
+++ b/Platform/Shared/VMToolbarModifier.swift
@@ -24,7 +24,7 @@ struct VMToolbarModifier: ViewModifier {
     @State private var confirmAction: ConfirmAction?
     @EnvironmentObject private var data: UTMData
     @State private var shareItem: VMShareItemModifier.ShareItem?
-    
+
     #if os(macOS)
     let buttonPlacement: ToolbarItemPlacement = .automatic
     let padding: CGFloat = 0
@@ -44,7 +44,7 @@ struct VMToolbarModifier: ViewModifier {
         }
     }
     #endif
-    
+
     func body(content: Content) -> some View {
         content.toolbar {
             ToolbarItemGroup(placement: buttonPlacement) {

--- a/Platform/Shared/VMWizardContent.swift
+++ b/Platform/Shared/VMWizardContent.swift
@@ -19,12 +19,12 @@ import SwiftUI
 struct VMWizardContent<Content>: View where Content: View {
     let titleKey: LocalizedStringKey
     let content: Content
-    
+
     init(_ titleKey: LocalizedStringKey, @ViewBuilder content: () -> Content) {
         self.titleKey = titleKey
         self.content = content()
     }
-    
+
     var body: some View {
         #if os(macOS)
         Text(titleKey)

--- a/Platform/Shared/VMWizardDrivesView.swift
+++ b/Platform/Shared/VMWizardDrivesView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct VMWizardDrivesView: View {
     @ObservedObject var wizardState: VMWizardState
-    
+
     var body: some View {
         VMWizardContent("Storage") {
             Section {
@@ -37,14 +37,13 @@ struct VMWizardDrivesView: View {
             } header: {
                 Text("Size")
             }
-            
         }
     }
 }
 
 struct VMWizardDrivesView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardDrivesView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardHardwareView.swift
+++ b/Platform/Shared/VMWizardHardwareView.swift
@@ -21,7 +21,7 @@ import Virtualization
 
 struct VMWizardHardwareView: View {
     @ObservedObject var wizardState: VMWizardState
-    
+
     var minCores: Int {
         #if canImport(Virtualization)
         VZVirtualMachineConfiguration.minimumAllowedCPUCount
@@ -29,7 +29,7 @@ struct VMWizardHardwareView: View {
         1
         #endif
     }
-    
+
     var maxCores: Int {
         #if canImport(Virtualization)
         VZVirtualMachineConfiguration.maximumAllowedCPUCount
@@ -37,7 +37,7 @@ struct VMWizardHardwareView: View {
         Int(sysctlIntRead("hw.ncpu"))
         #endif
     }
-    
+
     var minMemoryMib: Int {
         #if canImport(Virtualization)
         Int(VZVirtualMachineConfiguration.minimumAllowedMemorySize / UInt64(wizardState.bytesInMib))
@@ -45,7 +45,7 @@ struct VMWizardHardwareView: View {
         8
         #endif
     }
-    
+
     var maxMemoryMib: Int {
         #if canImport(Virtualization)
         Int(VZVirtualMachineConfiguration.maximumAllowedMemorySize / UInt64(wizardState.bytesInMib))
@@ -53,7 +53,7 @@ struct VMWizardHardwareView: View {
         sysctlIntRead("hw.memsize")
         #endif
     }
-    
+
     var body: some View {
         VMWizardContent("Hardware") {
             if !wizardState.useVirtualization {
@@ -65,7 +65,7 @@ struct VMWizardHardwareView: View {
                 } header: {
                     Text("Architecture")
                 }
-                
+
                 Section {
                     VMConfigConstantPicker(selection: $wizardState.systemTarget, type: wizardState.systemArchitecture.targetType)
                 } header: {
@@ -84,7 +84,7 @@ struct VMWizardHardwareView: View {
             } header: {
                 Text("Memory")
             }
-            
+
             Section {
                 HStack {
                     Stepper(value: $wizardState.systemCpuCount, in: minCores...maxCores) {
@@ -106,14 +106,11 @@ struct VMWizardHardwareView: View {
             } header: {
                 Text("CPU")
             }
-            
-            
-            
+
             if !wizardState.useAppleVirtualization && wizardState.operatingSystem == .Linux {
                 DetailedSection("Hardware OpenGL Acceleration", description: "There are known issues in some newer Linux drivers including black screen, broken compositing, and apps failing to render.") {
                     Toggle("Enable hardware OpenGL acceleration", isOn: $wizardState.isGLEnabled)
                 }
-                
             }
         }
         .textFieldStyle(.roundedBorder)
@@ -130,7 +127,7 @@ struct VMWizardHardwareView: View {
             }
         }
     }
-    
+
     private func sysctlIntRead(_ name: String) -> Int {
         var value: Int = 0
         var size = MemoryLayout<UInt64>.size
@@ -141,7 +138,7 @@ struct VMWizardHardwareView: View {
 
 struct VMWizardHardwareView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardHardwareView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardOSLinuxView.swift
+++ b/Platform/Shared/VMWizardOSLinuxView.swift
@@ -27,7 +27,7 @@ struct VMWizardOSLinuxView: View {
     @ObservedObject var wizardState: VMWizardState
     @State private var isFileImporterPresented: Bool = false
     @State private var selectImage: SelectImage = .kernel
-    
+
     private var hasVenturaFeatures: Bool {
         if #available(macOS 13, *) {
             return true
@@ -111,7 +111,7 @@ struct VMWizardOSLinuxView: View {
                 } header: {
                     Text("Linux Root FS Image (optional)")
                 }
-                
+
                 Section {
                     FileBrowseField(url: $wizardState.bootImageURL, isFileImporterPresented: $isFileImporterPresented) {
                         selectImage = .bootImage

--- a/Platform/Shared/VMWizardOSLinuxView.swift
+++ b/Platform/Shared/VMWizardOSLinuxView.swift
@@ -23,7 +23,7 @@ struct VMWizardOSLinuxView: View {
         case rootImage
         case bootImage
     }
-    
+
     @ObservedObject var wizardState: VMWizardState
     @State private var isFileImporterPresented: Bool = false
     @State private var selectImage: SelectImage = .kernel
@@ -35,7 +35,7 @@ struct VMWizardOSLinuxView: View {
             return false
         }
     }
-    
+
     var body: some View {
         VMWizardContent("Linux") {
 #if os(macOS)
@@ -45,7 +45,7 @@ struct VMWizardOSLinuxView: View {
                 }
             }
 #endif
-            
+
             Section {
                 Toggle("Boot from kernel image", isOn: $wizardState.useLinuxKernel)
                     .help("If set, boot directly from a raw kernel image and initrd. Otherwise, boot from a supported ISO.")
@@ -64,7 +64,7 @@ struct VMWizardOSLinuxView: View {
             } header: {
                 Text("Boot Image Type")
             }
-            
+
             #if arch(arm64)
             if #available(macOS 13, *), wizardState.useAppleVirtualization {
                 Section {
@@ -77,9 +77,9 @@ struct VMWizardOSLinuxView: View {
                 }
             }
             #endif
-            
+
             if wizardState.useLinuxKernel {
-                
+
                 Section {
                     FileBrowseField(url: $wizardState.linuxKernelURL, isFileImporterPresented: $isFileImporterPresented, hasClearButton: false) {
                         selectImage = .kernel
@@ -91,7 +91,7 @@ struct VMWizardOSLinuxView: View {
                         Text("Linux kernel (required)")
                     }
                 }
-                
+
                 Section {
                     FileBrowseField(url: $wizardState.linuxInitialRamdiskURL, isFileImporterPresented: $isFileImporterPresented) {
                         selectImage = .initialRamdisk
@@ -103,7 +103,7 @@ struct VMWizardOSLinuxView: View {
                         Text("Linux initial ramdisk (optional)")
                     }
                 }
-                
+
                 Section {
                     FileBrowseField(url: $wizardState.linuxRootImageURL, isFileImporterPresented: $isFileImporterPresented) {
                         selectImage = .rootImage
@@ -119,7 +119,7 @@ struct VMWizardOSLinuxView: View {
                 } header: {
                     Text("Boot ISO Image (optional)")
                 }
-                
+
                 Section {
                     TextField("Boot Arguments", text: $wizardState.linuxBootArguments)
                 } header: {
@@ -137,12 +137,10 @@ struct VMWizardOSLinuxView: View {
             if wizardState.isBusy {
                 Spinner(size: .large)
             }
-            
-            
         }
         .fileImporter(isPresented: $isFileImporterPresented, allowedContentTypes: [.data], onCompletion: processImage)
     }
-    
+
     private func processImage(_ result: Result<URL, Error>) {
         wizardState.busyWorkAsync {
             let url = try result.get()
@@ -165,7 +163,7 @@ struct VMWizardOSLinuxView: View {
 
 struct VMWizardOSLinuxView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardOSLinuxView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardOSMacView.swift
+++ b/Platform/Shared/VMWizardOSMacView.swift
@@ -49,7 +49,7 @@ struct VMWizardOSMacView: View {
         .fileImporter(isPresented: $isFileImporterPresented, allowedContentTypes: [.ipsw], onCompletion: processIpsw)
         .onDrop(of: [.fileURL], delegate: self)
     }
-    
+
     private func processIpsw(_ result: Result<URL, Error>) {
         wizardState.busyWorkAsync {
             #if arch(arm64)
@@ -120,7 +120,7 @@ extension VMWizardOSMacView: DropDelegate {
 @available(macOS 12, *)
 struct VMWizardOSMacView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardOSMacView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardOSOtherView.swift
+++ b/Platform/Shared/VMWizardOSOtherView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct VMWizardOSOtherView: View {
     @ObservedObject var wizardState: VMWizardState
     @State private var isFileImporterPresented: Bool = false
-    
+
     var body: some View {
         VMWizardContent("Other") {
             if !wizardState.isSkipBootImage {
@@ -41,7 +41,7 @@ struct VMWizardOSOtherView: View {
         }
         .fileImporter(isPresented: $isFileImporterPresented, allowedContentTypes: [.data], onCompletion: processImage)
     }
-    
+
     private func processImage(_ result: Result<URL, Error>) {
         wizardState.busyWorkAsync {
             let url = try result.get()
@@ -54,7 +54,7 @@ struct VMWizardOSOtherView: View {
 
 struct VMWizardOSOtherView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardOSOtherView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardOSView.swift
+++ b/Platform/Shared/VMWizardOSView.swift
@@ -80,12 +80,12 @@ struct VMWizardOSView: View {
 struct OperatingSystem: View {
     let imageName: String
     let name: LocalizedStringKey
-    
+
     private var imageURL: URL {
         let path = Bundle.main.path(forResource: imageName, ofType: "png", inDirectory: "Icons")!
         return URL(fileURLWithPath: path)
     }
-    
+
 #if os(macOS)
     private var icon: Image {
         Image(nsImage: NSImage(byReferencing: imageURL))
@@ -95,7 +95,7 @@ struct OperatingSystem: View {
         Image(uiImage: UIImage(contentsOfURL: imageURL)!)
     }
 #endif
-    
+
     var body: some View {
         HStack {
             icon
@@ -111,7 +111,7 @@ struct OperatingSystem: View {
 
 struct VMWizardOSView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardOSView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardOSWindowsView.swift
+++ b/Platform/Shared/VMWizardOSWindowsView.swift
@@ -20,7 +20,7 @@ struct VMWizardOSWindowsView: View {
     @ObservedObject var wizardState: VMWizardState
     @State private var isFileImporterPresented: Bool = false
     @State private var useVhdx: Bool = false
-    
+
     var body: some View {
         VMWizardContent("Windows") {
             Section {
@@ -35,7 +35,7 @@ struct VMWizardOSWindowsView: View {
                             wizardState.isGuestToolsInstallRequested = false
                         }
                     }
-                
+
                 if wizardState.isWindows10OrHigher {
                     Toggle("Import VHDX Image", isOn: $useVhdx)
                     #if os(macOS)
@@ -77,14 +77,14 @@ struct VMWizardOSWindowsView: View {
                     }
                 }
             }
-            
+
             Section {
                 if useVhdx {
                     FileBrowseField(url: $wizardState.windowsBootVhdx, isFileImporterPresented: $isFileImporterPresented, hasClearButton: false)
                 } else {
                     FileBrowseField(url: $wizardState.bootImageURL, isFileImporterPresented: $isFileImporterPresented, hasClearButton: false)
                 }
-                
+
                 if wizardState.isBusy {
                     Spinner(size: .large)
                 }
@@ -108,7 +108,7 @@ struct VMWizardOSWindowsView: View {
                         .disabled(!wizardState.systemBootUefi)
                 }
             }
-            
+
             // Disabled on iOS 14 due to a SwiftUI layout bug
             // Disabled for non-Windows 10 installs due to autounattend version
             if #available(iOS 15, *), wizardState.isWindows10OrHigher {
@@ -119,7 +119,7 @@ struct VMWizardOSWindowsView: View {
         }
         .fileImporter(isPresented: $isFileImporterPresented, allowedContentTypes: [.data], onCompletion: processImage)
     }
-    
+
     private func processImage(_ result: Result<URL, Error>) {
         wizardState.busyWorkAsync {
             let url = try result.get()
@@ -140,7 +140,7 @@ struct VMWizardOSWindowsView: View {
 
 struct VMWizardOSWindowsView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardOSWindowsView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardSharingView.swift
+++ b/Platform/Shared/VMWizardSharingView.swift
@@ -19,16 +19,16 @@ import SwiftUI
 struct VMWizardSharingView: View {
     @ObservedObject var wizardState: VMWizardState
     @State private var isFileImporterPresented: Bool = false
-    
+
     var body: some View {
         VMWizardContent("Shared Directory") {
             DetailedSection("Shared Directory Path", description: "Optionally select a directory to make accessible inside the VM. Note that support for shared directories varies by the guest operating system and may require additional guest drivers to be installed. See UTM support pages for more details.") {
                 FileBrowseField(url: $wizardState.sharingDirectoryURL, isFileImporterPresented: $isFileImporterPresented)
-                
+
                 if !wizardState.useAppleVirtualization {
                     Toggle("Share is read only", isOn: $wizardState.sharingReadOnly)
                 }
-                
+
                 if wizardState.isBusy {
                     Spinner(size: .large)
                 }
@@ -36,7 +36,7 @@ struct VMWizardSharingView: View {
         }
         .fileImporter(isPresented: $isFileImporterPresented, allowedContentTypes: [.folder], onCompletion: processDirectory)
     }
-    
+
     private func processDirectory(_ result: Result<URL, Error>) {
         wizardState.busyWorkAsync {
             let url = try result.get()
@@ -49,7 +49,7 @@ struct VMWizardSharingView: View {
 
 struct VMWizardSharingView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardSharingView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardStartView.swift
+++ b/Platform/Shared/VMWizardStartView.swift
@@ -21,7 +21,7 @@ import Virtualization
 
 struct VMWizardStartView: View {
     @ObservedObject var wizardState: VMWizardState
-    
+
     var isVirtualizationSupported: Bool {
         #if os(macOS)
         VZVirtualMachine.isSupported && !processIsTranslated()
@@ -29,7 +29,7 @@ struct VMWizardStartView: View {
         jb_has_hypervisor()
         #endif
     }
-    
+
     var isEmulationSupported: Bool {
         #if WITH_QEMU_TCI
         true
@@ -37,7 +37,7 @@ struct VMWizardStartView: View {
         Main.jitAvailable
         #endif
     }
-    
+
     var body: some View {
         VMWizardContent("Start") {
             Section {
@@ -127,7 +127,7 @@ struct VMWizardStartView: View {
 
         }
     }
-    
+
     private func processIsTranslated() -> Bool {
         let key = "sysctl.proc_translated"
         var ret = Int32(0)
@@ -143,7 +143,7 @@ struct VMWizardStartView: View {
 
 struct VMWizardStartView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardStartView(wizardState: wizardState)
     }

--- a/Platform/Shared/VMWizardState.swift
+++ b/Platform/Shared/VMWizardState.swift
@@ -24,7 +24,7 @@ enum VMWizardPage: Int, Identifiable {
     var id: Int {
         return self.rawValue
     }
-    
+
     case start
     case operatingSystem
     case macOSBoot
@@ -41,7 +41,7 @@ enum VMWizardOS: String, Identifiable {
     var id: String {
         return self.rawValue
     }
-    
+
     case Other
     case macOS
     case Linux
@@ -51,7 +51,7 @@ enum VMWizardOS: String, Identifiable {
 @MainActor class VMWizardState: ObservableObject {
     let bytesInMib = 1048576
     let bytesInGib = 1073741824
-    
+
     @Published var slide: AnyTransition = .identity
     @Published var currentPage: VMWizardPage = .start
     @Published var pageHistory = [VMWizardPage]() {
@@ -115,7 +115,7 @@ enum VMWizardOS: String, Identifiable {
     @Published var sharingReadOnly: Bool = false
     @Published var name: String?
     @Published var isOpenSettingsAfterCreation: Bool = false
-    
+
     /// SwiftUI BUG: on macOS 12, when VoiceOver is enabled and isBusy changes the disable state of a button being clicked, 
     var isNeverDisabledWorkaround: Bool {
         #if os(macOS)
@@ -129,7 +129,7 @@ enum VMWizardOS: String, Identifiable {
         return true
         #endif
     }
-    
+
     var hasNextButton: Bool {
         switch currentPage {
         case .start:
@@ -142,7 +142,7 @@ enum VMWizardOS: String, Identifiable {
             return true
         }
     }
-    
+
     #if os(macOS) && arch(arm64)
     var isPendingIPSWDownload: Bool {
         guard #available(macOS 12, *), useAppleVirtualization && operatingSystem == .macOS else {
@@ -156,15 +156,15 @@ enum VMWizardOS: String, Identifiable {
     #else
     let isPendingIPSWDownload: Bool = false
     #endif
-    
+
     var slideIn: AnyTransition {
         .asymmetric(insertion: .move(edge: .trailing), removal: .opacity)
     }
-    
+
     var slideOut: AnyTransition {
         .asymmetric(insertion: .move(edge: .leading), removal: .opacity)
     }
-    
+
     func next() {
         var nextPage = currentPage
         switch currentPage {
@@ -254,14 +254,14 @@ enum VMWizardOS: String, Identifiable {
             nextPageBinding = .constant(nil)
         }
     }
-    
+
     func back() {
         slide = slideOut
         withAnimation {
             _ = pageHistory.popLast()
         }
     }
-    
+
     #if os(macOS)
     private func generateAppleConfig() throws -> UTMAppleConfiguration {
         let config = UTMAppleConfiguration()
@@ -340,7 +340,7 @@ enum VMWizardOS: String, Identifiable {
         }
         return config
     }
-    
+
     #if arch(arm64)
     @available(macOS 12, *)
     private func fetchLatestPlatform() {
@@ -365,7 +365,7 @@ enum VMWizardOS: String, Identifiable {
     }
     #endif
     #endif
-    
+
     private func generateQemuConfig() throws -> UTMQemuConfiguration {
         let config = UTMQemuConfiguration()
         config.information.name = name!
@@ -471,7 +471,7 @@ enum VMWizardOS: String, Identifiable {
         }
         return config
     }
-    
+
     func generateConfig() throws -> any UTMConfiguration {
         if useVirtualization && useAppleVirtualization {
             #if os(macOS)
@@ -483,7 +483,7 @@ enum VMWizardOS: String, Identifiable {
             return try generateQemuConfig()
         }
     }
-    
+
     /// Execute a task with spinning progress indicator (Swift concurrency version)
     /// - Parameter work: Function to execute
     func busyWorkAsync(_ work: @escaping @Sendable () async throws -> Void) {
@@ -512,7 +512,7 @@ extension VMWizardState {
             }
         }
     }
-    
+
     private func confusedUserCheckBootImage() throws {
         guard let path = bootImageURL?.path.lowercased() else {
             return

--- a/Platform/Shared/VMWizardSummaryView.swift
+++ b/Platform/Shared/VMWizardSummaryView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct VMWizardSummaryView: View {
     @ObservedObject var wizardState: VMWizardState
     @EnvironmentObject private var data: UTMData
-    
+
     var storageDescription: String {
         var size = Int64(wizardState.storageSizeGib * wizardState.bytesInGib)
         #if arch(arm64)
@@ -31,7 +31,7 @@ struct VMWizardSummaryView: View {
         #endif
         return ByteCountFormatter.string(fromByteCount: size, countStyle: .binary)
     }
-    
+
     var coreDescription: String {
         let cores = wizardState.systemCpuCount
         if cores == 0 {
@@ -40,7 +40,7 @@ struct VMWizardSummaryView: View {
             return String.localizedStringWithFormat(NSLocalizedString("%lld Cores", comment: "VMWizardSummaryView"), cores)
         }
     }
-    
+
     var body: some View {
         VStack {
             #if os(macOS)
@@ -104,7 +104,7 @@ struct VMWizardSummaryView: View {
             }
         }
     }
-    
+
     var info: some View {
         Group {
             TextField("Name", text: $wizardState.name.bound)
@@ -115,7 +115,7 @@ struct VMWizardSummaryView: View {
             #endif
         }
     }
-    
+
     var system: some View {
         Group {
             TextField("Engine", text: .constant(NSLocalizedString(wizardState.useAppleVirtualization ? "Apple Virtualization" : "QEMU", comment: "VMWizardSummaryView")))
@@ -132,7 +132,7 @@ struct VMWizardSummaryView: View {
             }
         }
     }
-    
+
     var boot: some View {
         Group {
             TextField("Operating System", text: .constant(NSLocalizedString(wizardState.operatingSystem.rawValue, comment: "VMWizardSummaryView")))
@@ -164,7 +164,7 @@ struct VMWizardSummaryView: View {
             }
         }
     }
-    
+
     var sharing: some View {
         Group {
             Toggle("Share Directory", isOn: .constant(wizardState.sharingDirectoryURL != nil))
@@ -178,7 +178,7 @@ struct VMWizardSummaryView: View {
 
 struct VMWizardSummaryView_Previews: PreviewProvider {
     @StateObject static var wizardState = VMWizardState()
-    
+
     static var previews: some View {
         VMWizardSummaryView(wizardState: wizardState)
     }

--- a/Platform/UTMDownloadIPSWTask.swift
+++ b/Platform/UTMDownloadIPSWTask.swift
@@ -22,21 +22,21 @@ import Virtualization
 @available(macOS 12, *)
 class UTMDownloadIPSWTask: UTMDownloadTask {
     let config: UTMAppleConfiguration
-    
+
     private var cacheUrl: URL {
         fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first!
     }
-    
+
     @MainActor init(for config: UTMAppleConfiguration) {
         self.config = config
         super.init(for: config.system.boot.macRecoveryIpswURL!, named: config.information.name)
     }
-    
+
     override func processCompletedDownload(at location: URL) async throws -> any UTMVirtualMachine {
         if !fileManager.fileExists(atPath: cacheUrl.path) {
             try fileManager.createDirectory(at: cacheUrl, withIntermediateDirectories: false)
         }
-        
+
         let cacheIpsw = cacheUrl.appendingPathComponent(url.lastPathComponent)
         if fileManager.fileExists(atPath: cacheIpsw.path) {
             try fileManager.removeItem(at: cacheIpsw)

--- a/Platform/UTMDownloadTask.swift
+++ b/Platform/UTMDownloadTask.swift
@@ -24,26 +24,26 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
     private var downloadTask: Task<(any UTMVirtualMachine)?, Error>!
     private var taskContinuation: CheckedContinuation<(any UTMVirtualMachine)?, Error>?
     @MainActor private(set) lazy var pendingVM: UTMPendingVirtualMachine = createPendingVM()
-    
+
     private let kMaxRetries = 5
     private var retries = 0
-    
+
     var fileManager: FileManager {
         FileManager.default
     }
-    
+
     init(for url: URL, named name: String) {
         self.url = url
         self.name = name
     }
-    
+
     /// Called by subclass when download is completed
     /// - Parameter location: Downloaded file location
     /// - Returns: Processed UTM virtual machine
     func processCompletedDownload(at location: URL) async throws -> any UTMVirtualMachine {
         throw "Not Implemented"
     }
-    
+
     internal func urlSession(_ session: URLSession, downloadTask sessionTask: URLSessionDownloadTask, didFinishDownloadingTo location: URL) {
         guard !downloadTask.isCancelled else {
             sessionTask.cancel()
@@ -78,7 +78,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
 #endif
         }
     }
-    
+
     /// received when the download progresses
     internal func urlSession(_ session: URLSession, downloadTask sessionTask: URLSessionDownloadTask, didWriteData bytesWritten: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite: Int64) {
         guard !downloadTask.isCancelled else {
@@ -92,7 +92,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
                                                 estimatedTotal: totalBytesExpectedToWrite)
         }
     }
-    
+
     /// when the session ends with an error, it could be cancelled or an actual error
     internal func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         let error = error as? NSError
@@ -123,7 +123,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
             taskContinuation.resume(returning: nil)
         }
     }
-    
+
     internal func urlSession(_ session: URLSession, didBecomeInvalidWithError error: Error?) {
         guard let taskContinuation = taskContinuation else {
             return
@@ -135,7 +135,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
             taskContinuation.resume(returning: nil)
         }
     }
-    
+
     /// Create a placeholder object to show
     /// - Returns: Pending VM
     @MainActor private func createPendingVM() -> UTMPendingVirtualMachine {
@@ -143,8 +143,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
             self.cancel()
         }
     }
-    
-    
+
     /// Starts the download
     /// - Returns: Completed download or nil if canceled
     func download() async throws -> (any UTMVirtualMachine)? {
@@ -160,7 +159,7 @@ class UTMDownloadTask: NSObject, URLSessionDelegate, URLSessionDownloadDelegate 
         }
         return try await downloadTask.value
     }
-    
+
     /// Try to cancel the download
     func cancel() {
         downloadTask?.cancel()

--- a/Platform/UTMDownloadVMTask.swift
+++ b/Platform/UTMDownloadVMTask.swift
@@ -23,7 +23,7 @@ class UTMDownloadVMTask: UTMDownloadTask {
     init(for url: URL) {
         super.init(for: url, named: UTMDownloadVMTask.name(for: url))
     }
-    
+
     static private func name(for url: URL) -> String {
         /// try to detect the filename from the URL
         let filename = url.lastPathComponent
@@ -34,12 +34,12 @@ class UTMDownloadVMTask: UTMDownloadTask {
         }
         return nameWithoutZIP
     }
-    
+
     override func processCompletedDownload(at location: URL) async throws -> any UTMVirtualMachine {
         let tempDir = fileManager.temporaryDirectory
         let originalFilename = url.lastPathComponent
         let downloadedZip = tempDir.appendingPathComponent(originalFilename)
-        var fileURL: URL? = nil
+        var fileURL: URL?
         do {
             if fileManager.fileExists(atPath: downloadedZip.path) {
                 try fileManager.removeItem(at: downloadedZip)
@@ -65,7 +65,7 @@ class UTMDownloadVMTask: UTMDownloadTask {
             throw error
         }
     }
-    
+
     private func partialUnzipOnlyUtmVM(zipFileURL: URL, destinationFolder: URL, fileManager: FileManager) throws -> URL {
         let utmFileEnding = ".utm"
         let utmDirectoryEnding = "\(utmFileEnding)/"
@@ -97,13 +97,13 @@ class UTMDownloadVMTask: UTMDownloadTask {
             throw UnzipNoUTMFileError()
         }
     }
-    
+
     private class UnzipNoUTMFileError: Error {
         var errorDescription: String? {
             NSLocalizedString("There is no UTM file in the downloaded ZIP archive.", comment: "Error shown when importing a ZIP file from web that doesn't contain a UTM Virtual Machine.")
         }
     }
-    
+
     private class CreateUTMFailed: Error {
         var errorDescription: String? {
             NSLocalizedString("Failed to parse the downloaded VM.", comment: "UTMDownloadVMTask")

--- a/Platform/iOS/ActivityView.swift
+++ b/Platform/iOS/ActivityView.swift
@@ -18,12 +18,12 @@ import SwiftUI
 
 struct ActivityView: UIViewControllerRepresentable {
     let activityItems: [Any]
-    
+
     func makeUIViewController(context: Context) -> UIActivityViewController {
         let controller = UIActivityViewController(activityItems: activityItems, applicationActivities: nil)
         return controller
     }
-    
+
     func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {
     }
 }

--- a/Platform/iOS/IASKAppSettings.swift
+++ b/Platform/iOS/IASKAppSettings.swift
@@ -21,7 +21,7 @@ struct IASKAppSettings: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> IASKAppSettingsViewController {
         return IASKAppSettingsViewController()
     }
-    
+
     func updateUIViewController(_ uiViewController: IASKAppSettingsViewController, context: Context) {
         uiViewController.neverShowPrivacySettings = !context.environment.showPrivacyLink
         uiViewController.showCreditsFooter = false

--- a/Platform/iOS/ImagePicker.swift
+++ b/Platform/iOS/ImagePicker.swift
@@ -23,16 +23,16 @@ struct ImagePicker: UIViewControllerRepresentable {
         init(_ parent: ImagePicker) {
             self.parent = parent
         }
-        
+
         func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
             if let imageURL = info[.imageURL] as? URL {
                 parent.onImageSelected(imageURL)
             }
         }
     }
-    
+
     let onImageSelected: (URL?) -> Void
-    
+
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
         picker.delegate = context.coordinator
@@ -43,7 +43,7 @@ struct ImagePicker: UIViewControllerRepresentable {
     func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
 
     }
-    
+
     func makeCoordinator() -> Coordinator {
         Coordinator(self)
     }
@@ -51,8 +51,8 @@ struct ImagePicker: UIViewControllerRepresentable {
 
 struct ImagePicker_Previews: PreviewProvider {
     static var previews: some View {
-        ImagePicker() { _ in
-            
+        ImagePicker { _ in
+
         }
     }
 }

--- a/Platform/iOS/UTMDataExtension.swift
+++ b/Platform/iOS/UTMDataExtension.swift
@@ -29,7 +29,7 @@ extension UTMData {
         let session = VMSessionState(for: wrapped as! UTMQemuVirtualMachine)
         session.start()
     }
-    
+
     func stop(vm: VMData) {
         guard let wrapped = vm.wrapped else {
             return
@@ -38,11 +38,11 @@ extension UTMData {
             wrapped.requestVmDeleteState()
         }
     }
-    
+
     func close(vm: VMData) {
         // do nothing
     }
-    
+
     func tryClickAtPoint(point: CGPoint, button: CSInputButton) {
         if let vc = vmVC as? VMDisplayMetalViewController, let input = vc.vmInput {
             input.sendMouseButton(button, pressed: true)
@@ -51,7 +51,7 @@ extension UTMData {
             }
         }
     }
-    
+
     func trySendTextSpice(_ text: String) {
         if let vc = vmVC as? VMDisplayMetalViewController {
             #if !os(visionOS) // FIXME: broken in visionOS

--- a/Platform/iOS/UTMExternalSceneDelegate.swift
+++ b/Platform/iOS/UTMExternalSceneDelegate.swift
@@ -19,10 +19,10 @@ import SwiftUI
 class UTMExternalSceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObject {
     var window: UIWindow?
     var screen: UIScreen?
-    
+
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
+
         if session.role == .windowExternalDisplay {
             let window = UIWindow(windowScene: windowScene)
             let viewController = UIHostingController(rootView: UTMMainView(isInteractive: false))
@@ -32,7 +32,7 @@ class UTMExternalSceneDelegate: NSObject, UIWindowSceneDelegate, ObservableObjec
             setupDisplayLinkIfNecessary()
         }
     }
-    
+
     func windowScene(_ windowScene: UIWindowScene, didUpdate previousCoordinateSpace: UICoordinateSpace, interfaceOrientation previousInterfaceOrientation: UIInterfaceOrientation, traitCollection previousTraitCollection: UITraitCollection) {
         setupDisplayLinkIfNecessary()
     }

--- a/Platform/iOS/UTMMainView.swift
+++ b/Platform/iOS/UTMMainView.swift
@@ -19,17 +19,17 @@ import SwiftUI
 @MainActor
 struct UTMMainView: View {
     let isInteractive: Bool
-    
+
     @State private var data: UTMData = UTMData()
     @State private var session: VMSessionState?
-    
+
     private let vmSessionCreatedNotification = NotificationCenter.default.publisher(for: .vmSessionCreated)
     private let vmSessionEndedNotification = NotificationCenter.default.publisher(for: .vmSessionEnded)
-    
+
     init(isInteractive: Bool = true) {
         self.isInteractive = isInteractive
     }
-    
+
     var body: some View {
         ZStack {
             if let session = session {

--- a/Platform/iOS/VMToolbarUSBMenuView.swift
+++ b/Platform/iOS/VMToolbarUSBMenuView.swift
@@ -18,7 +18,7 @@ import SwiftUI
 
 struct VMToolbarUSBMenuView: View {
     @EnvironmentObject private var session: VMSessionState
-    
+
     var body: some View {
         Menu {
             if session.allUsbDevices.isEmpty {
@@ -48,7 +48,7 @@ struct VMToolbarUSBMenuView: View {
             session.refreshDevices()
         })
     }
-    
+
     // When < iOS 14.5, the checkmark label image does not show up
     private func suffix(connected isConnected: Bool) -> String {
         if #unavailable(iOS 14.5), isConnected {

--- a/Platform/iOS/VMToolbarView.swift
+++ b/Platform/iOS/VMToolbarView.swift
@@ -172,7 +172,7 @@ struct VMToolbarView: View {
                     }
                 }
             }
-            .onChange(of: state.isUserInteracting) { newValue in
+            .onChange(of: state.isUserInteracting) { _ in
                 longIdleTimeout.assertUserInteraction()
                 session.activeWindow = state.id
             }
@@ -304,7 +304,7 @@ struct ToolbarButtonStyle: ButtonStyle, ToolbarButtonBaseStyle {
             self.verticalSizeClass = verticalSizeClassEnvironment
         }
     }
-    
+
     func makeBody(configuration: Configuration) -> some View {
         return makeBodyBase(label: configuration.label, isPressed: configuration.isPressed)
     }

--- a/Platform/iOS/VMToolbarView.swift
+++ b/Platform/iOS/VMToolbarView.swift
@@ -24,14 +24,14 @@ struct VMToolbarView: View {
     @State private var isIdle: Bool = false
     @State private var dragPosition: CGPoint = .zero
     @State private var shortIdleTask: DispatchWorkItem?
-    
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
     @EnvironmentObject private var session: VMSessionState
     @StateObject private var longIdleTimeout = LongIdleTimeout()
-    
+
     @Binding var state: VMWindowState
-    
+
     private var spacing: CGFloat {
         let direction: CGFloat
         let distance: CGFloat
@@ -47,7 +47,7 @@ struct VMToolbarView: View {
         }
         return direction * distance
     }
-    
+
     private var nameOfHideIcon: String {
         if location == .topLeft || location == .bottomLeft {
             return "chevron.right"
@@ -55,7 +55,7 @@ struct VMToolbarView: View {
             return "chevron.left"
         }
     }
-    
+
     private var nameOfShowIcon: String {
         if location == .topLeft || location == .bottomLeft {
             return "chevron.left"
@@ -63,7 +63,7 @@ struct VMToolbarView: View {
             return "chevron.right"
         }
     }
-    
+
     private var toolbarToggleOpacity: Double {
         if state.device != nil && !state.isBusy && state.isRunning && isCollapsed && !isMoving {
             if !longIdleTimeout.isUserInteracting {
@@ -77,7 +77,7 @@ struct VMToolbarView: View {
             return 1
         }
     }
-    
+
     var body: some View {
         GeometryReader { geometry in
             Group {
@@ -101,7 +101,7 @@ struct VMToolbarView: View {
                     Label("Restart", systemImage: "restart")
                 }.offset(offset(for: 6))
                 Button {
-                    if case .serial(_, _) = state.device {
+                    if case .serial = state.device {
                         let template = session.qemuConfig.serials[state.device!.configIndex].terminal?.resizeCommand
                         state.toggleDisplayResize(command: template)
                     } else {
@@ -178,7 +178,7 @@ struct VMToolbarView: View {
             }
         }
     }
-    
+
     private func withOptionalAnimation<Result>(_ animation: Animation? = .default, _ body: () throws -> Result) rethrows -> Result {
         if UIAccessibility.isReduceMotionEnabled {
             return try body()
@@ -186,7 +186,7 @@ struct VMToolbarView: View {
             return try withAnimation(animation, body)
         }
     }
-    
+
     private func position(for geometry: GeometryProxy) -> CGPoint {
         let yoffset: CGFloat = 48
         var xoffset: CGFloat = 48
@@ -207,7 +207,7 @@ struct VMToolbarView: View {
             return CGPoint(x: xoffset, y: geometry.size.height - yoffset)
         }
     }
-    
+
     private func closestLocation(to point: CGPoint, for geometry: GeometryProxy) -> ToolbarLocation {
         if point.x < geometry.size.width/2 && point.y < geometry.size.height/2 {
             return .topLeft
@@ -219,7 +219,7 @@ struct VMToolbarView: View {
             return .topRight
         }
     }
-    
+
     private func offset(for index: Int) -> CGSize {
         var sub = 0
         if !session.vm.hasUsbRedirection && index >= 4 {
@@ -228,7 +228,7 @@ struct VMToolbarView: View {
         let x = isCollapsed ? 0 : -CGFloat(index-sub)*spacing
         return CGSize(width: x, height: 0)
     }
-    
+
     private func resetIdle() {
         if let task = shortIdleTask {
             task.cancel()
@@ -254,10 +254,10 @@ enum ToolbarLocation: Int {
 protocol ToolbarButtonBaseStyle<Label, Content> {
     associatedtype Label: View
     associatedtype Content: View
-    
+
     var horizontalSizeClass: UserInterfaceSizeClass? { get }
     var verticalSizeClass: UserInterfaceSizeClass? { get }
-    
+
     func makeBodyBase(label: Label, isPressed: Bool) -> Content
 }
 
@@ -265,7 +265,7 @@ extension ToolbarButtonBaseStyle {
     private var size: CGFloat {
         (horizontalSizeClass == .compact || verticalSizeClass == .compact) ? 32 : 48
     }
-    
+
     func makeBodyBase(label: Label, isPressed: Bool) -> some View {
         ZStack {
             Circle()
@@ -283,16 +283,15 @@ extension ToolbarButtonBaseStyle {
     }
 }
 
-
 struct ToolbarButtonStyle: ButtonStyle, ToolbarButtonBaseStyle {
     typealias Label = Configuration.Label
-    
+
     @Environment(\.horizontalSizeClass) private var horizontalSizeClassEnvironment
     @Environment(\.verticalSizeClass) private var verticalSizeClassEnvironment
-    
+
     var horizontalSizeClass: UserInterfaceSizeClass?
     var verticalSizeClass: UserInterfaceSizeClass?
-    
+
     init(horizontalSizeClass: UserInterfaceSizeClass? = nil, verticalSizeClass: UserInterfaceSizeClass? = nil) {
         if horizontalSizeClass != nil {
             self.horizontalSizeClass = horizontalSizeClass
@@ -313,10 +312,10 @@ struct ToolbarButtonStyle: ButtonStyle, ToolbarButtonBaseStyle {
 
 struct ToolbarMenuStyle: MenuStyle, ToolbarButtonBaseStyle {
     typealias Label = Menu<Configuration.Label, Configuration.Content>
-    
+
     @Environment(\.horizontalSizeClass) internal var horizontalSizeClass
     @Environment(\.verticalSizeClass) internal var verticalSizeClass
-    
+
     func makeBody(configuration: Configuration) -> some View {
         return makeBodyBase(label: Menu(configuration), isPressed: false)
     }
@@ -327,7 +326,7 @@ struct Shake: GeometryEffect {
     var amount: CGFloat = 8
     var shakesPerUnit = 3
     var animatableData: CGFloat
-    
+
     init(shake: Bool) {
         animatableData = shake ? 1.0 : 0.0
     }
@@ -343,8 +342,8 @@ extension ButtonStyle where Self == ToolbarButtonStyle {
     static var toolbar: ToolbarButtonStyle {
         ToolbarButtonStyle()
     }
-    
-    // this is needed to workaround a SwiftUI bug on < iOS 15
+
+    // This is needed to workaround a SwiftUI bug on < iOS 15
     static func toolbar(horizontalSizeClass: UserInterfaceSizeClass?, verticalSizeClass: UserInterfaceSizeClass?) -> ToolbarButtonStyle {
         ToolbarButtonStyle(horizontalSizeClass: horizontalSizeClass, verticalSizeClass: verticalSizeClass)
     }
@@ -358,9 +357,9 @@ extension MenuStyle where Self == ToolbarMenuStyle {
 
 @MainActor private class LongIdleTimeout: ObservableObject {
     private var longIdleTask: DispatchWorkItem?
-    
+
     @Published var isUserInteracting: Bool = true
-    
+
     private func setIsUserInteracting(_ value: Bool) {
         if !UIAccessibility.isReduceMotionEnabled {
             withAnimation {
@@ -370,7 +369,7 @@ extension MenuStyle where Self == ToolbarMenuStyle {
             self.isUserInteracting = value
         }
     }
-    
+
     func assertUserInteraction() {
         if let task = longIdleTask {
             task.cancel()
@@ -386,7 +385,7 @@ extension MenuStyle where Self == ToolbarMenuStyle {
 
 struct VMToolbarView_Previews: PreviewProvider {
     @State static var state = VMWindowState()
-    
+
     static var previews: some View {
         VMToolbarView(state: $state)
     }

--- a/Platform/iOS/VMWindowState.swift
+++ b/Platform/iOS/VMWindowState.swift
@@ -21,55 +21,55 @@ struct VMWindowState: Identifiable {
     enum Device: Identifiable, Hashable {
         case display(CSDisplay, Int)
         case serial(CSPort, Int)
-        
+
         var configIndex: Int {
             switch self {
             case .display(_, let index): return index
             case .serial(_, let index): return index
             }
         }
-        
+
         var id: Self {
             self
         }
     }
-    
+
     let id = UUID()
-    
+
     var device: Device?
-    
+
     private var shouldViewportChange: Bool {
         !(displayScale == 1.0 && displayOrigin == .zero)
     }
-    
+
     var displayScale: CGFloat = 1.0 {
         didSet {
             isViewportChanged = shouldViewportChange
         }
     }
-    
+
     var displayOrigin: CGPoint = CGPoint(x: 0, y: 0) {
         didSet {
             isViewportChanged = shouldViewportChange
         }
     }
-    
+
     var displayViewSize: CGSize = .zero
-    
+
     var isDisplayZoomLocked: Bool = false
-    
+
     var isKeyboardRequested: Bool = false
-    
+
     var isKeyboardShown: Bool = false
-    
+
     var isViewportChanged: Bool = false
-    
+
     var isUserInteracting: Bool = false
-    
+
     var isBusy: Bool = false
-    
+
     var isRunning: Bool = false
-    
+
     var alert: Alert?
 }
 
@@ -83,14 +83,14 @@ extension VMWindowState {
             case .terminateApp: return 1
             case .restart: return 2
             #if !WITH_QEMU_TCI
-            case .deviceConnected(_): return 3
+            case .deviceConnected: return 3
             #endif
-            case .nonfatalError(_): return 4
-            case .fatalError(_): return 5
+            case .nonfatalError: return 4
+            case .fatalError: return 5
             case .memoryWarning: return 6
             }
         }
-        
+
         case powerDown
         case terminateApp
         case restart
@@ -109,7 +109,7 @@ extension VMWindowState {
     private var kVMDefaultResizeCmd: String {
         "stty cols $COLS rows $ROWS\\n"
     }
-    
+
     mutating func resizeDisplayToFit(_ display: CSDisplay, size: CGSize = .zero) {
         let viewSize = displayViewSize
         let displaySize = size == .zero ? display.displaySize : size
@@ -119,13 +119,13 @@ extension VMWindowState {
         displayScale = viewportScale
         displayOrigin = .zero
     }
-    
+
     private mutating func resetDisplay(_ display: CSDisplay) {
         // persist this change in viewState
         displayScale = 1.0
         displayOrigin = .zero
     }
-    
+
     private mutating func resetConsole(_ serial: CSPort, command: String? = nil) {
         let cols = Int(displayViewSize.width)
         let rows = Int(displayViewSize.height)
@@ -136,7 +136,7 @@ extension VMWindowState {
             .replacingOccurrences(of: "\\n", with: "\n")
         serial.write(cmd.data(using: .nonLossyASCII)!)
     }
-    
+
     mutating func toggleDisplayResize(command: String? = nil) {
         if case let .display(display, _) = device {
             if isViewportChanged {
@@ -170,7 +170,7 @@ extension VMWindowState {
         window.isKeyboardVisible = isKeyboardShown
         registryEntry.windowSettings[id] = window
     }
-    
+
     mutating func restoreWindow(from registryEntry: UTMRegistryEntry, device: Device?) {
         guard case let .display(_, id) = device else {
             return

--- a/Platform/iOS/VMWindowView.swift
+++ b/Platform/iOS/VMWindowView.swift
@@ -22,11 +22,11 @@ struct VMWindowView: View {
     @State private var state = VMWindowState()
     @EnvironmentObject private var session: VMSessionState
     @Environment(\.scenePhase) private var scenePhase
-    
+
     private let keyboardDidShowNotification = NotificationCenter.default.publisher(for: UIResponder.keyboardDidShowNotification)
     private let keyboardDidHideNotification = NotificationCenter.default.publisher(for: UIResponder.keyboardDidHideNotification)
     private let didReceiveMemoryWarningNotification = NotificationCenter.default.publisher(for: UIApplication.didReceiveMemoryWarningNotification)
-    
+
     private func withOptionalAnimation<Result>(_ animation: Animation? = .default, _ body: () throws -> Result) rethrows -> Result {
         if UIAccessibility.isReduceMotionEnabled {
             return try body()
@@ -34,19 +34,19 @@ struct VMWindowView: View {
             return try withAnimation(animation, body)
         }
     }
-    
+
     var body: some View {
         ZStack {
             ZStack {
                 if let device = state.device {
                     switch device {
-                    case .display(_, _):
+                    case .display:
                         VMDisplayHostedView(vm: session.vm, device: device, state: $state)
-                    case .serial(_, _):
+                    case .serial:
                         VMDisplayHostedView(vm: session.vm, device: device, state: $state)
                     }
                 } else if !state.isBusy && state.isRunning {
-                    // headless
+                    // Headless
                     HeadlessView()
                 }
                 if state.isBusy || !state.isRunning {
@@ -117,7 +117,7 @@ struct VMWindowView: View {
             #endif
             case .nonfatalError(let message), .fatalError(let message):
                 return Alert(title: Text(message), dismissButton: .cancel(Text("OK")) {
-                    if case .fatalError(_) = type {
+                    if case .fatalError = type {
                         session.stop()
                     } else {
                         session.nonfatalError = nil
@@ -202,7 +202,7 @@ struct VMWindowView: View {
             }
         }
     }
-    
+
     private func vmStateUpdated(from oldState: UTMVirtualMachineState?, to vmState: UTMVirtualMachineState) {
         if oldState == .started {
             saveWindow()
@@ -260,7 +260,7 @@ private struct HeadlessView: View {
 
 #if !os(visionOS)
 /// Stub for non-Vision platforms
-fileprivate struct VMToolbarOrnamentModifier: ViewModifier {
+private struct VMToolbarOrnamentModifier: ViewModifier {
     @Binding var state: VMWindowState
     func body(content: Content) -> some View {
         content

--- a/Platform/iOS/VMWindowView.swift
+++ b/Platform/iOS/VMWindowView.swift
@@ -230,7 +230,7 @@ struct VMWindowView: View {
             }
         }
     }
-    
+
     private func saveWindow() {
         state.saveWindow(to: session.vm.registryEntry, device: state.device)
     }

--- a/Platform/iOS/VMWizardView.swift
+++ b/Platform/iOS/VMWizardView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct VMWizardView: View {
     @StateObject var wizardState = VMWizardState()
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
-    
+
     var body: some View {
         if #available(iOS 16, visionOS 1.0, *) {
             WizardNavigationView(wizardState: wizardState) {
@@ -39,7 +39,7 @@ struct VMWizardView: View {
     }
 }
 
-fileprivate struct WizardToolbar: ViewModifier {
+private struct WizardToolbar: ViewModifier {
     @ObservedObject var wizardState: VMWizardState
     let onDismiss: () -> Void
     @EnvironmentObject private var data: UTMData
@@ -87,13 +87,13 @@ fileprivate struct WizardToolbar: ViewModifier {
 
 @available(iOS, deprecated: 17, message: "Use WizardViewWrapper")
 @available(visionOS, deprecated: 1, message: "Use WizardViewWrapper")
-fileprivate struct WizardWrapper: View {
+private struct WizardWrapper: View {
     let page: VMWizardPage
     @ObservedObject var wizardState: VMWizardState
     @State private var nextPage: VMWizardPage?
     let onDismiss: () -> Void
     @EnvironmentObject private var data: UTMData
-    
+
     var body: some View {
         VStack {
             WizardViewWrapper(page: page, wizardState: wizardState)
@@ -125,14 +125,14 @@ fileprivate struct WizardWrapper: View {
 }
 
 @available(iOS 16, visionOS 1.0, *)
-fileprivate struct WizardNavigationView: View {
+private struct WizardNavigationView: View {
     @StateObject var wizardState = VMWizardState()
     let onDismiss: () -> Void
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @State private var navigationPath: NavigationPath = .init()
     @State private var previousPage: VMWizardPage?
     @State private var isAlertShown: Bool = false
-    
+
     var body: some View {
         NavigationStack(path: $wizardState.pageHistory) {
             WizardViewWrapper(page: .start, wizardState: wizardState)
@@ -157,7 +157,7 @@ fileprivate struct WizardNavigationView: View {
     }
 }
 
-fileprivate struct WizardViewWrapper: View {
+private struct WizardViewWrapper: View {
     let page: VMWizardPage
     @ObservedObject var wizardState: VMWizardState
 

--- a/Platform/macOS/AppDelegate.swift
+++ b/Platform/macOS/AppDelegate.swift
@@ -16,18 +16,18 @@
 
 @MainActor class AppDelegate: NSObject, NSApplicationDelegate {
     var data: UTMData?
-    
+
     @Setting("KeepRunningAfterLastWindowClosed") private var isKeepRunningAfterLastWindowClosed: Bool = false
     @Setting("HideDockIcon") private var isDockIconHidden: Bool = false
     @Setting("NoQuitConfirmation") private var isNoQuitConfirmation: Bool = false
-    
+
     private var hasRunningVirtualMachines: Bool {
         guard let vmList = data?.vmWindows.keys else {
             return false
         }
         return vmList.contains(where: { $0.wrapped?.state == .started || ($0.wrapped?.state == .paused && !$0.hasSuspendState) })
     }
-    
+
     @MainActor
     @objc var scriptingVirtualMachines: [UTMScriptingVirtualMachineImpl] {
         guard let data = data else {
@@ -37,22 +37,22 @@
             UTMScriptingVirtualMachineImpl(for: vm, data: data)
         }
     }
-    
+
     @MainActor
     @objc var isAutoTerminate: Bool {
         get {
             !isKeepRunningAfterLastWindowClosed
         }
-        
+
         set {
             isKeepRunningAfterLastWindowClosed = !newValue
         }
     }
-    
+
     func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
         !isKeepRunningAfterLastWindowClosed && !hasRunningVirtualMachines
     }
-    
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         guard let data = data else {
             return .terminateNow
@@ -75,7 +75,7 @@
             return .terminateCancel
         }
     }
-    
+
     private func handleTerminateAfterSaving(allVMs: some Sequence<VMData>, sender: NSApplication) -> Bool {
         let candidates = allVMs.filter({ $0.wrapped?.state == .started || ($0.wrapped?.state == .paused && !$0.hasSuspendState) })
         guard !candidates.contains(where: { $0.wrapped?.snapshotUnsupportedError != nil }) else {
@@ -101,7 +101,7 @@
         }
         return true
     }
-    
+
     private func handleTerminateAfterConfirmation(_ sender: NSApplication) {
         let alert = NSAlert()
         alert.alertStyle = .informational
@@ -128,7 +128,7 @@
             confirm(response)
         }
     }
-    
+
     func applicationWillTerminate(_ notification: Notification) {
         /// Synchronize registry
         UTMRegistry.shared.sync()
@@ -147,13 +147,13 @@
             }
         }
     }
-    
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         if isDockIconHidden {
             NSApp.setActivationPolicy(.accessory)
         }
     }
-    
+
     func application(_ sender: NSApplication, delegateHandlesKey key: String) -> Bool {
         switch key {
         case "scriptingVirtualMachines": return true

--- a/Platform/macOS/Display/VMDisplayAppleWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayAppleWindowController.swift
@@ -18,31 +18,31 @@ import Foundation
 
 class VMDisplayAppleWindowController: VMDisplayWindowController {
     var mainView: NSView?
-    
+
     var isInstallSuccessful: Bool = false
-    
+
     var appleVM: UTMAppleVirtualMachine! {
         vm as? UTMAppleVirtualMachine
     }
-    
+
     var appleConfig: UTMAppleConfiguration! {
         appleVM?.config
     }
-    
+
     var defaultTitle: String {
         appleConfig.information.name
     }
-    
+
     var defaultSubtitle: String {
         ""
     }
-    
+
     private var isSharePathAlertShownOnce = false
-    
+
     // MARK: - User preferences
-    
+
     @Setting("SharePathAlertShown") private var isSharePathAlertShownPersistent: Bool = false
-    
+
     override func windowDidLoad() {
         mainView!.translatesAutoresizingMaskIntoConstraints = false
         displayView.addSubview(mainView!)
@@ -74,7 +74,7 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
             }
         }
     }
-    
+
     override func enterLive() {
         window!.title = defaultTitle
         window!.subtitle = defaultSubtitle
@@ -91,11 +91,11 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
             sharedFolderToolbarItem.isEnabled = false
         }
     }
-    
+
     override func enterSuspended(isBusy busy: Bool) {
         super.enterSuspended(isBusy: busy)
     }
-    
+
     override func virtualMachine(_ vm: any UTMVirtualMachine, didTransitionToState state: UTMVirtualMachineState) {
         super.virtualMachine(vm, didTransitionToState: state)
         if state == .stopped && isInstallSuccessful {
@@ -103,15 +103,15 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
             vm.requestVmStart()
         }
     }
-    
+
     func updateWindowFrame() {
         // implement in subclass
     }
-    
+
     override func resizeConsoleButtonPressed(_ sender: Any) {
         // implement in subclass
     }
-    
+
     @IBAction override func sharedFolderButtonPressed(_ sender: Any) {
         guard #available(macOS 12, *) else {
             return
@@ -131,9 +131,9 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
             openShareMenu(sender)
         }
     }
-    
+
     // MARK: - Installation progress
-    
+
     override func virtualMachine(_ vm: any UTMVirtualMachine, didCompleteInstallation success: Bool) {
         Task { @MainActor in
             self.window!.subtitle = ""
@@ -146,7 +146,7 @@ class VMDisplayAppleWindowController: VMDisplayWindowController {
             }
         }
     }
-    
+
     override func virtualMachine(_ vm: any UTMVirtualMachine, didUpdateInstallationProgress progress: Double) {
         Task { @MainActor in
             let installationFormat = NSLocalizedString("Installation: %@", comment: "VMDisplayAppleWindowController")
@@ -196,7 +196,7 @@ extension VMDisplayAppleWindowController {
         menu.addItem(add)
         menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
-    
+
     @objc func addShare(sender: AnyObject) {
         pickShare { url in
             if let sharedDirectory = try? UTMRegistryEntry.File(url: url) {
@@ -204,7 +204,7 @@ extension VMDisplayAppleWindowController {
             }
         }
     }
-    
+
     @objc func changeShare(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for changeShare")
@@ -218,7 +218,7 @@ extension VMDisplayAppleWindowController {
             }
         }
     }
-    
+
     @objc func flipReadOnlyShare(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for changeShare")
@@ -228,7 +228,7 @@ extension VMDisplayAppleWindowController {
         let isReadOnly = appleVM.registryEntry.sharedDirectories[i].isReadOnly
         appleVM.registryEntry.sharedDirectories[i].isReadOnly = !isReadOnly
     }
-    
+
     @objc func removeShare(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for removeShare")
@@ -237,7 +237,7 @@ extension VMDisplayAppleWindowController {
         let i = menu.tag
         appleVM.registryEntry.sharedDirectories.remove(at: i)
     }
-    
+
     func pickShare(_ onComplete: @escaping (URL) -> Void) {
         let openPanel = NSOpenPanel()
         openPanel.title = NSLocalizedString("Select Shared Folder", comment: "VMDisplayAppleWindowController")
@@ -299,7 +299,7 @@ extension VMDisplayAppleWindowController {
         }
         menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
-    
+
     @available(macOS 12, *)
     @objc private func showWindowFromDisplay(sender: AnyObject) {
         if self is VMDisplayAppleDisplayWindowController {
@@ -309,7 +309,7 @@ extension VMDisplayAppleWindowController {
             window.showWindow(self)
         }
     }
-    
+
     @objc private func showWindowFromSerial(sender: AnyObject) {
         let item = sender as! NSMenuItem
         let id = item.tag
@@ -323,11 +323,9 @@ extension VMDisplayAppleWindowController {
         } else {
             secondaryWindows = self.secondaryWindows
         }
-        for window in secondaryWindows {
-            if (window as? VMDisplayAppleTerminalWindowController)?.index == id {
-                window.showWindow(self)
-                return
-            }
+        for window in secondaryWindows where (window as? VMDisplayAppleTerminalWindowController)?.index == id {
+            window.showWindow(self)
+            return
         }
         // create new serial window
         let vc = VMDisplayAppleTerminalWindowController(secondaryForIndex: id, vm: appleVM)

--- a/Platform/macOS/Display/VMDisplayQemuDisplayController.swift
+++ b/Platform/macOS/Display/VMDisplayQemuDisplayController.swift
@@ -20,19 +20,19 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
     private var allUsbDevices: [CSUSBDevice] = []
     private var connectedUsbDevices: [CSUSBDevice] = []
     @Setting("NoUsbPrompt") private var isNoUsbPrompt: Bool = false
-    
+
     var qemuVM: UTMQemuVirtualMachine! {
         vm as? UTMQemuVirtualMachine
     }
-    
+
     var vmQemuConfig: UTMQemuConfiguration! {
         qemuVM?.config
     }
-    
+
     var defaultTitle: String {
         vmQemuConfig.information.name
     }
-    
+
     var defaultSubtitle: String {
         if qemuVM.isRunningAsDisposible {
             return NSLocalizedString("Disposable Mode", comment: "VMDisplayQemuDisplayController")
@@ -40,12 +40,12 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
             return ""
         }
     }
-    
+
     convenience init(vm: UTMQemuVirtualMachine, id: Int) {
         self.init(vm: vm, onClose: nil)
         self.id = id
     }
-    
+
     override func enterLive() {
         if !isSecondary {
             qemuVM.ioServiceDelegate = self
@@ -57,7 +57,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
         window!.subtitle = defaultSubtitle
         super.enterLive()
     }
-    
+
     override func enterSuspended(isBusy busy: Bool) {
         if vm.state == .stopped {
             connectedUsbDevices.removeAll()
@@ -83,7 +83,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
         updateDrivesMenu(menu, drives: vmQemuConfig.drives)
         menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
-    
+
     @nonobjc func updateDrivesMenu(_ menu: NSMenu, drives: [UTMQemuConfigurationDrive]) {
         menu.removeAllItems()
         if drives.count == 0 {
@@ -131,7 +131,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
         }
         menu.update()
     }
-    
+
     func ejectDrive(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for ejectDrive")
@@ -148,7 +148,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
             }
         }
     }
-    
+
     func openDriveImage(forDriveIndex index: Int) {
         let drive = vmQemuConfig.drives[index]
         let openPanel = NSOpenPanel()
@@ -173,7 +173,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
             }
         }
     }
-    
+
     func changeDriveImage(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for ejectDrive")
@@ -181,7 +181,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
         }
         openDriveImage(forDriveIndex: menu.tag)
     }
-    
+
     @nonobjc private func label(for drive: UTMQemuConfigurationDrive) -> String {
         let imageURL = qemuVM.externalImageURL(for: drive) ?? drive.imageURL
         return String.localizedStringWithFormat(NSLocalizedString("%@ (%@): %@", comment: "VMDisplayQemuDisplayController"),
@@ -189,7 +189,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
                                                 drive.interface.prettyValue,
                                                 imageURL?.lastPathComponent ?? NSLocalizedString("none", comment: "VMDisplayQemuDisplayController"))
     }
-    
+
     @MainActor private func installWindowsGuestTools(sender: AnyObject) {
         vmQemuConfig.qemu.isGuestToolsInstallRequested = true
     }
@@ -234,19 +234,19 @@ extension VMDisplayQemuWindowController: UTMSpiceIODelegate {
         }
         return Int(serial.name!.dropFirst(prefix.count))
     }
-    
+
     func spiceDidCreateInput(_ input: CSInput) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDidCreateInput(input)
         }
     }
-    
+
     func spiceDidDestroyInput(_ input: CSInput) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDidDestroyInput(input)
         }
     }
-    
+
     func spiceDidCreateDisplay(_ display: CSDisplay) {
         guard !isSecondary else {
             return
@@ -255,19 +255,19 @@ extension VMDisplayQemuWindowController: UTMSpiceIODelegate {
             findWindow(for: display)
         }
     }
-    
+
     func spiceDidUpdateDisplay(_ display: CSDisplay) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDidUpdateDisplay(display)
         }
     }
-    
+
     func spiceDidDestroyDisplay(_ display: CSDisplay) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDidDestroyDisplay(display)
         }
     }
-    
+
     func spiceDidChangeUsbManager(_ usbManager: CSUSBManager?) {
         if usbManager != vmUsbManager {
             connectedUsbDevices.removeAll()
@@ -281,13 +281,13 @@ extension VMDisplayQemuWindowController: UTMSpiceIODelegate {
             (subwindow as! VMDisplayQemuWindowController).spiceDidChangeUsbManager(usbManager)
         }
     }
-    
+
     func spiceDynamicResolutionSupportDidChange(_ supported: Bool) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDynamicResolutionSupportDidChange(supported)
         }
     }
-    
+
     func spiceDidCreateSerial(_ serial: CSPort) {
         guard !isSecondary else {
             return
@@ -296,7 +296,7 @@ extension VMDisplayQemuWindowController: UTMSpiceIODelegate {
             findWindow(for: serial)
         }
     }
-    
+
     func spiceDidDestroySerial(_ serial: CSPort) {
         for subwindow in secondaryWindows {
             (subwindow as! VMDisplayQemuWindowController).spiceDidDestroySerial(serial)
@@ -313,7 +313,7 @@ extension VMDisplayQemuWindowController: CSUSBManagerDelegate {
             self.showErrorAlert(error)
         }
     }
-    
+
     func spiceUsbManager(_ usbManager: CSUSBManager, deviceAttached device: CSUSBDevice) {
         logger.debug("USB device attached: \(device)")
         if !isNoUsbPrompt {
@@ -324,14 +324,14 @@ extension VMDisplayQemuWindowController: CSUSBManagerDelegate {
             }
         }
     }
-    
+
     func spiceUsbManager(_ usbManager: CSUSBManager, deviceRemoved device: CSUSBDevice) {
         logger.debug("USB device removed: \(device)")
         if let i = connectedUsbDevices.firstIndex(of: device) {
             connectedUsbDevices.remove(at: i)
         }
     }
-    
+
     func showConnectPrompt(for usbDevice: CSUSBDevice) {
         guard let usbManager = vmUsbManager else {
             logger.error("cannot get usb manager")
@@ -377,11 +377,11 @@ let usbBlockList = [
     (0x05ac, 0x8263),
     (0x05ac, 0x8302), // Apple Touch Bar Display
     (0x05ac, 0x8514), // Apple FaceTime HD Camera (Built-in)
-    (0x05ac, 0x8600), // Apple iBridge
+    (0x05ac, 0x8600)  // Apple iBridge
 ]
 
 extension VMDisplayQemuWindowController {
-    
+
     @IBAction override func usbButtonPressed(_ sender: Any) {
         let menu = NSMenu()
         menu.autoenablesItems = false
@@ -397,7 +397,7 @@ extension VMDisplayQemuWindowController {
         }
         menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
-    
+
     func updateUsbDevicesMenu(_ menu: NSMenu, devices: [CSUSBDevice]) {
         allUsbDevices = devices
         menu.removeAllItems()
@@ -415,7 +415,7 @@ extension VMDisplayQemuWindowController {
             item.title = device.name ?? device.description
             let blocked = usbBlockList.contains { (usbVid, usbPid) in usbVid == device.usbVendorId && usbPid == device.usbProductId }
             item.isEnabled = !blocked && canRedirect && (isConnectedToSelf || !isConnected)
-            item.state = isConnectedToSelf ? .on : .off;
+            item.state = isConnectedToSelf ? .on : .off
             item.tag = i
             item.target = self
             item.action = isConnectedToSelf ? #selector(disconnectUsbDevice) : #selector(connectUsbDevice)
@@ -423,7 +423,7 @@ extension VMDisplayQemuWindowController {
         }
         menu.update()
     }
-    
+
     @objc func connectUsbDevice(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for connectUsbDevice")
@@ -447,7 +447,7 @@ extension VMDisplayQemuWindowController {
             }
         }
     }
-    
+
     @objc func disconnectUsbDevice(sender: AnyObject) {
         guard let menu = sender as? NSMenuItem else {
             logger.error("wrong sender for disconnectUsbDevice")
@@ -513,7 +513,7 @@ extension VMDisplayQemuWindowController {
         }
         menu.popUp(positioning: nil, at: NSEvent.mouseLocation, in: nil)
     }
-    
+
     @objc private func showWindowFromDisplay(sender: AnyObject) {
         let item = sender as! NSMenuItem
         let id = item.tag
@@ -527,7 +527,7 @@ extension VMDisplayQemuWindowController {
             window.showWindow(self)
         }
     }
-    
+
     @objc private func showWindowFromSerial(sender: AnyObject) {
         let item = sender as! NSMenuItem
         let id = item.tag
@@ -541,7 +541,7 @@ extension VMDisplayQemuWindowController {
             window.showWindow(self)
         }
     }
-    
+
     @MainActor private func findWindow(for display: CSDisplay) -> VMDisplayQemuWindowController? {
         let id = display.monitorID
         let secondaryWindows: [VMDisplayWindowController]
@@ -570,7 +570,7 @@ extension VMDisplayQemuWindowController {
             return nil
         }
     }
-    
+
     @MainActor private func newWindow(from display: CSDisplay) -> VMDisplayQemuMetalWindowController? {
         let id = display.monitorID
         guard id < vmQemuConfig.displays.count else {
@@ -583,7 +583,7 @@ extension VMDisplayQemuWindowController {
         registerSecondaryWindow(secondary)
         return secondary
     }
-    
+
     @MainActor private func findWindow(for serial: CSPort) -> VMDisplayQemuWindowController? {
         let id = configIdForSerial(serial)!
         let secondaryWindows: [VMDisplayWindowController]
@@ -612,7 +612,7 @@ extension VMDisplayQemuWindowController {
             return nil
         }
     }
-    
+
     @MainActor private func newWindow(from serial: CSPort) -> VMDisplayQemuTerminalWindowController? {
         guard let id = configIdForSerial(serial) else {
             return nil

--- a/Platform/macOS/SavePanel.swift
+++ b/Platform/macOS/SavePanel.swift
@@ -31,17 +31,17 @@ struct SavePanel: NSViewRepresentable {
             guard let shareItem = shareItem else {
                 return
             }
-            
+
             guard let window = nsView.window else {
                 return
             }
-            
+
             // Initializing the SavePanel and setting its properties
             let savePanel = NSSavePanel()
             if let downloadsUrl = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first {
                 savePanel.directoryURL = downloadsUrl
             }
-            
+
             switch shareItem {
             case .debugLog:
                 savePanel.title = NSLocalizedString("Select where to save debug log:", comment: "SavePanel")
@@ -56,7 +56,7 @@ struct SavePanel: NSViewRepresentable {
                 savePanel.nameFieldStringValue = "command"
                 savePanel.allowedContentTypes = [.plainText]
             }
-            
+
             // Calling savePanel.begin with the appropriate completion handlers
             // SwiftUI BUG: if we don't wait, there is a crash due to an access issue
             DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
@@ -67,14 +67,14 @@ struct SavePanel: NSViewRepresentable {
                             if let destUrl = savePanel.url {
                                 data.busyWorkAsync {
                                     let fileManager = FileManager.default
-                                    
+
                                     // All this mess is because FileManager.replaceItemAt deletes the source item
                                     let tempUrl = fileManager.temporaryDirectory.appendingPathComponent(sourceUrl.lastPathComponent)
                                     if fileManager.fileExists(atPath: tempUrl.path) {
                                         try fileManager.removeItem(at: tempUrl)
                                     }
                                     try fileManager.copyItem(at: sourceUrl, to: tempUrl)
-                                    
+
                                     _ = try fileManager.replaceItemAt(destUrl, withItemAt: tempUrl)
                                 }
                             }
@@ -86,7 +86,7 @@ struct SavePanel: NSViewRepresentable {
                         if result == .OK {
                             if let destUrl = savePanel.url {
                                 data.busyWorkAsync {
-                                    if case .utmMove(_) = shareItem {
+                                    if case .utmMove = shareItem {
                                         try await data.move(vm: vm, to: destUrl)
                                     } else {
                                         try await data.export(vm: vm, to: destUrl)

--- a/Platform/macOS/SettingsView.swift
+++ b/Platform/macOS/SettingsView.swift
@@ -18,7 +18,6 @@ import SwiftUI
 
 @available(macOS 11, *)
 struct SettingsView: View {
-    
     var body: some View {
         TabView {
             ApplicationSettingsView().padding()
@@ -47,7 +46,7 @@ struct ApplicationSettingsView: View {
     @AppStorage("ShowMenuIcon") var isMenuIconShown = false
     @AppStorage("PreventIdleSleep") var isPreventIdleSleep = false
     @AppStorage("NoQuitConfirmation") var isNoQuitConfirmation = false
-    
+
     var body: some View {
         Form {
             Toggle(isOn: $isKeepRunningAfterLastWindowClosed, label: {
@@ -81,7 +80,7 @@ struct DisplaySettingsView: View {
     @AppStorage("NoSaveScreenshot") var isNoSaveScreenshot = false
     @AppStorage("QEMURendererBackend") var qemuRendererBackend: UTMQEMURendererBackend = .qemuRendererBackendDefault
     @AppStorage("QEMURendererFPSLimit") var qemuRendererFpsLimit: Int = 0
-    
+
     var body: some View {
         Form {
             Section(header: Text("Display")) {
@@ -92,7 +91,7 @@ struct DisplaySettingsView: View {
                     Text("Do not save VM screenshot to disk")
                 }.help("If enabled, any existing screenshot will be deleted the next time the VM is started.")
             }
-            
+
             Section(header: Text("QEMU Graphics Acceleration")) {
                 Picker("Renderer Backend", selection: $qemuRendererBackend) {
                     Text("Default").tag(UTMQEMURendererBackend.qemuRendererBackendDefault)
@@ -113,7 +112,7 @@ struct DisplaySettingsView: View {
 
 struct SoundSettingsView: View {
     @AppStorage("QEMUSoundBackend") var qemuSoundBackend: UTMQEMUSoundBackend = .qemuSoundBackendDefault
-    
+
     var body: some View {
         Form {
             Section(header: Text("QEMU Sound")) {
@@ -136,7 +135,7 @@ struct InputSettingsView: View {
     @AppStorage("IsNumLockForced") var isNumLockForced = false
     @AppStorage("InvertScroll") var isInvertScroll = false
     @AppStorage("NoUsbPrompt") var isNoUsbPrompt = false
-    
+
     var body: some View {
         Form {
             Section(header: Text("Mouse/Keyboard")) {
@@ -144,13 +143,13 @@ struct InputSettingsView: View {
                     Text("Capture input automatically when entering full screen")
                 }.help("If enabled, input capture will toggle automatically when entering and exiting full screen mode.")
             }
-            
+
             Section(header: Text("Console")) {
                 Toggle(isOn: $isOptionAsMetaKey, label: {
                     Text("Option (⌥) is Meta key")
                 }).help("If enabled, Option will be mapped to the Meta key which can be useful for emacs. Otherwise, option will work as the system intended (such as for entering international text).")
             }
-            
+
             Section(header: Text("QEMU Pointer")) {
                 Toggle(isOn: $isCtrlRightClick, label: {
                     Text("Hold Control (⌃) for right click")
@@ -159,7 +158,7 @@ struct InputSettingsView: View {
                     Text("Invert scrolling")
                 }).help("If enabled, scroll wheel input will be inverted.")
             }
-            
+
             Section(header: Text("QEMU Keyboard")) {
                 Toggle(isOn: $isAlternativeCaptureKey, label: {
                     Text("Use Command+Option (⌘+⌥) for input capture/release")
@@ -171,7 +170,7 @@ struct InputSettingsView: View {
                     Text("Num Lock is forced on")
                 }).help("If enabled, num lock will always be on to the guest. Note this may make your keyboard's num lock indicator out of sync.")
             }
-            
+
             Section(header: Text("QEMU USB")) {
                 Toggle(isOn: $isNoUsbPrompt, label: {
                     Text("Do not show prompt when USB device is plugged in")

--- a/Platform/macOS/UTMApp.swift
+++ b/Platform/macOS/UTMApp.swift
@@ -45,7 +45,7 @@ struct UTMApp: App {
             SettingsView()
         }
     }
-    
+
     @available(macOS 13, *)
     @SceneBuilder
     var newBody: some Scene {

--- a/Platform/macOS/UTMApp.swift
+++ b/Platform/macOS/UTMApp.swift
@@ -19,7 +19,7 @@ import SwiftUI
 struct UTMApp: App {
     @State var data = UTMData()
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate: AppDelegate
-    
+
     @ViewBuilder
     var homeWindow: some View {
         ContentView().environmentObject(data)
@@ -33,7 +33,7 @@ struct UTMApp: App {
                 }
             }
     }
-    
+
     @SceneBuilder
     var oldBody: some Scene {
         WindowGroup {
@@ -59,7 +59,7 @@ struct UTMApp: App {
         }
         UTMMenuBarExtraScene(data: data)
     }
-    
+
     // HACK: SwiftUI doesn't provide if-statement support in SceneBuilder
     var body: some Scene {
         if #available(macOS 13, *) {

--- a/Platform/macOS/UTMPatches.swift
+++ b/Platform/macOS/UTMPatches.swift
@@ -19,7 +19,7 @@ import Foundation
 /// Handles Obj-C patches to fix AppKit issues
 final class UTMPatches {
     static private var isPatched: Bool = false
-    
+
     /// Installs the patches
     /// TODO: Some thread safety/race issues etc
     static func patchAll() {
@@ -49,7 +49,7 @@ extension NSKeyedUnarchiver {
         default: return xxx_decodeObject(forKey: key)
         }
     }
-    
+
     /// Workaround for exception when creating NSMenuToolbarItem from XIB
     fileprivate static func patchToolbarItem() {
         patch(#selector(Self.decodeObject(forKey:)),
@@ -65,12 +65,12 @@ private var ScriptingDelegateHandle: Int = 0
 extension NSApplication {
     /// Set this, at startup, to the delegate used for scripting
     weak var scriptingDelegate: NSApplicationDelegate? {
-        set {
-            objc_setAssociatedObject(self, &ScriptingDelegateHandle, newValue, .OBJC_ASSOCIATION_ASSIGN)
-        }
-        
         get {
             objc_getAssociatedObject(self, &ScriptingDelegateHandle) as? NSApplicationDelegate
+        }
+
+        set {
+            objc_setAssociatedObject(self, &ScriptingDelegateHandle, newValue, .OBJC_ASSOCIATION_ASSIGN)
         }
     }
     
@@ -84,7 +84,7 @@ extension NSApplication {
             return xxx_value(forKey: key)
         }
     }
-    
+
     /// Set KVO value in scripting delegate if implemented
     /// - Parameters:
     ///   - value: Value to set to
@@ -96,7 +96,7 @@ extension NSApplication {
             return xxx_setValue(value, forKey: key)
         }
     }
-    
+
     /// Get KVO value from scripting delegate if implemented
     /// - Parameters:
     ///   - index: Index of item
@@ -109,7 +109,7 @@ extension NSApplication {
             return xxx_value(at: index, inPropertyWithKey: key)
         }
     }
-    
+
     /// Set KVO value in scripting delegate if implemented
     /// - Parameters:
     ///   - index: Index of item
@@ -122,7 +122,7 @@ extension NSApplication {
             return xxx_replaceValue(at: index, inPropertyWithKey: key, withValue: value)
         }
     }
-    
+
     fileprivate static func patchApplicationScripting() {
         patch(#selector(Self.value(forKey:)),
               with: #selector(Self.xxx_value(forKey:)),

--- a/Platform/macOS/VMDrivesSettingsView.swift
+++ b/Platform/macOS/VMDrivesSettingsView.swift
@@ -24,7 +24,7 @@ struct VMDrivesSettingsView<Drive: UTMConfigurationDrive>: View {
     @State private var newDrivePopover: Bool = false
     @State private var importDrivePresented: Bool = false
     @State private var requestDriveDelete: Drive?
-    
+
     init(drives: Binding<[Drive]>, template: Drive) {
         self._drives = drives
         self._newDrive = State<Drive>(initialValue: template)
@@ -112,7 +112,7 @@ struct VMDrivesSettingsView<Drive: UTMConfigurationDrive>: View {
             }.padding()
         }
     }
-    
+
     private func label(for drive: Drive) -> String {
         if let qemuDrive = drive as? UTMQemuConfigurationDrive {
             if qemuDrive.interface == .none && qemuDrive.imageName == QEMUPackageFileName.efiVariables.rawValue {
@@ -136,7 +136,6 @@ struct VMDrivesSettingsView<Drive: UTMConfigurationDrive>: View {
                     drive.imageURL = url
                     drives.append(drive)
                 }
-                break
             case .failure(let err):
                 throw err
             }
@@ -156,7 +155,7 @@ struct VMDrivesSettingsView<Drive: UTMConfigurationDrive>: View {
 private struct DriveDetailsView<Drive: UTMConfigurationDrive>: View {
     @Binding var config: Drive
     @Binding var requestDriveDelete: Drive?
-    
+
     var body: some View {
         if config is UTMQemuConfigurationDrive {
             VMConfigDriveDetailsView(config: $config as Any as! Binding<UTMQemuConfigurationDrive>, requestDriveDelete: $requestDriveDelete as Any as! Binding<UTMQemuConfigurationDrive?>)

--- a/Platform/macOS/VMSettingsView.swift
+++ b/Platform/macOS/VMSettingsView.swift
@@ -106,17 +106,17 @@ struct SettingsToolbarViewModifier<AdditionalContent>: ViewModifier where Additi
     @EnvironmentObject private var vm: VMData
     @EnvironmentObject private var data: UTMData
     @Environment(\.dismiss) private var dismiss
-    
+
     let additionalContent: AdditionalContent?
-    
+
     fileprivate init() where AdditionalContent == EmptyToolbarContent {
         self.additionalContent = nil
     }
-    
+
     init(additionalContent: () -> AdditionalContent) {
         self.additionalContent = additionalContent()
     }
-    
+
     func body(content: Content) -> some View {
         let view = content.toolbar {
             ToolbarItemGroup(placement: .cancellationAction) {
@@ -141,7 +141,7 @@ struct SettingsToolbarViewModifier<AdditionalContent>: ViewModifier where Additi
             view
         }
     }
-    
+
     private func save() {
         data.busyWorkAsync {
             try await data.save(vm: vm)
@@ -150,7 +150,7 @@ struct SettingsToolbarViewModifier<AdditionalContent>: ViewModifier where Additi
             }
         }
     }
-    
+
     private func cancel() {
         dismiss()
         data.busyWorkAsync {
@@ -164,7 +164,7 @@ extension View {
     func scrollable() -> some View {
         self.modifier(ScrollableViewModifier())
     }
-    
+
     @ViewBuilder
     fileprivate func legacySettingsToolbar<Content>(@ToolbarContentBuilder content: () -> Content) -> some View where Content: ToolbarContent {
         if #available(macOS 12, *) {
@@ -173,7 +173,7 @@ extension View {
             self.toolbar(content: content)
         }
     }
-    
+
     @ViewBuilder
     func settingsToolbar() -> some View {
         if #available(macOS 12, *) {
@@ -182,7 +182,7 @@ extension View {
             self
         }
     }
-    
+
     @ViewBuilder
     func settingsToolbar<Content>(@ToolbarContentBuilder additionalContent: () -> Content) -> some View where Content: ToolbarContent {
         if #available(macOS 12, *) {
@@ -198,7 +198,7 @@ struct VMSettingsView_Previews: PreviewProvider {
     @State static private var qemuConfig = UTMQemuConfiguration()
     @State static private var appleConfig = UTMAppleConfiguration()
     @State static private var data = UTMData()
-    
+
     static var previews: some View {
         VMSettingsView(vm: VMData(from: .empty), config: qemuConfig)
             .environmentObject(data)

--- a/Platform/macOS/VMSettingsView.swift
+++ b/Platform/macOS/VMSettingsView.swift
@@ -20,10 +20,10 @@ import SwiftUI
 struct VMSettingsView<Config: UTMConfiguration>: View {
     let vm: VMData
     @ObservedObject var config: Config
-    
+
     @EnvironmentObject private var data: UTMData
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
-    
+
     var body: some View {
         NavigationView {
             List {
@@ -53,7 +53,7 @@ struct VMSettingsView<Config: UTMConfiguration>: View {
         .disabled(data.busy)
         .overlay(BusyOverlay())
     }
-    
+
     func save() {
         data.busyWorkAsync {
             try await data.save(vm: vm)
@@ -62,7 +62,7 @@ struct VMSettingsView<Config: UTMConfiguration>: View {
             }
         }
     }
-    
+
     func cancel() {
         presentationMode.wrappedValue.dismiss()
         data.busyWorkAsync {
@@ -74,7 +74,7 @@ struct VMSettingsView<Config: UTMConfiguration>: View {
 @available(macOS 11, *)
 struct ScrollableViewModifier: ViewModifier {
     @State private var scrollViewContentSize: CGSize = .zero
-    
+
     func body(content: Content) -> some View {
         ScrollView {
             content
@@ -93,7 +93,7 @@ struct ScrollableViewModifier: ViewModifier {
     }
 }
 
-fileprivate struct EmptyToolbarContent: ToolbarContent {
+private struct EmptyToolbarContent: ToolbarContent {
     var body: some ToolbarContent {
         ToolbarItem {
             EmptyView()

--- a/Platform/macOS/VMWizardView.swift
+++ b/Platform/macOS/VMWizardView.swift
@@ -21,7 +21,7 @@ struct VMWizardView: View {
     @StateObject var wizardState = VMWizardState()
     @Environment(\.presentationMode) private var presentationMode: Binding<PresentationMode>
     @EnvironmentObject private var data: UTMData
-    
+
     /// SwiftUI BUG: on macOS 12, when VoiceOver is enabled and isBusy changes
     /// the disable state of a button being clicked, the app crashes
     private var isNeverDisabledWorkaround: Bool {
@@ -36,7 +36,7 @@ struct VMWizardView: View {
         return true
         #endif
     }
-    
+
     var body: some View {
         Group {
             switch wizardState.currentPage {

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -43,15 +43,15 @@ class UTMScriptingConfigImpl {
     private var bytesInMib: Int64 {
         1048576
     }
-    
+
     private(set) var config: any UTMConfiguration
     private weak var data: UTMData?
-    
+
     init(_ config: any UTMConfiguration, data: UTMData? = nil) {
         self.config = config
         self.data = data
     }
-    
+
     func serializeConfiguration() -> [AnyHashable : Any] {
         if let qemuConfig = config as? UTMQemuConfiguration {
             return serializeQemuConfiguration(qemuConfig)
@@ -61,7 +61,7 @@ class UTMScriptingConfigImpl {
             fatalError()
         }
     }
-    
+
     func updateConfiguration(from record: [AnyHashable : Any]) throws {
         if let _ = config as? UTMQemuConfiguration {
             try updateQemuConfiguration(from: record)
@@ -71,7 +71,7 @@ class UTMScriptingConfigImpl {
             fatalError()
         }
     }
-    
+
     private func size(of drive: any UTMConfigurationDrive) -> Int {
         guard let data = data else {
             return 0
@@ -92,7 +92,7 @@ extension UTMScriptingConfigImpl {
         case .virtfs: return .virtFS
         }
     }
-    
+
     private func serializeQemuConfiguration(_ config: UTMQemuConfiguration) -> [AnyHashable : Any] {
         [
             "name": config.information.name,
@@ -109,7 +109,7 @@ extension UTMScriptingConfigImpl {
             "serialPorts": config.serials.enumerated().map({ serializeQemuSerial($1, index: $0) }),
         ]
     }
-    
+
     private func qemuDriveInterface(from interface: QEMUDriveInterface) -> UTMScriptingQemuDriveInterface {
         switch interface {
         case .none: return .none

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -17,13 +17,13 @@
 import Foundation
 
 @objc extension UTMScriptingVirtualMachineImpl {
-    @objc var configuration: [AnyHashable : Any] {
+    var configuration: [AnyHashable: Any] {
         let wrapper = UTMScriptingConfigImpl(vm.config, data: data)
         return wrapper.serializeConfiguration()
     }
-    
-    @objc func updateConfiguration(_ command: NSScriptCommand) {
-        let newConfiguration = command.evaluatedArguments?["newConfiguration"] as? [AnyHashable : Any]
+
+    func updateConfiguration(_ command: NSScriptCommand) {
+        let newConfiguration = command.evaluatedArguments?["newConfiguration"] as? [AnyHashable: Any]
         withScriptCommand(command) { [self] in
             guard let newConfiguration = newConfiguration else {
                 throw ScriptingError.invalidParameter
@@ -52,7 +52,7 @@ class UTMScriptingConfigImpl {
         self.data = data
     }
 
-    func serializeConfiguration() -> [AnyHashable : Any] {
+    func serializeConfiguration() -> [AnyHashable: Any] {
         if let qemuConfig = config as? UTMQemuConfiguration {
             return serializeQemuConfiguration(qemuConfig)
         } else if let appleConfig = config as? UTMAppleConfiguration {
@@ -62,10 +62,10 @@ class UTMScriptingConfigImpl {
         }
     }
 
-    func updateConfiguration(from record: [AnyHashable : Any]) throws {
-        if let _ = config as? UTMQemuConfiguration {
+    func updateConfiguration(from record: [AnyHashable: Any]) throws {
+        if config as? UTMQemuConfiguration != nil {
             try updateQemuConfiguration(from: record)
-        } else if let _ = config as? UTMAppleConfiguration {
+        } else if config as? UTMAppleConfiguration != nil {
             try updateAppleConfiguration(from: record)
         } else {
             fatalError()
@@ -93,7 +93,7 @@ extension UTMScriptingConfigImpl {
         }
     }
 
-    private func serializeQemuConfiguration(_ config: UTMQemuConfiguration) -> [AnyHashable : Any] {
+    private func serializeQemuConfiguration(_ config: UTMQemuConfiguration) -> [AnyHashable: Any] {
         [
             "name": config.information.name,
             "notes": config.information.notes ?? "",
@@ -106,7 +106,7 @@ extension UTMScriptingConfigImpl {
             "directoryShareMode": qemuDirectoryShareMode(from: config.sharing.directoryShareMode).rawValue,
             "drives": config.drives.map({ serializeQemuDriveExisting($0) }),
             "networkInterfaces": config.networks.enumerated().map({ serializeQemuNetwork($1, index: $0) }),
-            "serialPorts": config.serials.enumerated().map({ serializeQemuSerial($1, index: $0) }),
+            "serialPorts": config.serials.enumerated().map({ serializeQemuSerial($1, index: $0) })
         ]
     }
 
@@ -124,16 +124,16 @@ extension UTMScriptingConfigImpl {
         case .usb: return .usb
         }
     }
-    
-    private func serializeQemuDriveExisting(_ config: UTMQemuConfigurationDrive) -> [AnyHashable : Any] {
+
+    private func serializeQemuDriveExisting(_ config: UTMQemuConfigurationDrive) -> [AnyHashable: Any] {
         [
             "id": config.id,
             "removable": config.isExternal,
             "interface": qemuDriveInterface(from: config.interface).rawValue,
-            "hostSize": size(of: config),
+            "hostSize": size(of: config)
         ]
     }
-    
+
     private func qemuNetworkMode(from mode: QEMUNetworkMode) -> UTMScriptingQemuNetworkMode {
         switch mode {
         case .emulated: return .emulated
@@ -142,35 +142,35 @@ extension UTMScriptingConfigImpl {
         case .bridged: return .bridged
         }
     }
-    
-    private func serializeQemuNetwork(_ config: UTMQemuConfigurationNetwork, index: Int) -> [AnyHashable : Any] {
+
+    private func serializeQemuNetwork(_ config: UTMQemuConfigurationNetwork, index: Int) -> [AnyHashable: Any] {
         [
             "index": index,
             "hardware": config.hardware.rawValue,
             "mode": qemuNetworkMode(from: config.mode).rawValue,
             "address": config.macAddress,
             "hostInterface": config.bridgeInterface ?? "",
-            "portForwards": config.portForward.map({ serializeQemuPortForward($0) }),
+            "portForwards": config.portForward.map({ serializeQemuPortForward($0) })
         ]
     }
-    
+
     private func networkProtocol(from protc: QEMUNetworkProtocol) -> UTMScriptingNetworkProtocol {
         switch protc {
         case .tcp: return .tcp
         case .udp: return .udp
         }
     }
-    
-    private func serializeQemuPortForward(_ config: UTMQemuConfigurationPortForward) -> [AnyHashable : Any] {
+
+    private func serializeQemuPortForward(_ config: UTMQemuConfigurationPortForward) -> [AnyHashable: Any] {
         [
             "protocol": networkProtocol(from: config.protocol).rawValue,
             "hostAddress": config.hostAddress ?? "",
             "hostPort": config.hostPort,
             "guestAddress": config.guestAddress ?? "",
-            "guestPort": config.guestPort,
+            "guestPort": config.guestPort
         ]
     }
-    
+
     private func qemuSerialInterface(from mode: QEMUSerialMode) -> UTMScriptingSerialInterface {
         switch mode {
         case .ptty: return .ptty
@@ -178,17 +178,17 @@ extension UTMScriptingConfigImpl {
         default: return .unavailable
         }
     }
-    
-    private func serializeQemuSerial(_ config: UTMQemuConfigurationSerial, index: Int) -> [AnyHashable : Any] {
+
+    private func serializeQemuSerial(_ config: UTMQemuConfigurationSerial, index: Int) -> [AnyHashable: Any] {
         [
             "index": index,
             "hardware": config.hardware?.rawValue ?? "",
             "interface": qemuSerialInterface(from: config.mode).rawValue,
-            "port": config.tcpPort ?? 0,
+            "port": config.tcpPort ?? 0
         ]
     }
-    
-    private func serializeAppleConfiguration(_ config: UTMAppleConfiguration) -> [AnyHashable : Any] {
+
+    private func serializeAppleConfiguration(_ config: UTMAppleConfiguration) -> [AnyHashable: Any] {
         [
             "name": config.information.name,
             "notes": config.information.notes ?? "",
@@ -197,59 +197,59 @@ extension UTMScriptingConfigImpl {
             "directoryShares": config.sharedDirectories.enumerated().map({ serializeAppleDirectoryShare($1, index: $0) }),
             "drives": config.drives.map({ serializeAppleDriveExisting($0) }),
             "networkInterfaces": config.networks.enumerated().map({ serializeAppleNetwork($1, index: $0) }),
-            "serialPorts": config.serials.enumerated().map({ serializeAppleSerial($1, index: $0) }),
+            "serialPorts": config.serials.enumerated().map({ serializeAppleSerial($1, index: $0) })
         ]
     }
-    
-    private func serializeAppleDirectoryShare(_ config: UTMAppleConfigurationSharedDirectory, index: Int) -> [AnyHashable : Any] {
+
+    private func serializeAppleDirectoryShare(_ config: UTMAppleConfigurationSharedDirectory, index: Int) -> [AnyHashable: Any] {
         [
             "index": index,
             "readOnly": config.isReadOnly
         ]
     }
-    
-    private func serializeAppleDriveExisting(_ config: UTMAppleConfigurationDrive) -> [AnyHashable : Any] {
+
+    private func serializeAppleDriveExisting(_ config: UTMAppleConfigurationDrive) -> [AnyHashable: Any] {
         [
             "id": config.id,
             "removable": config.isExternal,
-            "hostSize": size(of: config),
+            "hostSize": size(of: config)
         ]
     }
-    
+
     private func appleNetworkMode(from mode: UTMAppleConfigurationNetwork.NetworkMode) -> UTMScriptingAppleNetworkMode {
         switch mode {
         case .shared: return .shared
         case .bridged: return .bridged
         }
     }
-    
-    private func serializeAppleNetwork(_ config: UTMAppleConfigurationNetwork, index: Int) -> [AnyHashable : Any] {
+
+    private func serializeAppleNetwork(_ config: UTMAppleConfigurationNetwork, index: Int) -> [AnyHashable: Any] {
         [
             "index": index,
             "mode": appleNetworkMode(from: config.mode).rawValue,
             "address": config.macAddress,
-            "hostInterface": config.bridgeInterface ?? "",
+            "hostInterface": config.bridgeInterface ?? ""
         ]
     }
-    
+
     private func appleSerialInterface(from mode: UTMAppleConfigurationSerial.SerialMode) -> UTMScriptingSerialInterface {
         switch mode {
         case .ptty: return .ptty
         default: return .unavailable
         }
     }
-    
-    private func serializeAppleSerial(_ config: UTMAppleConfigurationSerial, index: Int) -> [AnyHashable : Any] {
+
+    private func serializeAppleSerial(_ config: UTMAppleConfigurationSerial, index: Int) -> [AnyHashable: Any] {
         [
             "index": index,
-            "interface": appleSerialInterface(from: config.mode).rawValue,
+            "interface": appleSerialInterface(from: config.mode).rawValue
         ]
     }
 }
 
 @MainActor
 extension UTMScriptingConfigImpl {
-    private func updateElements<T>(_ array: inout [T], with records: [[AnyHashable : Any]], onExisting: @MainActor (inout T, [AnyHashable : Any]) throws -> Void, onNew: @MainActor ([AnyHashable : Any]) throws -> T) throws {
+    private func updateElements<T>(_ array: inout [T], with records: [[AnyHashable: Any]], onExisting: @MainActor (inout T, [AnyHashable: Any]) throws -> Void, onNew: @MainActor ([AnyHashable: Any]) throws -> T) throws {
         var unseenIndicies = IndexSet(integersIn: array.indices)
         for record in records {
             if let index = record["index"] as? Int {
@@ -264,8 +264,8 @@ extension UTMScriptingConfigImpl {
         }
         array.remove(atOffsets: unseenIndicies)
     }
-    
-    private func updateIdentifiedElements<T: Identifiable>(_ array: inout [T], with records: [[AnyHashable : Any]], onExisting: @MainActor (inout T, [AnyHashable : Any]) throws -> Void, onNew: @MainActor ([AnyHashable : Any]) throws -> T) throws {
+
+    private func updateIdentifiedElements<T: Identifiable>(_ array: inout [T], with records: [[AnyHashable: Any]], onExisting: @MainActor (inout T, [AnyHashable: Any]) throws -> Void, onNew: @MainActor ([AnyHashable: Any]) throws -> T) throws {
         var unseenIndicies = IndexSet(integersIn: array.indices)
         for record in records {
             if let id = record["id"] as? T.ID {
@@ -280,7 +280,7 @@ extension UTMScriptingConfigImpl {
         }
         array.remove(atOffsets: unseenIndicies)
     }
-    
+
     private func parseQemuDirectoryShareMode(_ value: AEKeyword?) -> QEMUFileShareMode? {
         guard let value = value, let parsed = UTMScriptingQemuDirectoryShareMode(rawValue: value) else {
             return Optional.none
@@ -292,8 +292,8 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func updateQemuConfiguration(from record: [AnyHashable : Any]) throws {
+
+    private func updateQemuConfiguration(from record: [AnyHashable: Any]) throws {
         let config = config as! UTMQemuConfiguration
         if let name = record["name"] as? String, !name.isEmpty {
             config.information.name = name
@@ -329,17 +329,17 @@ extension UTMScriptingConfigImpl {
         if let directoryShareMode = parseQemuDirectoryShareMode(record["directoryShareMode"] as? AEKeyword) {
             config.sharing.directoryShareMode = directoryShareMode
         }
-        if let drives = record["drives"] as? [[AnyHashable : Any]] {
+        if let drives = record["drives"] as? [[AnyHashable: Any]] {
             try updateQemuDrives(from: drives)
         }
-        if let networkInterfaces = record["networkInterfaces"] as? [[AnyHashable : Any]] {
+        if let networkInterfaces = record["networkInterfaces"] as? [[AnyHashable: Any]] {
             try updateQemuNetworks(from: networkInterfaces)
         }
-        if let serialPorts = record["serialPorts"] as? [[AnyHashable : Any]] {
+        if let serialPorts = record["serialPorts"] as? [[AnyHashable: Any]] {
             try updateQemuSerials(from: serialPorts)
         }
     }
-    
+
     private func parseQemuDriveInterface(_ value: AEKeyword?) -> QEMUDriveInterface? {
         guard let value = value, let parsed = UTMScriptingQemuDriveInterface(rawValue: value) else {
             return Optional.none
@@ -358,13 +358,13 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func updateQemuDrives(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateQemuDrives(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMQemuConfiguration
         try updateIdentifiedElements(&config.drives, with: records, onExisting: updateQemuExistingDrive, onNew: unserializeQemuDriveNew)
     }
-    
-    private func updateQemuExistingDrive(_ drive: inout UTMQemuConfigurationDrive, from record: [AnyHashable : Any]) throws {
+
+    private func updateQemuExistingDrive(_ drive: inout UTMQemuConfigurationDrive, from record: [AnyHashable: Any]) throws {
         if let interface = parseQemuDriveInterface(record["interface"] as? AEKeyword) {
             drive.interface = interface
         }
@@ -372,8 +372,8 @@ extension UTMScriptingConfigImpl {
             drive.imageURL = source
         }
     }
-    
-    private func unserializeQemuDriveNew(from record: [AnyHashable : Any]) throws -> UTMQemuConfigurationDrive {
+
+    private func unserializeQemuDriveNew(from record: [AnyHashable: Any]) throws -> UTMQemuConfigurationDrive {
         let config = config as! UTMQemuConfiguration
         let removable = record["removable"] as? Bool ?? false
         var newDrive = UTMQemuConfigurationDrive(forArchitecture: config.system.architecture, target: config.system.target, isExternal: removable)
@@ -390,8 +390,8 @@ extension UTMScriptingConfigImpl {
         }
         return newDrive
     }
-    
-    private func updateQemuNetworks(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateQemuNetworks(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMQemuConfiguration
         try updateElements(&config.networks, with: records, onExisting: updateQemuExistingNetwork, onNew: { record in
             guard var newNetwork = UTMQemuConfigurationNetwork(forArchitecture: config.system.architecture, target: config.system.target) else {
@@ -401,7 +401,7 @@ extension UTMScriptingConfigImpl {
             return newNetwork
         })
     }
-    
+
     private func parseQemuNetworkMode(_ value: AEKeyword?) -> QEMUNetworkMode? {
         guard let value = value, let parsed = UTMScriptingQemuNetworkMode(rawValue: value) else {
             return Optional.none
@@ -414,8 +414,8 @@ extension UTMScriptingConfigImpl {
         default: return .none
         }
     }
-    
-    private func updateQemuExistingNetwork(_ network: inout UTMQemuConfigurationNetwork, from record: [AnyHashable : Any]) throws {
+
+    private func updateQemuExistingNetwork(_ network: inout UTMQemuConfigurationNetwork, from record: [AnyHashable: Any]) throws {
         let config = config as! UTMQemuConfiguration
         if let hardware = record["hardware"] as? String, let hardware = config.system.architecture.networkDeviceType.init(rawValue: hardware) {
             network.hardware = hardware
@@ -429,11 +429,11 @@ extension UTMScriptingConfigImpl {
         if let interface = record["hostInterface"] as? String, !interface.isEmpty {
             network.bridgeInterface = interface
         }
-        if let portForwards = record["portForwards"] as? [[AnyHashable : Any]] {
+        if let portForwards = record["portForwards"] as? [[AnyHashable: Any]] {
             network.portForward = portForwards.map({ unserializeQemuPortForward(from: $0) })
         }
     }
-    
+
     private func parseNetworkProtocol(_ value: AEKeyword?) -> QEMUNetworkProtocol? {
         guard let value = value, let parsed = UTMScriptingNetworkProtocol(rawValue: value) else {
             return Optional.none
@@ -444,8 +444,8 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func unserializeQemuPortForward(from record: [AnyHashable : Any]) -> UTMQemuConfigurationPortForward {
+
+    private func unserializeQemuPortForward(from record: [AnyHashable: Any]) -> UTMQemuConfigurationPortForward {
         var forward = UTMQemuConfigurationPortForward()
         if let protoc = parseNetworkProtocol(record["protocol"] as? AEKeyword) {
             forward.protocol = protoc
@@ -464,8 +464,8 @@ extension UTMScriptingConfigImpl {
         }
         return forward
     }
-    
-    private func updateQemuSerials(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateQemuSerials(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMQemuConfiguration
         try updateElements(&config.serials, with: records, onExisting: updateQemuExistingSerial, onNew: { record in
             guard var newSerial = UTMQemuConfigurationSerial(forArchitecture: config.system.architecture, target: config.system.target) else {
@@ -475,7 +475,7 @@ extension UTMScriptingConfigImpl {
             return newSerial
         })
     }
-    
+
     private func parseQemuSerialInterface(_ value: AEKeyword?) -> QEMUSerialMode? {
         guard let value = value, let parsed = UTMScriptingSerialInterface(rawValue: value) else {
             return Optional.none
@@ -486,8 +486,8 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func updateQemuExistingSerial(_ serial: inout UTMQemuConfigurationSerial, from record: [AnyHashable : Any]) throws {
+
+    private func updateQemuExistingSerial(_ serial: inout UTMQemuConfigurationSerial, from record: [AnyHashable: Any]) throws {
         let config = config as! UTMQemuConfiguration
         if let hardware = record["hardware"] as? String, let hardware = config.system.architecture.serialDeviceType.init(rawValue: hardware) {
             serial.hardware = hardware
@@ -499,8 +499,8 @@ extension UTMScriptingConfigImpl {
             serial.tcpPort = port
         }
     }
-    
-    private func updateAppleConfiguration(from record: [AnyHashable : Any]) throws {
+
+    private func updateAppleConfiguration(from record: [AnyHashable: Any]) throws {
         let config = config as! UTMAppleConfiguration
         if let name = record["name"] as? String, !name.isEmpty {
             config.information.name = name
@@ -514,21 +514,21 @@ extension UTMScriptingConfigImpl {
         if let cpuCores = record["cpuCores"] as? Int {
             config.system.cpuCount = cpuCores
         }
-        if let directoryShares = record["directoryShares"] as? [[AnyHashable : Any]] {
+        if let directoryShares = record["directoryShares"] as? [[AnyHashable: Any]] {
             try updateAppleDirectoryShares(from: directoryShares)
         }
-        if let drives = record["drives"] as? [[AnyHashable : Any]] {
+        if let drives = record["drives"] as? [[AnyHashable: Any]] {
             try updateAppleDrives(from: drives)
         }
-        if let networkInterfaces = record["networkInterfaces"] as? [[AnyHashable : Any]] {
+        if let networkInterfaces = record["networkInterfaces"] as? [[AnyHashable: Any]] {
             try updateAppleNetworks(from: networkInterfaces)
         }
-        if let serialPorts = record["serialPorts"] as? [[AnyHashable : Any]] {
+        if let serialPorts = record["serialPorts"] as? [[AnyHashable: Any]] {
             try updateAppleSerials(from: serialPorts)
         }
     }
-    
-    private func updateAppleDirectoryShares(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateAppleDirectoryShares(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMAppleConfiguration
         try updateElements(&config.sharedDirectories, with: records, onExisting: updateAppleExistingDirectoryShare, onNew: { record in
             var newShare = UTMAppleConfigurationSharedDirectory(directoryURL: nil, isReadOnly: false)
@@ -536,25 +536,25 @@ extension UTMScriptingConfigImpl {
             return newShare
         })
     }
-    
-    private func updateAppleExistingDirectoryShare(_ share: inout UTMAppleConfigurationSharedDirectory, from record: [AnyHashable : Any]) throws {
+
+    private func updateAppleExistingDirectoryShare(_ share: inout UTMAppleConfigurationSharedDirectory, from record: [AnyHashable: Any]) throws {
         if let readOnly = record["readOnly"] as? Bool {
             share.isReadOnly = readOnly
         }
     }
-    
-    private func updateAppleDrives(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateAppleDrives(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMAppleConfiguration
         try updateIdentifiedElements(&config.drives, with: records, onExisting: updateAppleExistingDrive, onNew: unserializeAppleNewDrive)
     }
-    
-    private func updateAppleExistingDrive(_ drive: inout UTMAppleConfigurationDrive, from record: [AnyHashable : Any]) throws {
+
+    private func updateAppleExistingDrive(_ drive: inout UTMAppleConfigurationDrive, from record: [AnyHashable: Any]) throws {
         if let source = record["source"] as? URL {
             drive.imageURL = source
         }
     }
-    
-    private func unserializeAppleNewDrive(from record: [AnyHashable : Any]) throws -> UTMAppleConfigurationDrive {
+
+    private func unserializeAppleNewDrive(from record: [AnyHashable: Any]) throws -> UTMAppleConfigurationDrive {
         let removable = record["removable"] as? Bool ?? false
         var newDrive: UTMAppleConfigurationDrive
         if let size = record["guestSize"] as? Int {
@@ -564,8 +564,8 @@ extension UTMScriptingConfigImpl {
         }
         return newDrive
     }
-    
-    private func updateAppleNetworks(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateAppleNetworks(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMAppleConfiguration
         try updateElements(&config.networks, with: records, onExisting: updateAppleExistingNetwork, onNew: { record in
             var newNetwork = UTMAppleConfigurationNetwork()
@@ -573,7 +573,7 @@ extension UTMScriptingConfigImpl {
             return newNetwork
         })
     }
-    
+
     private func parseAppleNetworkMode(_ value: AEKeyword?) -> UTMAppleConfigurationNetwork.NetworkMode? {
         guard let value = value, let parsed = UTMScriptingQemuNetworkMode(rawValue: value) else {
             return Optional.none
@@ -584,8 +584,8 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func updateAppleExistingNetwork(_ network: inout UTMAppleConfigurationNetwork, from record: [AnyHashable : Any]) throws {
+
+    private func updateAppleExistingNetwork(_ network: inout UTMAppleConfigurationNetwork, from record: [AnyHashable: Any]) throws {
         if let mode = parseAppleNetworkMode(record["mode"] as? AEKeyword) {
             network.mode = mode
         }
@@ -596,8 +596,8 @@ extension UTMScriptingConfigImpl {
             network.bridgeInterface = interface
         }
     }
-    
-    private func updateAppleSerials(from records: [[AnyHashable : Any]]) throws {
+
+    private func updateAppleSerials(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMAppleConfiguration
         try updateElements(&config.serials, with: records, onExisting: updateAppleExistingSerial, onNew: { record in
             var newSerial = UTMAppleConfigurationSerial()
@@ -605,7 +605,7 @@ extension UTMScriptingConfigImpl {
             return newSerial
         })
     }
-    
+
     private func parseAppleSerialInterface(_ value: AEKeyword?) -> UTMAppleConfigurationSerial.SerialMode? {
         guard let value = value, let parsed = UTMScriptingSerialInterface(rawValue: value) else {
             return Optional.none
@@ -615,19 +615,19 @@ extension UTMScriptingConfigImpl {
         default: return Optional.none
         }
     }
-    
-    private func updateAppleExistingSerial(_ serial: inout UTMAppleConfigurationSerial, from record: [AnyHashable : Any]) throws {
+
+    private func updateAppleExistingSerial(_ serial: inout UTMAppleConfigurationSerial, from record: [AnyHashable: Any]) throws {
         if let interface = parseAppleSerialInterface(record["interface"] as? AEKeyword) {
             serial.mode = interface
         }
     }
-    
+
     enum ConfigurationError: Error, LocalizedError {
         case identifierNotFound(id: any Hashable)
         case invalidDriveDescription
         case indexNotFound(index: Int)
         case deviceNotSupported
-        
+
         var errorDescription: String? {
             switch self {
             case .identifierNotFound(let id): return String.localizedStringWithFormat(NSLocalizedString("Identifier '%@' cannot be found.", comment: "UTMScriptingConfigImpl"), String(describing: id))

--- a/Scripting/UTMScriptingUSBDeviceImpl.swift
+++ b/Scripting/UTMScriptingUSBDeviceImpl.swift
@@ -21,27 +21,27 @@ import CocoaSpice
 @objc(UTMScriptingUSBDeviceImpl)
 class UTMScriptingUSBDeviceImpl: NSObject, UTMScriptable {
     @nonobjc var box: CSUSBDevice
-    
+
     private var data: UTMData? {
         (NSApp.scriptingDelegate as? AppDelegate)?.data
     }
-    
+
     @objc var id: Int {
         box.usbBusNumber << 16 | box.usbPortNumber
     }
-    
+
     @objc var name: String {
         box.name ?? String(format: "%04X:%04X", box.usbVendorId, box.usbProductId)
     }
-    
+
     @objc var manufacturerName: String {
         box.usbManufacturerName ?? name
     }
-    
+
     @objc var productName: String {
         box.usbProductName ?? name
     }
-    
+
     @objc var vendorId: Int {
         box.usbVendorId
     }
@@ -57,11 +57,11 @@ class UTMScriptingUSBDeviceImpl: NSObject, UTMScriptable {
                                    key: "scriptingUsbDevices",
                                    uniqueID: id)
     }
-    
+
     init(for usbDevice: CSUSBDevice) {
         self.box = usbDevice
     }
-    
+
     /// Return the same USB device in context of a USB manager
     ///
     /// This is required because we may be using `CSUSBDevice` objects returned from a different `CSUSBManager`
@@ -70,14 +70,12 @@ class UTMScriptingUSBDeviceImpl: NSObject, UTMScriptable {
     ///   - usbManager: USB manager
     /// - Returns: USB device in same context as the manager
     private func same(usbDevice: CSUSBDevice, for usbManager: CSUSBManager) -> CSUSBDevice? {
-        for other in usbManager.usbDevices {
-            if other.isEqual(to: usbDevice) {
-                return other
-            }
+        for other in usbManager.usbDevices where other.isEqual(to: usbDevice) {
+            return other
         }
         return nil
     }
-    
+
     @objc func connect(_ command: NSScriptCommand) {
         let scriptingVM = command.evaluatedArguments?["vm"] as? UTMScriptingVirtualMachineImpl
         withScriptCommand(command) { [self] in
@@ -93,7 +91,7 @@ class UTMScriptingUSBDeviceImpl: NSObject, UTMScriptable {
             try await usbManager.connectUsbDevice(usbDevice)
         }
     }
-    
+
     @objc func disconnect(_ command: NSScriptCommand) {
         withScriptCommand(command) { [self] in
             guard let data = data else {
@@ -128,7 +126,7 @@ extension UTMScriptingUSBDeviceImpl {
         case notReady
         case deviceNotFound
         case deviceNotConnected
-        
+
         var errorDescription: String? {
             switch self {
             case .notReady: return NSLocalizedString("UTM is not ready to accept commands.", comment: "UTMScriptingUSBDeviceImpl")

--- a/Services/UTMExtensions.swift
+++ b/Services/UTMExtensions.swift
@@ -66,7 +66,7 @@ extension Optional where Wrapped == Bool {
             self = newValue
         }
     }
-    
+
     public var bound: Wrapped {
         get {
             return _bound ?? false
@@ -90,11 +90,9 @@ extension Binding where Value == Bool {
 extension LocalizedStringKey {
     var localizedString: String {
         let mirror = Mirror(reflecting: self)
-        var key: String? = nil
-        for property in mirror.children {
-            if property.label == "key" {
-                key = property.value as? String
-            }
+        var key: String?
+        for property in mirror.children where property.label == "key" {
+            key = property.value as? String
         }
         guard let goodKey = key else {
             logger.error("Failed to get localization key")
@@ -120,13 +118,11 @@ extension IndexSet: Identifiable {
 
 extension Array {
     subscript(indicies: IndexSet) -> [Element] {
-        get {
-            var slice = [Element]()
-            for i in indicies {
-                slice.append(self[i])
-            }
-            return slice
+        var slice = [Element]()
+        for i in indicies {
+            slice.append(self[i])
         }
+        return slice
     }
 }
 
@@ -143,10 +139,10 @@ extension View {
 
 extension UTType {
     static let UTM = UTType(exportedAs: "com.utmapp.utm")
-    
+
     // SwiftUI BUG: exportedAs: "com.utmapp.utm" doesn't work on macOS and older iOS
     static let UTMextension = UTType(exportedAs: "utm")
-    
+
     static let appleLog = UTType(filenameExtension: "log")!
 
     static let ipsw = UTType(filenameExtension: "ipsw")!
@@ -164,20 +160,20 @@ extension Color {
         if hex.count != 7 { // The '#' included
             return nil
         }
-            
+
         let hexColor = String(hex.dropFirst())
-        
+
         let scanner = Scanner(string: hexColor)
         var hexNumber: UInt64 = 0
-        
+
         if !scanner.scanHexInt64(&hexNumber) {
             return nil
         }
-        
+
         let r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
         let g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
         let b = CGFloat(hexNumber & 0x0000ff) / 255
-        
+
         self.init(.displayP3, red: r, green: g, blue: b, opacity: 1.0)
     }
 }
@@ -186,11 +182,11 @@ extension CGColor {
     var hexString: String? {
         hexString(for: .init(name: CGColorSpace.displayP3)!)
     }
-    
+
     var sRGBhexString: String? {
         hexString(for: .init(name: CGColorSpace.sRGB)!)
     }
-    
+
     private func hexString(for colorSpace: CGColorSpace) -> String? {
         guard let rgbColor = self.converted(to: colorSpace, intent: .defaultIntent, options: nil),
               let components = rgbColor.components else {
@@ -241,23 +237,23 @@ extension UIImage {
         if hex.count != 7 { // The '#' included
             return nil
         }
-            
+
         let hexColor = String(hex.dropFirst())
-        
+
         let scanner = Scanner(string: hexColor)
         var hexNumber: UInt64 = 0
-        
+
         if !scanner.scanHexInt64(&hexNumber) {
             return nil
         }
-        
+
         let r = CGFloat((hexNumber & 0xff0000) >> 16) / 255
         let g = CGFloat((hexNumber & 0x00ff00) >> 8) / 255
         let b = CGFloat(hexNumber & 0x0000ff) / 255
-        
+
         self.init(displayP3Red: r, green: g, blue: b, alpha: 1.0)
     }
-    
+
     var sRGBhexString: String? {
         cgColor.sRGBhexString
     }
@@ -271,21 +267,19 @@ typealias PlatformImage = UIImage
 #endif
 
 #if os(macOS)
-enum FakeKeyboardType : Int {
+enum FakeKeyboardType: Int {
     case asciiCapable
     case decimalPad
     case numberPad
 }
 
-struct EditButton {
-    
-}
+struct EditButton {}
 
 extension View {
     func keyboardType(_ type: FakeKeyboardType) -> some View {
         return self
     }
-    
+
     func navigationBarItems(trailing: EditButton) -> some View {
         return self
     }
@@ -306,7 +300,7 @@ extension NSImage {
 struct Setting<T> {
     private(set) var keyName: String
     private var defaultValue: T
-    
+
     var wrappedValue: T {
         get {
             let defaults = UserDefaults.standard
@@ -315,13 +309,13 @@ struct Setting<T> {
             }
             return value as! T
         }
-        
+
         set {
             let defaults = UserDefaults.standard
             defaults.set(newValue, forKey: keyName)
         }
     }
-    
+
     init(wrappedValue: T, _ keyName: String) {
         self.defaultValue = wrappedValue
         self.keyName = keyName
@@ -337,7 +331,7 @@ extension URL {
         return .withSecurityScope
         #endif
     }
-    
+
     private static var defaultResolutionOptions: BookmarkResolutionOptions {
         #if os(iOS) || os(visionOS)
         return []
@@ -345,7 +339,7 @@ extension URL {
         return .withSecurityScope
         #endif
     }
-    
+
     func persistentBookmarkData(isReadyOnly: Bool = false) throws -> Data {
         var options = Self.defaultCreationOptions
         #if os(macOS)
@@ -363,7 +357,7 @@ extension URL {
                                      includingResourceValuesForKeys: nil,
                                      relativeTo: nil)
     }
-    
+
     init(resolvingPersistentBookmarkData bookmark: Data) throws {
         var stale: Bool = false
         try self.init(resolvingBookmarkData: bookmark,

--- a/Services/UTMExtensions.swift
+++ b/Services/UTMExtensions.swift
@@ -26,7 +26,7 @@ extension Optional where Wrapped == String {
             self = newValue
         }
     }
-    
+
     public var bound: String {
         get {
             return _bound ?? ""
@@ -46,7 +46,7 @@ extension Optional where Wrapped: FixedWidthInteger {
             self = newValue
         }
     }
-    
+
     public var bound: Wrapped {
         get {
             return _bound ?? 0

--- a/Services/UTMRegistry.swift
+++ b/Services/UTMRegistry.swift
@@ -19,21 +19,21 @@ import Foundation
 
 class UTMRegistry: NSObject {
     @objc static let shared = UTMRegistry()
-    
+
     private var serializedEntries: [String: Any] {
         get {
             UserDefaults.standard.dictionary(forKey: "Registry") ?? [:]
         }
-        
+
         set {
             UserDefaults.standard.setValue(newValue, forKey: "Registry")
         }
     }
-    
+
     private var registryListener: AnyCancellable?
-    
+
     private var changeListeners: [String: AnyCancellable] = [:]
-    
+
     @Published private var entries: [String: UTMRegistryEntry] {
         didSet {
             let toAdd = entries.keys.filter({ !changeListeners.keys.contains($0) })
@@ -53,7 +53,7 @@ class UTMRegistry: NSObject {
             }
         }
     }
-    
+
     private override init() {
         entries = [:]
         super.init()
@@ -69,7 +69,7 @@ class UTMRegistry: NSObject {
                 self?.commitAll(entries: newEntries)
             }
     }
-    
+
     /// Gets an existing registry entry or create a new entry
     /// - Parameter vm: UTM virtual machine to locate in the registry
     /// - Returns: Either an existing registry entry or a new entry
@@ -81,7 +81,7 @@ class UTMRegistry: NSObject {
         entries[newEntry.uuid.uuidString] = newEntry
         return newEntry
     }
-    
+
     /// Gets an existing registry entry or create a new entry for a legacy bookmark
     /// - Parameters:
     ///   - uuid: UUID
@@ -97,14 +97,14 @@ class UTMRegistry: NSObject {
         entries[uuid.uuidString] = newEntry
         return newEntry
     }
-    
+
     /// Get an existing registry entry for a UUID
     /// - Parameter uuidString: UUID
     /// - Returns: An existing registry entry or nil if it does not exist
     func entry(for uuidString: String) -> UTMRegistryEntry? {
         return entries[uuidString]
     }
-    
+
     /// Commit the entry to persistent storage
     /// This runs in a background queue.
     /// - Parameter entry: Entry to commit
@@ -116,7 +116,7 @@ class UTMRegistry: NSObject {
             logger.error("Failed to commit entry for \(uuid)")
         }
     }
-    
+
     /// Commit all entries to persistent storage
     /// This runs in a background queue.
     /// - Parameter entries: All entries to commit
@@ -128,23 +128,21 @@ class UTMRegistry: NSObject {
         }
         serializedEntries = newSerializedEntries
     }
-    
+
     /// Remove an entry from the registry
     /// - Parameter entry: Entry to remove
     func remove(entry: UTMRegistryEntry) {
         entries.removeValue(forKey: entry.uuid.uuidString)
     }
-    
+
     /// Remove all entries from the registry except for the specified set
     /// - Parameter uuidStrings: Keys to NOT remove
     func prune(exceptFor uuidStrings: Set<String>) {
-        for key in entries.keys {
-            if !uuidStrings.contains(key) {
-                entries.removeValue(forKey: key)
-            }
+        for key in entries.keys where !uuidStrings.contains(key) {
+            entries.removeValue(forKey: key)
         }
     }
-    
+
     /// Make sure the registry is synchronized when UTM terminates
     func sync() {
         commitAll(entries: entries)

--- a/Services/UTMRegistryEntry.swift
+++ b/Services/UTMRegistryEntry.swift
@@ -19,27 +19,27 @@ import Foundation
 @objc class UTMRegistryEntry: NSObject, Codable, ObservableObject {
     /// Empty registry entry used only as a workaround for object initialization
     static let empty = UTMRegistryEntry(uuid: UUID(uuidString: "00000000-0000-0000-0000-000000000000")!, name: "", path: "")
-    
+
     @Published private var _name: String
-    
+
     @Published private var _package: File
-    
+
     private(set) var uuid: UUID
-    
+
     @Published private var _isSuspended: Bool
-    
+
     @Published private var _externalDrives: [String: File]
-    
+
     @Published private var _sharedDirectories: [File]
-    
+
     @Published private var _windowSettings: [Int: Window]
-    
+
     @Published private var _terminalSettings: [Int: Terminal]
-    
+
     @Published private var _hasMigratedConfig: Bool
-    
+
     @Published private var _macRecoveryIpsw: File?
-    
+
     private enum CodingKeys: String, CodingKey {
         case name = "Name"
         case package = "Package"
@@ -52,7 +52,7 @@ import Foundation
         case hasMigratedConfig = "MigratedConfig"
         case macRecoveryIpsw = "MacRecoveryIpsw"
     }
-    
+
     init(uuid: UUID, name: String, path: String, bookmark: Data? = nil) {
         _name = name
         let package: File?
@@ -70,14 +70,14 @@ import Foundation
         _terminalSettings = [:]
         _hasMigratedConfig = false
     }
-    
+
     convenience init(newFrom vm: any UTMVirtualMachine) {
         self.init(uuid: vm.id, name: vm.name, path: vm.pathUrl.path)
         if let package = try? File(url: vm.pathUrl) {
             _package = package
         }
     }
-    
+
     required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         _name = try container.decode(String.self, forKey: .name)
@@ -91,7 +91,7 @@ import Foundation
         _hasMigratedConfig = try container.decodeIfPresent(Bool.self, forKey: .hasMigratedConfig) ?? false
         _macRecoveryIpsw = try container.decodeIfPresent(File.self, forKey: .macRecoveryIpsw)
     }
-    
+
     func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(_name, forKey: .name)
@@ -107,7 +107,7 @@ import Foundation
         }
         try container.encodeIfPresent(_macRecoveryIpsw, forKey: .macRecoveryIpsw)
     }
-    
+
     func asDictionary() throws -> [String: Any] {
         let encoder = PropertyListEncoder()
         encoder.outputFormat = .xml
@@ -115,7 +115,7 @@ import Foundation
         let dict = try PropertyListSerialization.propertyList(from: xml, format: nil)
         return dict as! [String: Any]
     }
-    
+
     /// Update the UUID
     ///
     /// Should only be called from `UTMRegistry`!
@@ -142,118 +142,118 @@ extension UTMRegistryEntryDecodable {
         get {
             _name
         }
-        
+
         set {
             _name = newValue
         }
     }
-    
+
     var package: File {
         get {
             _package
         }
-        
+
         set {
             _package = newValue
         }
     }
-    
+
     var isSuspended: Bool {
         get {
             _isSuspended
         }
-        
+
         set {
             _isSuspended = newValue
         }
     }
-    
+
     var externalDrives: [String: File] {
         get {
             _externalDrives
         }
-        
+
         set {
             _externalDrives = newValue
         }
     }
-    
+
     var sharedDirectories: [File] {
         get {
             _sharedDirectories
         }
-        
+
         set {
             _sharedDirectories = newValue
         }
     }
-    
+
     var windowSettings: [Int: Window] {
         get {
             _windowSettings
         }
-        
+
         set {
             _windowSettings = newValue
         }
     }
-    
+
     var terminalSettings: [Int: Terminal] {
         get {
             _terminalSettings
         }
-        
+
         set {
             _terminalSettings = newValue
         }
     }
-    
+
     var hasMigratedConfig: Bool {
         get {
             _hasMigratedConfig
         }
-        
+
         set {
             _hasMigratedConfig = newValue
         }
     }
-    
+
     var macRecoveryIpsw: File? {
         get {
             _macRecoveryIpsw
         }
-        
+
         set {
             _macRecoveryIpsw = newValue
         }
     }
-    
+
     func setExternalDrive(_ file: File, forId id: String) {
         externalDrives[id] = file
     }
-    
+
     func updateExternalDriveRemoteBookmark(_ bookmark: Data, forId id: String) {
         externalDrives[id]?.remoteBookmark = bookmark
     }
-    
+
     func removeExternalDrive(forId id: String) {
         externalDrives.removeValue(forKey: id)
     }
-    
+
     func setSingleSharedDirectory(_ file: File) {
         sharedDirectories = [file]
     }
-    
+
     func updateSingleSharedDirectoryRemoteBookmark(_ bookmark: Data) {
         if !sharedDirectories.isEmpty {
             sharedDirectories[0].remoteBookmark = bookmark
         }
     }
-    
+
     func removeAllSharedDirectories() {
         sharedDirectories = []
     }
-    
+
     func update(copying other: UTMRegistryEntry) {
         isSuspended = other.isSuspended
         externalDrives = other.externalDrives
@@ -262,11 +262,11 @@ extension UTMRegistryEntryDecodable {
         terminalSettings = other.terminalSettings
         hasMigratedConfig = other.hasMigratedConfig
     }
-    
+
     func setIsSuspended(_ isSuspended: Bool) {
         self.isSuspended = isSuspended
     }
-    
+
     func setPackageRemoteBookmark(_ remoteBookmark: Data?, path: String? = nil) {
         package.remoteBookmark = remoteBookmark
         if let path = path {
@@ -313,7 +313,7 @@ extension UTMRegistryEntry {
             }
         }
     }
-    
+
     /// Try to migrate from a view.plist or does nothing if it does not exist.
     /// - Parameter viewStateURL: URL to view.plist
     @objc func migrateUnsafe(viewStateURL: URL) {
@@ -321,7 +321,7 @@ extension UTMRegistryEntry {
         guard fileManager.fileExists(atPath: viewStateURL.path) else {
             return
         }
-        guard let dict = try? NSDictionary(contentsOf: viewStateURL, error: ()) as? [AnyHashable : Any] else {
+        guard let dict = try? NSDictionary(contentsOf: viewStateURL, error: ()) as? [AnyHashable: Any] else {
             logger.error("Failed to parse legacy \(viewStateURL)")
             return
         }
@@ -329,7 +329,7 @@ extension UTMRegistryEntry {
         migrate(viewState: viewState)
         try? fileManager.removeItem(at: viewStateURL) // delete view.plist
     }
-    
+
     #if os(macOS)
     /// Try to migrate bookmarks from an Apple VM config.
     /// - Parameter config: Apple config to migrate
@@ -357,26 +357,26 @@ extension UTMRegistryEntry {
 extension UTMRegistryEntry {
     struct File: Codable, Identifiable {
         var url: URL
-        
+
         var path: String
-        
+
         var bookmark: Data
-        
+
         var remoteBookmark: Data?
-        
+
         var isReadOnly: Bool
-        
+
         let id: UUID = UUID()
-        
+
         fileprivate var isValid: Bool
-        
+
         private enum CodingKeys: String, CodingKey {
             case path = "Path"
             case bookmark = "Bookmark"
             case remoteBookmark = "BookmarkRemote"
             case isReadOnly = "ReadOnly"
         }
-        
+
         init(path: String, bookmark: Data, isReadOnly: Bool = false) throws {
             self.path = path
             self.bookmark = bookmark
@@ -384,7 +384,7 @@ extension UTMRegistryEntry {
             self.url = try URL(resolvingPersistentBookmarkData: bookmark)
             self.isValid = true
         }
-        
+
         init(url: URL, isReadOnly: Bool = false) throws {
             self.path = url.path
             self.bookmark = try url.persistentBookmarkData(isReadyOnly: isReadOnly)
@@ -401,7 +401,7 @@ extension UTMRegistryEntry {
             self.remoteBookmark = remoteBookmark
             self.isValid = true
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             path = try container.decode(String.self, forKey: .path)
@@ -421,7 +421,7 @@ extension UTMRegistryEntry {
                 }
             }
         }
-        
+
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(path, forKey: .path)

--- a/Services/UTMRegistryEntry.swift
+++ b/Services/UTMRegistryEntry.swift
@@ -430,18 +430,18 @@ extension UTMRegistryEntry {
             try container.encodeIfPresent(remoteBookmark, forKey: .remoteBookmark)
         }
     }
-    
+
     struct Window: Codable, Equatable {
         var scale: CGFloat = 1.0
-        
+
         var origin: CGPoint = .zero
-        
+
         var isToolbarVisible: Bool = true
-        
+
         var isKeyboardVisible: Bool = false
-        
+
         var isDisplayZoomLocked: Bool = true
-        
+
         private enum CodingKeys: String, CodingKey {
             case scale = "Scale"
             case origin = "Origin"
@@ -449,10 +449,10 @@ extension UTMRegistryEntry {
             case isKeyboardVisible = "KeyboardVisible"
             case isDisplayZoomLocked = "DisplayZoomLocked"
         }
-        
+
         init() {
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             scale = try container.decode(CGFloat.self, forKey: .scale)
@@ -461,7 +461,7 @@ extension UTMRegistryEntry {
             isKeyboardVisible = try container.decode(Bool.self, forKey: .isKeyboardVisible)
             isDisplayZoomLocked = try container.decode(Bool.self, forKey: .isDisplayZoomLocked)
         }
-        
+
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(scale, forKey: .scale)
@@ -471,28 +471,28 @@ extension UTMRegistryEntry {
             try container.encode(isDisplayZoomLocked, forKey: .isDisplayZoomLocked)
         }
     }
-    
+
     struct Terminal: Codable, Equatable {
         var columns: Int
-        
+
         var rows: Int
-        
+
         private enum CodingKeys: String, CodingKey {
             case columns = "Columns"
             case rows = "Rows"
         }
-        
+
         init(columns: Int = 80, rows: Int = 24) {
             self.columns = columns
             self.rows = rows
         }
-        
+
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             columns = try container.decode(Int.self, forKey: .columns)
             rows = try container.decode(Int.self, forKey: .rows)
         }
-        
+
         func encode(to encoder: Encoder) throws {
             var container = encoder.container(keyedBy: CodingKeys.self)
             try container.encode(columns, forKey: .columns)

--- a/Services/UTMSWTPM.swift
+++ b/Services/UTMSWTPM.swift
@@ -25,13 +25,13 @@ class UTMSWTPM: UTMProcess {
     private var swtpmMain: SwtpmMainFunction!
     private var hasProcessExited: Bool = false
     private var lastErrorLine: String?
-    
+
     var ctrlSocketUrl: URL?
     var dataUrl: URL?
-    
+
     private override init(arguments: [String]) {
         super.init(arguments: arguments)
-        entry = { process, argc, argv, envp in
+        entry = { process, argc, argv, _ in
             let _self = process as! UTMSWTPM
             return _self.swtpmMain(argc, argv, "swtpm", "socket")
         }
@@ -47,24 +47,24 @@ class UTMSWTPM: UTMProcess {
             logger.debug("\(string)")
         }
     }
-    
+
     convenience init() {
         self.init(arguments: [])
     }
-    
+
     override func didLoadDylib(_ handle: UnsafeMutableRawPointer) -> Bool {
         let sym = dlsym(handle, "swtpm_main")
         swtpmMain = unsafeBitCast(sym, to: SwtpmMainFunction.self)
         return swtpmMain != nil
     }
-    
+
     override func processHasExited(_ exitCode: Int, message: String?) {
         hasProcessExited = true
         if let message = message {
             logger.error("SWTPM exited: \(message)")
         }
     }
-    
+
     func start() async throws {
         guard let ctrlSocketUrl = ctrlSocketUrl else {
             throw UTMSWTPMError.socketNotSpecified

--- a/Services/UTMSerialPort.swift
+++ b/Services/UTMSerialPort.swift
@@ -21,7 +21,7 @@ import Foundation
     private let readFileHandle: FileHandle
     private let writeFileHandle: FileHandle
     private let terminalFileHandle: FileHandle?
-    
+
     public weak var delegate: UTMSerialPortDelegate? {
         didSet {
             if let delegate = delegate {
@@ -33,18 +33,18 @@ import Foundation
             }
         }
     }
-    
+
     init(portNamed name: String, readFileHandle: FileHandle, writeFileHandle: FileHandle, terminalFileHandle: FileHandle? = nil) {
         self.name = name
         self.readFileHandle = readFileHandle
         self.writeFileHandle = writeFileHandle
         self.terminalFileHandle = terminalFileHandle
     }
-    
+
     deinit {
         close()
     }
-    
+
     public func write(data: Data) {
         if #available(iOS 13.4, macOS 10.15, *) {
             try! writeFileHandle.write(contentsOf: data)
@@ -52,7 +52,7 @@ import Foundation
             writeFileHandle.write(data)
         }
     }
-    
+
     public func close() {
         if #available(iOS 13, macOS 10.15, *) {
             try? readFileHandle.close()

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -2583,6 +2583,7 @@
 				CE2D951824AD48BE0059923A /* Sources */,
 				CE2D951924AD48BE0059923A /* Frameworks */,
 				CE2D951A24AD48BE0059923A /* Resources */,
+				6ED11DCA2AABFD5C001D097C /* SwiftLint */,
 				CE0B6E6D24AD66CE00FE012D /* Embed Libraries */,
 				CEBDA1E924D8BDDB0010B5EC /* Embed XPC Services */,
 				84E3A8FA293DB70A0024A740 /* Embed CLI Tool */,
@@ -2822,6 +2823,28 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		6ED11DCA2AABFD5C001D097C /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -z \"$FASTLANE\" ]]; then\n    export PATH=\"$PATH:/opt/homebrew/bin\"\n    if which swiftlint > /dev/null; then\n        swiftlint\n    else\n        echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\n        exit -1\n    fi\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		8401FD5E269BE9C500265F0D /* Sources */ = {
@@ -3682,6 +3705,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = Platform/macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -3710,6 +3734,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				INFOPLIST_FILE = Platform/macOS/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This PR adds SwiftLint, a linting tool for Swift that ensures code quality and consistency. This PR adds it to the macOS app's build process and establishes a GitHub action.

The configuration I've opted for here is fairly permissive, as I found some of the rules to cause significant problems for UTM's codebase without refactoring.

Most of these violations here pertain to whitespace; a few are stylistic or safety-based. To avoid tripping the trailing whitespace rule when writing code, I recommend enabling this setting (and the one below it not highlighted) in Xcode:

![image](https://github.com/utmapp/UTM/assets/42140194/55909f29-09ad-4c2f-9c49-abcc3e35403d)