### PR TITLE
display(macos): add a setting to start a given VM in fullscreen

### DIFF
--- a/Configuration/UTMConfigurationInfo.swift
+++ b/Configuration/UTMConfigurationInfo.swift
@@ -21,6 +21,11 @@ struct UTMConfigurationInfo: Codable {
     /// VM name displayed to user.
     var name: String = NSLocalizedString("Virtual Machine", comment: "UTMConfigurationInfo")
     
+    #if os(macOS)
+    /// If true, starts the VM in full screen.
+    var isFullScreenStart: Bool = false
+    #endif
+    
     /// Path to the icon.
     var iconURL: URL?
     
@@ -39,6 +44,7 @@ struct UTMConfigurationInfo: Codable {
         case isIconCustom = "IconCustom"
         case notes = "Notes"
         case uuid = "UUID"
+        case isFullScreenStart = "IsFullScreenStart"
     }
     
     init() {
@@ -59,6 +65,9 @@ struct UTMConfigurationInfo: Codable {
         }
         notes = try values.decodeIfPresent(String.self, forKey: .notes)
         uuid = try values.decode(UUID.self, forKey: .uuid)
+        #if os(macOS)
+        isFullScreenStart = try values.decodeIfPresent(Bool.self, forKey: .isFullScreenStart) ?? false
+        #endif
     }
     
     func encode(to encoder: Encoder) throws {
@@ -75,6 +84,9 @@ struct UTMConfigurationInfo: Codable {
         }
         try container.encodeIfPresent(notes, forKey: .notes)
         try container.encode(uuid, forKey: .uuid)
+        #if os(macOS)
+        try container.encode(isFullScreenStart, forKey: .isFullScreenStart)
+        #endif
     }
     
     static func builtinIcon(named name: String) -> URL? {

--- a/Platform/Shared/VMConfigInfoView.swift
+++ b/Platform/Shared/VMConfigInfoView.swift
@@ -47,6 +47,15 @@ struct VMConfigInfoView: View {
                 Text("Name").frame(width: 50, alignment: .trailing)
                 nameField
             }
+            HStack {
+                Text("").frame(width: 50, alignment: .trailing)
+                Toggle(isOn:
+                    $config.isFullScreenStart,
+                    label: {
+                        Text("Start the VM display(s) in full screen")
+                    }
+                )
+            }
             HStack(alignment: .top) {
                 Text("Notes").frame(width: 50, alignment: .trailing)
                 notesField

--- a/Platform/macOS/UTMDataExtension.swift
+++ b/Platform/macOS/UTMDataExtension.swift
@@ -59,6 +59,10 @@ extension UTMData {
             vm.wrapped!.delegate = unwrappedWindow
             unwrappedWindow.showWindow(nil)
             unwrappedWindow.window!.makeMain()
+            if vm.wrapped!.config.information.isFullScreenStart && !unwrappedWindow.window!.styleMask.contains(.fullScreen) {
+                unwrappedWindow.window!.toggleFullScreen(nil)
+            }
+            
             if startImmediately {
                 unwrappedWindow.requestAutoStart(options: options)
             }


### PR DESCRIPTION
I didn't add the setting in the display section because it will toggle all windows (displays and terminals) to full screen.
I'm open to changing the parameter location and/or the behaviour.

fixes #4304