### PR TITLE
Fix `'lsi53c895a' is not a valid device model name` error when starting m68k macOS VM

### DIFF
--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -644,7 +644,7 @@ import Virtualization // for getting network interfaces
             f()
         } else if drive.interface == .scsi {
             var bus = "scsi"
-            if system.architecture != .sparc && system.architecture != .sparc64 {
+            if system.architecture != .sparc && system.architecture != .sparc64 && system.architecture != .m68k {
                 bus = "scsi0"
                 if busindex == 0 {
                     f("-device")


### PR DESCRIPTION
Currently, UTM fails to open a m68k macOS guest with the following error:

<img width="282" alt="image" src="https://github.com/user-attachments/assets/0c4c2beb-b01e-468a-adc5-a07c11408398">

With this patch, it will load the VM successfully:

<img width="907" alt="Screenshot 2024-10-05 at 10 47 03 AM" src="https://github.com/user-attachments/assets/ab3984c8-65cf-47da-ae39-0301b133901c">
