### PR TITLE
Fix typo in French translation of "New Drive"

### DIFF
--- a/Platform/fr.lproj/Localizable.strings
+++ b/Platform/fr.lproj/Localizable.strings
@@ -680,7 +680,7 @@
 
 // VMSettingsAddDeviceMenuView.swift
 "Import Drive" = "Importer un lecteur";
-"New Drive" = "Nouveu lecteur";
+"New Drive" = "Nouveau lecteur";
 
 // VMToolbarModifier.swift
 "Remove selected shortcut" = "Supprimer le raccourci sélectionné";


### PR DESCRIPTION
There is a typo in the French translation of "New Drive" as the current word does not exist in this language. This PR fixes it.