### PR TITLE
[Localizable] The App name is translated to "UTM SE" by mistake

### DIFF
--- a/Platform/iOS/zh-HK.lproj/InfoPlist.strings
+++ b/Platform/iOS/zh-HK.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 /* Bundle name */
-"CFBundleName" = "UTM SE";
+"CFBundleName" = "UTM";
 
 /* Privacy - Local Network Usage Description */
 "NSLocalNetworkUsageDescription" = "虛擬電腦可以訪問本地網絡。UTM 還會使用本地網絡與 AltServer 進行通信。";

--- a/Platform/iOS/zh-Hans.lproj/InfoPlist.strings
+++ b/Platform/iOS/zh-Hans.lproj/InfoPlist.strings
@@ -1,5 +1,5 @@
 /* Bundle name */
-"CFBundleName" = "UTM SE";
+"CFBundleName" = "UTM";
 
 /* Privacy - Local Network Usage Description */
 "NSLocalNetworkUsageDescription" = "虚拟机可以访问本地网络。UTM 还使用本地网络与 AltServer 通信。";


### PR DESCRIPTION
**Describe the issue**
The "CFBundleName" is configured as "UTM SE," causing the app name to consistently appear as "UTM SE"

**Affected languages**
Chinese Simplified, Chinese Traditional

The builds of UTM or UTM-HV are both displayed as "UTM SE"

![Screenshot_2023-12-13 11 32 13_8HKkeb](https://github.com/utmapp/UTM/assets/9637998/462e9689-000a-4572-b21d-9cc13e5a61cd)

