### PR TITLE
WIP: enable suspend for QEMU hypervisor on x86-64?

### DIFF
--- a/Services/UTMQemuVirtualMachine.swift
+++ b/Services/UTMQemuVirtualMachine.swift
@@ -250,13 +250,6 @@ extension UTMQemuVirtualMachine {
         if isRunningAsDisposible {
             return UTMQemuVirtualMachineError.qemuError(NSLocalizedString("Suspend state cannot be saved when running in disposible mode.", comment: "UTMQemuVirtualMachine"))
         }
-        #if arch(x86_64)
-        let hasHypervisor = await config.qemu.hasHypervisor
-        let architecture = await config.system.architecture
-        if hasHypervisor && architecture == .x86_64 {
-            return UTMQemuVirtualMachineError.qemuError(NSLocalizedString("Suspend is not supported for virtualization.", comment: "UTMQemuVirtualMachine"))
-        }
-        #endif
         for display in await config.displays {
             if display.hardware.rawValue.contains("-gl-") || display.hardware.rawValue.hasSuffix("-gl") {
                 return UTMQemuVirtualMachineError.qemuError(NSLocalizedString("Suspend is not supported when GPU acceleration is enabled.", comment: "UTMQemuVirtualMachine"))


### PR DESCRIPTION
This PR attempts to enable suspend with the QEMU hypervisor on x86-64.

I'm suspicious because it seemed way too easy, but I thought worth sharing anyway. It apparently works for me on my 2019 i7 MacBook Pro running 14.3.1.

Clicking on the close box of a running VM causes the console window to show a throbber for a little while, then close. I can then quit UTM, restart UTM, and click “play” on the VM. The VM console window opens, throbs for a bit, appears to have resumed in the same place, and is responsive.

This VM has no network devices b/c I don’t have the right Apple Developer magic.