### PR TITLE
Fix translations for zh-Hans

### DIFF
--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -1735,7 +1735,7 @@
 "Emulated Network Card" = "模拟网卡";
 
 /* No comment provided by engineer. */
-"Emulated Serial Device" = "模拟序列设备";
+"Emulated Serial Device" = "模拟串行设备";
 
 /* No comment provided by engineer. */
 "Enable Balloon Device" = "启用 Balloon 设备";
@@ -2147,7 +2147,7 @@
 "Select an existing disk image." = "选择一个现有的磁盘映像。";
 
 /* No comment provided by engineer. */
-"Serial" = "序列";
+"Serial" = "串行端口";
 
 /* No comment provided by engineer. */
 "Server Address" = "服务器地址";


### PR DESCRIPTION
Serial在简体中文应当翻译为串行。请[参考](https://zh.wikipedia.org/zh-cn/%E4%B8%B2%E8%A1%8C%E7%AB%AF%E5%8F%A3)。