### PR TITLE
scripting: add qemu additional arguments

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -425,6 +425,11 @@
             description="List of serial configuration.">
             <type type="qemu serial configuration" list="yes"/>
           </property>
+          
+          <property name="qemu additional arguments" code="QeAd"
+            description="List of qemu arguments.">
+            <type type="qemu argument" list="yes"/>
+          </property>
         </record-type>
         
         <enumeration name="qemu directory share mode" code="QeSm" description="Method for sharing directory in QEMU.">
@@ -532,6 +537,14 @@
               
             <property name="port" code="PoRt" type="integer"
               description="The port number to listen on when the interface is a TCP server."/>
+        </record-type>
+        
+        <record-type name="qemu argument" code="QeAr" description="QEMU argument configuration.">
+          <property name="string" code="StAg" type="text"
+            description="The QEMU argument as a string."/>
+            
+          <property name="file urls" code="FlUr" type="file" list="yes"
+            description="Optional URLs associated with this argument."/>
         </record-type>
         
         <record-type name="apple configuration" code="ApCf" description="Apple virtual machine configuration.">

--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -542,9 +542,6 @@
         <record-type name="qemu argument" code="QeAr" description="QEMU argument configuration.">
           <property name="argument string" code="ArSt" type="text"
             description="The QEMU argument as a string."/>
-            
-          <property name="file urls" code="FlUr" type="file" list="yes"
-            description="Optional URLs associated with this argument."/>
         </record-type>
         
         <record-type name="apple configuration" code="ApCf" description="Apple virtual machine configuration.">

--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -540,7 +540,7 @@
         </record-type>
         
         <record-type name="qemu argument" code="QeAr" description="QEMU argument configuration.">
-          <property name="string" code="StAg" type="text"
+          <property name="argument string" code="ArSt" type="text"
             description="The QEMU argument as a string."/>
             
           <property name="file urls" code="FlUr" type="file" list="yes"

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -191,7 +191,7 @@ extension UTMScriptingConfigImpl {
     
     private func serializeQemuAdditionalArgument(_ argument: QEMUArgument) -> [AnyHashable: Any] {
         var serializedArgument: [AnyHashable: Any] = [
-            "string": argument.string
+            "argumentString": argument.string
         ]
         
         // Only add fileUrls if it is not nil and contains URLs
@@ -520,7 +520,7 @@ extension UTMScriptingConfigImpl {
     private func updateQemuAdditionalArguments(from records: [[AnyHashable: Any]]) throws {
         let config = config as! UTMQemuConfiguration
         let additionalArguments = records.compactMap { record -> QEMUArgument? in
-            guard let argumentString = record["string"] as? String else { return nil }
+            guard let argumentString = record["argumentString"] as? String else { return nil }
             var argument = QEMUArgument(argumentString)
             // Qemu Additional Arguments in UI, only takes strings
             // So, fileUrls of arguments will never be used

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -107,6 +107,7 @@ extension UTMScriptingConfigImpl {
             "drives": config.drives.map({ serializeQemuDriveExisting($0) }),
             "networkInterfaces": config.networks.enumerated().map({ serializeQemuNetwork($1, index: $0) }),
             "serialPorts": config.serials.enumerated().map({ serializeQemuSerial($1, index: $0) }),
+            "qemuAdditionalArguments": config.qemu.additionalArguments.map({ serializeQemuAdditionalArgument($0)}),
         ]
     }
     
@@ -186,6 +187,19 @@ extension UTMScriptingConfigImpl {
             "interface": qemuSerialInterface(from: config.mode).rawValue,
             "port": config.tcpPort ?? 0,
         ]
+    }
+    
+    private func serializeQemuAdditionalArgument(_ argument: QEMUArgument) -> [AnyHashable: Any] {
+        var serializedArgument: [AnyHashable: Any] = [
+            "string": argument.string
+        ]
+        
+        // Only add fileUrls if it is not nil and contains URLs
+        if let fileUrls = argument.fileUrls, !fileUrls.isEmpty {
+            serializedArgument["fileUrls"] = fileUrls.map({ $0 as AnyHashable })
+        }
+        
+        return serializedArgument
     }
     
     private func serializeAppleConfiguration(_ config: UTMAppleConfiguration) -> [AnyHashable : Any] {
@@ -337,6 +351,9 @@ extension UTMScriptingConfigImpl {
         }
         if let serialPorts = record["serialPorts"] as? [[AnyHashable : Any]] {
             try updateQemuSerials(from: serialPorts)
+        }
+        if let qemuAdditionalArguments = record["qemuAdditionalArguments"] as? [[AnyHashable: Any]] {
+            try updateQemuAdditionalArguments(from: qemuAdditionalArguments)
         }
     }
     
@@ -499,6 +516,24 @@ extension UTMScriptingConfigImpl {
             serial.tcpPort = port
         }
     }
+    
+    private func updateQemuAdditionalArguments(from records: [[AnyHashable: Any]]) throws {
+        let config = config as! UTMQemuConfiguration
+        let additionalArguments = records.compactMap { record -> QEMUArgument? in
+            guard let argumentString = record["string"] as? String else { return nil }
+            var argument = QEMUArgument(argumentString)
+            // Qemu Additional Arguments in UI, only takes strings
+            // So, fileUrls of arguments will never be used
+            // This is here if they support in future
+            if let fileUrls = record["fileUrls"] as? [URL] {
+                argument.fileUrls = fileUrls
+            }
+            return argument
+        }
+        // Update entire additional arguments with new one.
+        config.qemu.additionalArguments = additionalArguments
+    }
+        
     
     private func updateAppleConfiguration(from record: [AnyHashable : Any]) throws {
         let config = config as! UTMAppleConfiguration

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -194,11 +194,6 @@ extension UTMScriptingConfigImpl {
             "argumentString": argument.string
         ]
         
-        // Only add fileUrls if it is not nil and contains URLs
-        if let fileUrls = argument.fileUrls, !fileUrls.isEmpty {
-            serializedArgument["fileUrls"] = fileUrls.map({ $0 as AnyHashable })
-        }
-        
         return serializedArgument
     }
     
@@ -522,12 +517,7 @@ extension UTMScriptingConfigImpl {
         let additionalArguments = records.compactMap { record -> QEMUArgument? in
             guard let argumentString = record["argumentString"] as? String else { return nil }
             var argument = QEMUArgument(argumentString)
-            // Qemu Additional Arguments in UI, only takes strings
-            // So, fileUrls of arguments will never be used
-            // This is here if they support in future
-            if let fileUrls = record["fileUrls"] as? [URL] {
-                argument.fileUrls = fileUrls
-            }
+            
             return argument
         }
         // Update entire additional arguments with new one.


### PR DESCRIPTION
Fixes #6661 

read and update qemu additional argument of vm config


Usage:

```applescript
tell application "/Users/xxx/UTM.app"
  set vm to virtual machine named "VM"
  set config to configuration of VM
  
  -- read  qemu additional arguments 
  set qemuAddArgs to qemu additional arguments of config

  -- add
  set newArg to {{argument string:"-vnc 127.0.0.1:1"}}
  set qemuAddArgs to qemuAddArgs & newArg
  
  -- update 
  set qemu additional arguments of config to qemuAddArgs
  update configuration of vm with config
end tell
```

This will enable to launch VMs with custom qemu args via APIs
Related #5211 