### PR TITLE
Re-grab input when automatic capture is enabled

### DIFF
--- a/Platform/macOS/Display/VMDisplayQemuMetalWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayQemuMetalWindowController.swift
@@ -403,7 +403,6 @@ extension VMDisplayQemuMetalWindowController {
     func windowDidEnterFullScreen(_ notification: Notification) {
         isFullScreen = true
         if isFullScreenAutoCapture {
-            captureMouseToolbarButton.state = .on
             captureMouse()
         }
     }
@@ -411,9 +410,15 @@ extension VMDisplayQemuMetalWindowController {
     func windowDidExitFullScreen(_ notification: Notification) {
         isFullScreen = false
         if isFullScreenAutoCapture {
-            captureMouseToolbarButton.state = .off
             releaseMouse()
         }
+    }
+    
+    override func windowDidBecomeKey(_ notification: Notification) {
+        if isFullScreen && isFullScreenAutoCapture {
+            captureMouse()
+        }
+        super.windowDidBecomeKey(notification)
     }
     
     override func windowDidResignKey(_ notification: Notification) {


### PR DESCRIPTION
Make the window auto-capture the mouse again in full screen when it regains focus (for instance after swiping back to the UTM app).

fixes #6242 
