### PR TITLE
Replace GB/MB with GiB/MiB since binary units are actually being used

### DIFF
--- a/Platform/Shared/RAMSlider.swift
+++ b/Platform/Shared/RAMSlider.swift
@@ -60,7 +60,7 @@ struct RAMSlider: View {
                 }
                 NumberTextField("", number: $systemMemory, prompt: "Size", onEditingChanged: validateMemorySize)
                     .frame(width: 80)
-                Text("MB")
+                Text("MiB")
             }
         }.frame(height: 30)
     }

--- a/Platform/Shared/SizeTextField.swift
+++ b/Platform/Shared/SizeTextField.swift
@@ -40,9 +40,9 @@ struct SizeTextField: View {
             Button(action: { isGiB.toggle() }, label: {
                 Group {
                     if isGiB {
-                        Text("GB")
+                        Text("GiB")
                     } else {
-                        Text("MB")
+                        Text("MiB")
                     }
                 }.foregroundColor(.blue)
             }).buttonStyle(.plain)

--- a/Platform/Shared/VMConfigSystemView.swift
+++ b/Platform/Shared/VMConfigSystemView.swift
@@ -55,7 +55,7 @@ struct VMConfigSystemView: View {
                     HStack {
                         NumberTextField("", number: $config.jitCacheSize, prompt: "Default", onEditingChanged: validateMemorySize)
                             .multilineTextAlignment(.trailing)
-                        Text("MB")
+                        Text("MiB")
                     }
                 }
             }

--- a/Platform/Shared/VMWizardDrivesView.swift
+++ b/Platform/Shared/VMWizardDrivesView.swift
@@ -28,7 +28,7 @@ struct VMWizardDrivesView: View {
                     NumberTextField("", number: $wizardState.storageSizeGib)
                         .textFieldStyle(.roundedBorder)
                         .frame(maxWidth: 50)
-                    Text("GB")
+                    Text("GiB")
                 }
             } header: {
                 Text("Size")

--- a/Platform/de.lproj/Localizable.strings
+++ b/Platform/de.lproj/Localizable.strings
@@ -364,7 +364,7 @@
 "Force Multicore" = "Multicore erzwingen";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB Debug Stub";
@@ -520,7 +520,7 @@
 "Maximum Shared USB Devices" = "Anzahl weitergeleiteter USB-Geräte (max.)";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "Speicher";

--- a/Platform/es-419.lproj/Localizable.strings
+++ b/Platform/es-419.lproj/Localizable.strings
@@ -675,7 +675,7 @@
 "Full Graphics" = "Gráficos completos";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB Debug Stub";
@@ -989,7 +989,7 @@
 "Maximum Shared USB Devices" = "Número máximo de dispositivos USB compartidos";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "Memoria";

--- a/Platform/fi.lproj/Localizable.strings
+++ b/Platform/fi.lproj/Localizable.strings
@@ -440,7 +440,7 @@
 "Full Graphics" = "Täysi grafiikka";
 
 /* No comment provided by engineer. */
-"GB" = "Gt";
+"GiB" = "GiB";
 
 /* No comment provided by engineer. */
 "Generate Windows Installer ISO" = "Luo Windows Installer ISO";
@@ -650,7 +650,7 @@
 "Maximum Shared USB Devices" = "Jaettujen USB-laitteiden enimmäismäärä";
 
 /* No comment provided by engineer. */
-"MB" = "Mt";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "Muisti";

--- a/Platform/fr.lproj/Localizable.strings
+++ b/Platform/fr.lproj/Localizable.strings
@@ -463,11 +463,11 @@
 
 // RAMSlider.swift
 "Size" = "Taille";
-"MB" = "MB";
+"MiB" = "MiB";
 
 // SizeTextField.swift
 "The amount of storage to allocate for this image. Ignored if importing an image. If this is a raw image, then an empty file of this size will be stored with the VM. Otherwise, the disk image will dynamically expand up to this size." = "La quantité de stockage à allouer pour cette image. Ignoré si importation d’image. Si c'est une image brute, un fichier vide de la même taille sera enregistré avec la VM. Sinon, l’image disque sera dynamiquement étendue jusqu’à cette taille.";
-"GB" = "GB";
+"GiB" = "GiB";
 
 // VMCardView.swift
 "Run" = "Démarrer";

--- a/Platform/it.lproj/Localizable.strings
+++ b/Platform/it.lproj/Localizable.strings
@@ -703,7 +703,7 @@
 "Full Graphics" = "Grafica Completa";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB Debug Stub";
@@ -1100,7 +1100,7 @@
 "Maximum Shared USB Devices" = "Dispositivi USB Condivisi Massimi";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "Memoria";

--- a/Platform/ja.lproj/Localizable.strings
+++ b/Platform/ja.lproj/Localizable.strings
@@ -566,11 +566,11 @@
 
 // RAMSlider.swift
 "Size" = "サイズ";
-"MB" = "MB";
+"MiB" = "MiB";
 
 // SizeTextField.swift
 "The amount of storage to allocate for this image. Ignored if importing an image. If this is a raw image, then an empty file of this size will be stored with the VM. Otherwise, the disk image will dynamically expand up to this size." = "このイメージに割り当てるストレージ領域です。イメージを読み込む場合は無視されます。生イメージの場合、このサイズの空のファイルが仮想マシンに保存されます。そうでない場合、ディスクイメージはこのサイズまで動的に拡張されます。";
-"GB" = "GB";
+"GiB" = "GiB";
 
 // VMCardView.swift
 "Run" = "実行";

--- a/Platform/ko.lproj/Localizable.strings
+++ b/Platform/ko.lproj/Localizable.strings
@@ -398,7 +398,7 @@
 "Manager being deallocated, killing pending RPC." = "Manager being deallocated, killing pending RPC.";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "메모리";

--- a/Platform/pl.lproj/Localizable.strings
+++ b/Platform/pl.lproj/Localizable.strings
@@ -422,8 +422,8 @@
 "If checked, the drive image will be stored with the VM." = "Jeśli zaznaczone, obraz dysku będzie przechowywany wraz z wirtualną maszyną.";
 "Size" = "Rozmiar";
 "The amount of storage to allocate for this image. An empty file of this size will be stored with the VM." = "Ilość pamięci masowej przydzielonej dla tego obrazu. Pusty plik takiego rozmiaru będzie przechowywany wraz z maszyną wirtualną";
-"GB" = "GB";
-"MB" = "MB";
+"GiB" = "GiB";
+"MiB" = "MiB";
 
 /* VMConfigAppleDriveDetailsView.swift */
 "Name" = "Nazwa";
@@ -547,14 +547,14 @@
 
 /* RAMSlider.swift */
 "Size" = "Rozmiar";
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* FileBrowseField.swift */
 "Path" = "Ścieżka";
 
 /* SizeTextField.swift */
 "The amount of storage to allocate for this image. Ignored if importing an image. If this is a raw image, then an empty file of this size will be stored with the VM. Otherwise, the disk image will dynamically expand up to this size." = "Ilość pamięci masowej do przydzielenia dla tego obrazu. Ignorowane, jeśli importujesz obraz. Jeśli jest to surowy obraz, wtedy plusty plik tego rozmiaru będzie przechowywany wraz z wirtualną maszyną. W przeciwnym wypadku, obraz dysku będzie dynamicznie się rozszerzał do docelowego rozmiaru.";
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* VMCardView.swift */
 "Run" = "Uruchom";

--- a/Platform/ru.lproj/Localizable.strings
+++ b/Platform/ru.lproj/Localizable.strings
@@ -681,7 +681,7 @@
 "Full Graphics" = "Полная графика";
 
 /* No comment provided by engineer. */
-"GB" = "ГБ";
+"GiB" = "ГиБ";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "Плагин отладки GDB";
@@ -1004,7 +1004,7 @@
 "Maximum Shared USB Devices" = "Максимальное кол-во совместно используемых USB-устройств";
 
 /* No comment provided by engineer. */
-"MB" = "МБ";
+"MiB" = "МиБ";
 
 /* No comment provided by engineer. */
 "Memory" = "Память";

--- a/Platform/zh-HK.lproj/Localizable.strings
+++ b/Platform/zh-HK.lproj/Localizable.strings
@@ -542,7 +542,7 @@
 "Force shut down" = "強行關機";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB Debug Stub";
@@ -725,7 +725,7 @@
 "Maximum Shared USB Devices" = "最多分享 USB 裝置";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "記憶體";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -542,7 +542,7 @@
 "Force shut down" = "强制关机";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB 调试存根";
@@ -725,7 +725,7 @@
 "Maximum Shared USB Devices" = "最大共享 USB 设备数";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "内存";

--- a/Platform/zh-Hant.lproj/Localizable.strings
+++ b/Platform/zh-Hant.lproj/Localizable.strings
@@ -720,7 +720,7 @@
 "FPS Limit" = "FPS 上限";
 
 /* No comment provided by engineer. */
-"GB" = "GB";
+"GiB" = "GiB";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB 除錯 stub";
@@ -1023,7 +1023,7 @@
 "Maximum Shared USB Devices" = "最大共享 USB 裝置";
 
 /* No comment provided by engineer. */
-"MB" = "MB";
+"MiB" = "MiB";
 
 /* No comment provided by engineer. */
 "Memory" = "記憶體";


### PR DESCRIPTION
This shouldn't normally bother anyone but I've ran to a kernel panic on a niche OS and found out binary units are being used instead of decimal units displayed in disk settings. This PR also fixes this misuse in other areas where binary units are used (JIT Cache and Memory). I also replaced Finnish abbreviation with global one since nobody uses that way.