### PR TITLE
Update zh-Hans & zh-HK translations

### DIFF
--- a/Platform/iOS/Donation.storekit
+++ b/Platform/iOS/Donation.storekit
@@ -1,4 +1,14 @@
 {
+  "appPolicies" : {
+    "eula" : "",
+    "policies" : [
+      {
+        "locale" : "en_US",
+        "policyText" : "",
+        "policyURL" : ""
+      }
+    ]
+  },
   "identifier" : "A2B91788",
   "nonRenewingSubscriptions" : [
 
@@ -13,6 +23,16 @@
           "description" : "A small one time donation.",
           "displayName" : "Transistor",
           "locale" : "en_US"
+        },
+        {
+          "description" : "一次性小额捐赠。",
+          "displayName" : "晶体管",
+          "locale" : "zh_CN"
+        },
+        {
+          "description" : "一次性的少量捐贈。",
+          "displayName" : "電晶體",
+          "locale" : "zh_TW"
         }
       ],
       "productID" : "consumable.small",
@@ -28,6 +48,16 @@
           "description" : "A medium one time donation.",
           "displayName" : "Chip",
           "locale" : "en_US"
+        },
+        {
+          "description" : "一次性中等捐赠。",
+          "displayName" : "芯片",
+          "locale" : "zh_CN"
+        },
+        {
+          "description" : "一次性的中等量捐贈。",
+          "displayName" : "晶片",
+          "locale" : "zh_TW"
         }
       ],
       "productID" : "consumable.medium",
@@ -43,6 +73,16 @@
           "description" : "A large one time donation.",
           "displayName" : "Computer",
           "locale" : "en_US"
+        },
+        {
+          "description" : "一次性大额捐赠。",
+          "displayName" : "计算机",
+          "locale" : "zh_CN"
+        },
+        {
+          "description" : "一次性的大量捐贈。",
+          "displayName" : "電腦",
+          "locale" : "zh_TW"
         }
       ],
       "productID" : "consumable.large",
@@ -106,7 +146,7 @@
 
   ],
   "version" : {
-    "major" : 3,
+    "major" : 4,
     "minor" : 0
   }
 }

--- a/Platform/iOS/zh-HK.lproj/Info-Remote-InfoPlist.strings
+++ b/Platform/iOS/zh-HK.lproj/Info-Remote-InfoPlist.strings
@@ -1,9 +1,0 @@
-/* Bundle name */
-"CFBundleName" = "UTM 遠端";
-
-/* Privacy - Local Network Usage Description */
-"NSLocalNetworkUsageDescription" = "UTM 使用本地網絡以尋找和連接 UTM 遠端伺服器。";
-
-/* Privacy - Microphone Usage Description */
-"NSMicrophoneUsageDescription" = "任何虛擬機器都需要權限才能從咪高風錄製。";
-

--- a/Platform/iOS/zh-HK.lproj/Info-Remote-InfoPlist.strings
+++ b/Platform/iOS/zh-HK.lproj/Info-Remote-InfoPlist.strings
@@ -1,0 +1,9 @@
+/* Bundle name */
+"CFBundleName" = "UTM 遠端";
+
+/* Privacy - Local Network Usage Description */
+"NSLocalNetworkUsageDescription" = "UTM 使用本地網絡以尋找和連接 UTM 遠端伺服器。";
+
+/* Privacy - Microphone Usage Description */
+"NSMicrophoneUsageDescription" = "任何虛擬機器都需要權限才能從咪高風錄製。";
+

--- a/Platform/iOS/zh-HK.lproj/InfoPlist.strings
+++ b/Platform/iOS/zh-HK.lproj/InfoPlist.strings
@@ -2,7 +2,7 @@
 "CFBundleName" = "UTM";
 
 /* Privacy - Local Network Usage Description */
-"NSLocalNetworkUsageDescription" = "虛擬機器可以取用區域網絡。UTM 還會使用區域網絡與 AltServer 通訊。";
+"NSLocalNetworkUsageDescription" = "虛擬機器可能會取用區域網絡。UTM 也可能會使用區域網絡與本地伺服器通訊。";
 
 /* Privacy - Location Always and When In Use Usage Description */
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "UTM 定期請求位置資料，以確保系統保持背景程序處於啟用狀態。位置資料絕對不會離開裝置。";

--- a/Platform/iOS/zh-Hans.lproj/Info-Remote-InfoPlist.strings
+++ b/Platform/iOS/zh-Hans.lproj/Info-Remote-InfoPlist.strings
@@ -1,9 +1,0 @@
-/* Bundle name */
-"CFBundleName" = "UTM 远程";
-
-/* Privacy - Local Network Usage Description */
-"NSLocalNetworkUsageDescription" = "UTM 使用本地网络查找和连接 UTM 远程服务器。";
-
-/* Privacy - Microphone Usage Description */
-"NSMicrophoneUsageDescription" = "任何虚拟机都需要权限才能通过麦克风录音。";
-

--- a/Platform/iOS/zh-Hans.lproj/InfoPlist.strings
+++ b/Platform/iOS/zh-Hans.lproj/InfoPlist.strings
@@ -2,7 +2,7 @@
 "CFBundleName" = "UTM";
 
 /* Privacy - Local Network Usage Description */
-"NSLocalNetworkUsageDescription" = "虚拟机可能会访问本地网络。UTM 还会使用本地网络与 AltServer 通信。";
+"NSLocalNetworkUsageDescription" = "虚拟机可能会访问本地网络。UTM 也可能会使用本地网络与本地服务器通信。";
 
 /* Privacy - Location Always and When In Use Usage Description */
 "NSLocationAlwaysAndWhenInUseUsageDescription" = "UTM 定期请求位置数据，以确保系统维持后台进程处于活动状态。位置数据永远不会脱离设备。";

--- a/Platform/zh-HK.lproj/Localizable.strings
+++ b/Platform/zh-HK.lproj/Localizable.strings
@@ -13,14 +13,15 @@
 /* QEMUConstant */
 "%@ (%@)" = "%1$@ (%2$@)";
 
-/* VMToolbarDriveMenuView */
+/* VMDisplayQemuDisplayController
+VMToolbarDriveMenuView */
 "%@ (%@): %@" = "%1$@ (%2$@): %3$@";
 
 /* VMDisplayMetalWindowController */
 "%@ (Display %lld)" = "%1$@ (顯示 %2$lld)";
 
 /* VMDisplayAppleTerminalWindowController
-   VMDisplayQemuTerminalWindowController */
+VMDisplayQemuTerminalWindowController */
 "%@ (Terminal %lld)" = "%1$@ (終端機 %2$lld)";
 
 /* VMRemovableDrivesView */
@@ -56,6 +57,9 @@
 /* UTMDonateView */
 "%d years" = "%d 年";
 
+/* No comment provided by engineer. */
+"• " = "• ";
+
 /* UTMScriptingAppDelegate */
 "A valid backend must be specified." = "必須指定有效的後端。";
 
@@ -64,6 +68,9 @@
 
 /* UTMAppleConfiguration */
 "A valid kernel image must be specified." = "必須指定有效的核心映像檔。";
+
+/* UTMScriptingAppDelegate */
+"A valid UTM file must be specified." = "必須指定一個有效的 UTM 檔案。";
 
 /* VMDisplayAppleController */
 "Add…" = "新增⋯";
@@ -94,6 +101,9 @@
 
 /* UTMQemuImage */
 "An unknown QEMU error has occurred." = "發生未知的 QEMU 錯誤。";
+
+/* VMDisplayAppleDisplayController */
+"An USB device containing the installer will be mounted in the virtual machine. Only macOS Sequoia (15.0) and newer guests are supported." = "包含安裝程式的 USB 裝置將裝載至虛擬機器。僅支援 macOS Sequoia (15.0) 和較新的客户端。";
 
 /* No comment provided by engineer. */
 "ANGLE (Metal)" = "ANGLE (Metal)";
@@ -135,7 +145,7 @@
 "Background task is about to expire" = "背景任務即將過期";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "BIOS" = "BIOS";
 
 /* No comment provided by engineer. */
@@ -168,7 +178,8 @@
 /* No comment provided by engineer. */
 "Boot VHDX Image" = "啟動 VHDX 映像檔 (可選)";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationNetwork
+UTMQemuConstants */
 "Bridged (Advanced)" = "橋連 (進階)";
 
 /* No comment provided by engineer. */
@@ -183,14 +194,15 @@
 /* No comment provided by engineer. */
 "Build" = "構建";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationTerminal
+UTMQemuConstants */
 "Built-in Terminal" = "內置終端機";
 
 /* No comment provided by engineer. */
 "Busy…" = "忙碌中⋯";
 
 /* VMDisplayWindowController
-   VMQemuDisplayMetalWindowController */
+VMQemuDisplayMetalWindowController */
 "Cancel" = "取消";
 
 /* UTMAppleVirtualMachine */
@@ -233,7 +245,7 @@
 "CD/DVD" = "CD/DVD";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "CD/DVD (ISO) Image" = "CD/DVD (ISO) 映像檔";
 
 /* No comment provided by engineer. */
@@ -264,7 +276,7 @@
 "Confirm Delete" = "確認刪除";
 
 /* AppDelegate
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Confirmation" = "確認";
 
 /* No comment provided by engineer. */
@@ -322,7 +334,7 @@
 "Debug Logging" = "除錯記錄";
 
 /* QEMUConstantGenerated
-   UTMQemuConstants */
+UTMQemuConstants */
 "Default" = "預設";
 
 /* VMWizardSummaryView */
@@ -337,7 +349,8 @@
 /* VMDisplayAppleWindowController */
 "Directory sharing" = "目錄分享";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationDevices
+UTMQemuConstants */
 "Disabled" = "停用";
 
 /* No comment provided by engineer. */
@@ -347,7 +360,7 @@
 "Discovered" = "已偵測到";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Disk Image" = "磁碟映像檔";
 
 /* VMDisplayAppleWindowController */
@@ -381,7 +394,7 @@
 "Do you want to duplicate this VM and all its data?" = "你要製作這個虛擬機器及其所有資料的副本嗎？";
 
 /* No comment provided by engineer. */
-"Do you want to force stop this VM and lose all unsaved data?" = "你要強行停止這個虛擬機器並遺失所有未儲存的資料嗎？";
+"Do you want to force stop this VM and lose all unsaved data?" = "你要強制停止這個虛擬機器並遺失所有未儲存的資料嗎？";
 
 /* No comment provided by engineer. */
 "Do you want to forget all clients and generate a new server identity? Any clients that previously paired with this server will be instructed to manually unpair with this server before they can connect again." = "你要忘記所有客户端並生成新的伺服器身分嗎？之前與這個伺服器配對的任何客户端將被指示於再次連接之前手動取消與這個伺服器的配對。";
@@ -449,7 +462,8 @@
 /* UTMQemuVirtualMachine */
 "Failed to access drive image path." = "無法取用磁碟映像檔路徑。";
 
-/* UTMRemoteServer */
+/* UTMRemoteClient
+UTMRemoteServer */
 "Failed to access file." = "無法取用檔案。";
 
 /* UTMQemuVirtualMachine */
@@ -510,7 +524,7 @@
 "Failed to reconnect to the server." = "無法重新連接至伺服器。";
 
 /* AppDelegate
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Failed to save suspend state" = "無法儲存暫停狀態。";
 
 /* UTMQemuVirtualMachine */
@@ -526,7 +540,7 @@
 "Fingerprint" = "指紋";
 
 /* Configuration boot device
-   UTMQemuConstants */
+UTMQemuConstants */
 "Floppy" = "軟碟";
 
 /* No comment provided by engineer. */
@@ -536,16 +550,16 @@
 "Font Size" = "字體大小";
 
 /* VMDisplayWindowController */
-"Force kill" = "強行結束";
+"Force kill" = "強制結束";
 
 /* VMDisplayWindowController */
-"Force kill the VM process with high risk of data corruption." = "強行結束虛擬機器程序，會有甚高風險損毀資料。";
+"Force kill the VM process with high risk of data corruption." = "強制結束虛擬機器程序，會有甚高風險損毀資料。";
 
 /* No comment provided by engineer. */
-"Force Multicore" = "強行多核心";
+"Force Multicore" = "強制多核心";
 
 /* VMDisplayWindowController */
-"Force shut down" = "強行關機";
+"Force shut down" = "強制關機";
 
 /* UTMQemuConstants */
 "GDB Debug Stub" = "GDB 除錯空函式";
@@ -622,6 +636,9 @@
 /* No comment provided by engineer. */
 "Information" = "訊息";
 
+/* VMDisplayAppleWindowController */
+"Install Guest Tools…" = "安裝客户端工具⋯";
+
 /* VMDisplayWindowController */
 "Install Windows Guest Tools…" = "安裝 Windows 客户端工具⋯";
 
@@ -680,21 +697,21 @@
 "Linux" = "Linux";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux Device Tree Binary" = "Linux 裝置樹二進位檔";
 
 /* No comment provided by engineer. */
 "Linux initial ramdisk (optional)" = "Linux 起始 ramdisk (可選)";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux Kernel" = "Linux 核心";
 
 /* No comment provided by engineer. */
 "Linux kernel (required)" = "Linux 核心 (必填)";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux RAM Disk" = "Linux ramdisk";
 
 /* No comment provided by engineer. */
@@ -714,6 +731,9 @@
 
 /* UTMAppleConfigurationBoot */
 "macOS" = "macOS";
+
+/* UTMDownloadMacSupportToolsTask */
+"macOS Guest Support Tools" = "macOS 客户端支援工具";
 
 /* VMWizardOSMacView */
 "macOS guests are only supported on ARM64 devices." = "macOS 客户端只限支援 ARM64 裝置。";
@@ -797,6 +817,9 @@
 "No empty removable drive found. Make sure you have at least one removable drive that is not in use." = "無法找到空的可移除式磁碟。確保你至少有一個未使用的可移除式磁碟。";
 
 /* UTMScriptingAppDelegate */
+"No file specified in the command." = "命令中未指定檔案。";
+
+/* UTMScriptingAppDelegate */
 "No name specified in the configuration." = "設定當中未指定名稱。";
 
 /* No comment provided by engineer. */
@@ -811,11 +834,14 @@
 /* No comment provided by engineer. */
 "No virtual machines found." = "未找到虛擬機器。";
 
-/* VMToolbarDriveMenuView */
+/* VMDisplayAppleDisplayController
+VMDisplayQemuDisplayController
+VMToolbarDriveMenuView */
 "none" = "無";
 
-/* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+/* UTMAppleConfigurationBoot
+UTMLegacyQemuConfiguration
+UTMQemuConstants */
 "None" = "無";
 
 /* UTMQemuConstants */
@@ -831,7 +857,7 @@
 "Notes" = "備註";
 
 /* No comment provided by engineer. */
-"Num Lock is forced on" = "Num Lock 強行開啟";
+"Num Lock is forced on" = "Num Lock 強制開啟";
 
 /* UTMQemuConstants */
 "NVMe" = "NVMe";
@@ -851,7 +877,8 @@
 /* UTMScriptingVirtualMachineImpl */
 "Operation not available." = "操作不可用。";
 
-/* UTMData */
+/* UTMData
+UTMScriptingVirtualMachineImpl */
 "Operation not supported by the backend." = "操作不受後端支援。";
 
 /* No comment provided by engineer. */
@@ -923,7 +950,8 @@
 /* No comment provided by engineer. */
 "Prevent system from sleeping when any VM is running" = "執行任何虛擬機器時防止系統睡眠";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationTerminal
+UTMQemuConstants */
 "Pseudo-TTY Device" = "Pseudo-TTY 裝置";
 
 /* No comment provided by engineer. */
@@ -1047,7 +1075,7 @@
 "Select Drive Image" = "選擇磁碟映像檔";
 
 /* VMDisplayAppleWindowController
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Select Shared Folder" = "選擇分享的資料夾";
 
 /* SavePanel */
@@ -1066,7 +1094,7 @@
 "Sends power down request to the guest. This simulates pressing the power button on a PC." = "向客户端發送關閉電源請求。這個操作仿真了按一下 PC 上的電源按鈕。";
 
 /* VMDisplayAppleWindowController
-   VMDisplayQemuDisplayController */
+VMDisplayQemuDisplayController */
 "Serial %lld" = "序列裝置 %lld";
 
 /* Server view */
@@ -1084,7 +1112,8 @@
 /* No comment provided by engineer. */
 "Shared Directory" = "已分享目錄";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationNetwork
+UTMQemuConstants */
 "Shared Network" = "已分享網絡";
 
 /* No comment provided by engineer. */
@@ -1393,6 +1422,9 @@
 /* VMQemuDisplayMetalWindowController */
 "USB Device" = "USB 裝置";
 
+/* VMDisplayAppleDisplayController */
+"USB Mass Storage: %@" = "USB 大容量儲存裝置：%@";
+
 /* No comment provided by engineer. */
 "USB Sharing" = "USB 分享";
 
@@ -1409,7 +1441,7 @@
 "User Guide" = "用户指南";
 
 /* UTMScriptingAppDelegate
-   UTMScriptingUSBDeviceImpl */
+UTMScriptingUSBDeviceImpl */
 "UTM is not ready to accept commands." = "UTM 尚未準備好接受指令。";
 
 /* No comment provided by engineer. */
@@ -1422,7 +1454,8 @@
 "VirtIO" = "VirtIO";
 
 /* UTMConfigurationInfo
-   UTMData */
+UTMData
+VMMetalView */
 "Virtual Machine" = "虛擬機器";
 
 /* No comment provided by engineer. */
@@ -1477,7 +1510,7 @@
 "Your device has %llu MB of memory and the estimated usage is %llu MB." = "你的裝置有 %1$llu MB 大小的記憶體，大約使用量為 %2$llu MB。";
 
 /* VMConfigAppleBootView
-   VMWizardOSMacView */
+VMWizardOSMacView */
 "Your machine does not support running this IPSW." = "你的電腦不支援執行這個 IPSW。";
 
 /* UTMDonateView */

--- a/Platform/zh-HK.lproj/Localizable.strings
+++ b/Platform/zh-HK.lproj/Localizable.strings
@@ -817,7 +817,7 @@ UTMQemuConstants */
 "No empty removable drive found. Make sure you have at least one removable drive that is not in use." = "無法找到空的可移除式磁碟。確保你至少有一個未使用的可移除式磁碟。";
 
 /* UTMScriptingAppDelegate */
-"No file specified in the command." = "命令中未指定檔案。";
+"No file specified in the command." = "命令當中未指定檔案。";
 
 /* UTMScriptingAppDelegate */
 "No name specified in the configuration." = "設定當中未指定名稱。";
@@ -1354,7 +1354,7 @@ UTMQemuConstants */
 "This virtual machine is currently unavailable, make sure it is not open in another session." = "現時無法使用這個虛擬機器，確保它沒有在另一個會話當中開啟。";
 
 /* VMData */
-"This VM is not available or is configured for a backend that does not support remote clients." = "這個虛擬機器無法使用，或是被設定為不支援遠端客户端的後端。";
+"This VM is not available or is configured for a backend that does not support remote clients." = "這個虛擬機器無法使用，或是被設定為不支援遙距客户端的後端。";
 
 /* No comment provided by engineer. */
 "This VM is unavailable." = "這個虛擬機器無法使用。";
@@ -1483,7 +1483,7 @@ VMMetalView */
 "What's New" = "新功能";
 
 /* No comment provided by engineer. */
-"When the toolbar is hidden, the icon will disappear after a few seconds. To show the icon again, tap anywhere on the screen." = "當工具列隱藏時，圖示將會在幾秒鐘之後消失。如要再次顯示圖示，請在螢幕上的任意位置點一下。";
+"When the toolbar is hidden, the icon will disappear after a few seconds. To show the icon again, tap anywhere on the screen." = "當工具列隱藏時，圖示將會在幾秒鐘之後消失。如要再次顯示圖示，請點一下螢幕上的任意位置。";
 
 /* UTMDownloadSupportToolsTask */
 "Windows Guest Support Tools" = "Windows 客户端支援工具";
@@ -1552,7 +1552,7 @@ VMWizardOSMacView */
 "Allow access from external clients" = "允許外部客户端訪問";
 
 /* No comment provided by engineer. */
-"Allow Remote Connection" = "允許遠端連線";
+"Allow Remote Connection" = "允許遙距連線";
 
 /* No comment provided by engineer. */
 "Allows passing through additional input from trackpads. Only supported on macOS 13+ guests." = "允許透過觸控板額外輸入。只限支援 macOS 13+ 客户端。";
@@ -1561,7 +1561,7 @@ VMWizardOSMacView */
 "Any" = "任意";
 
 /* No comment provided by engineer. */
-"Apple Virtualization is experimental and only for advanced use cases. Leave unchecked to use QEMU, which is recommended." = "Apple 虛擬化為試驗性質，只限用作進階用例，不剔選框以使用推介的 QEMU。";
+"Apple Virtualization is experimental and only for advanced use cases. Leave unchecked to use QEMU, which is recommended." = "Apple 虛擬化為試驗性質，只限用作進階用例，保留取消剔選以使用推介的 QEMU。";
 
 /* No comment provided by engineer. */
 "Application" = "應用程式";
@@ -1825,10 +1825,10 @@ VMWizardOSMacView */
 "Force Enable CPU Flags" = "強制啟用 CPU 標記";
 
 /* No comment provided by engineer. */
-"Force multicore may improve speed of emulation but also might result in unstable and incorrect emulation." = "強行多核心可能會提高仿真速度，但亦會導致不穩定與不正確的仿真。";
+"Force multicore may improve speed of emulation but also might result in unstable and incorrect emulation." = "強制多核心可能會提高仿真速度，但亦會導致不穩定與不正確的仿真。";
 
 /* No comment provided by engineer. */
-"Force PS/2 controller" = "強行使用 PS/2 控制器";
+"Force PS/2 controller" = "強制使用 PS/2 控制器";
 
 /* No comment provided by engineer. */
 "FPS Limit" = "FPS 限制";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -13,14 +13,15 @@
 /* QEMUConstant */
 "%@ (%@)" = "%1$@ (%2$@)";
 
-/* VMToolbarDriveMenuView */
+/* VMDisplayQemuDisplayController
+VMToolbarDriveMenuView */
 "%@ (%@): %@" = "%1$@ (%2$@): %3$@";
 
 /* VMDisplayMetalWindowController */
 "%@ (Display %lld)" = "%1$@ (显示 %2$lld)";
 
 /* VMDisplayAppleTerminalWindowController
-   VMDisplayQemuTerminalWindowController */
+VMDisplayQemuTerminalWindowController */
 "%@ (Terminal %lld)" = "%1$@ (终端 %2$lld)";
 
 /* VMRemovableDrivesView */
@@ -56,6 +57,9 @@
 /* UTMDonateView */
 "%d years" = "%d 年";
 
+/* No comment provided by engineer. */
+"• " = "• ";
+
 /* UTMScriptingAppDelegate */
 "A valid backend must be specified." = "必须指定有效的后端。";
 
@@ -64,6 +68,9 @@
 
 /* UTMAppleConfiguration */
 "A valid kernel image must be specified." = "必须指定有效的内核映像。";
+
+/* UTMScriptingAppDelegate */
+"A valid UTM file must be specified." = "必须指定一个有效的 UTM 文件。";
 
 /* VMDisplayAppleController */
 "Add…" = "添加…";
@@ -94,6 +101,9 @@
 
 /* UTMQemuImage */
 "An unknown QEMU error has occurred." = "发生了未知的 QEMU 错误。";
+
+/* VMDisplayAppleDisplayController */
+"An USB device containing the installer will be mounted in the virtual machine. Only macOS Sequoia (15.0) and newer guests are supported." = "包含安装程序的 USB 设备将安装在虚拟机中。仅支持 macOS Sequoia (15.0) 及更新版本的客户机。";
 
 /* No comment provided by engineer. */
 "ANGLE (Metal)" = "ANGLE (Metal)";
@@ -135,7 +145,7 @@
 "Background task is about to expire" = "后台任务即将终止";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "BIOS" = "BIOS";
 
 /* No comment provided by engineer. */
@@ -168,7 +178,8 @@
 /* No comment provided by engineer. */
 "Boot VHDX Image" = "启动 VHDX 映像";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationNetwork
+UTMQemuConstants */
 "Bridged (Advanced)" = "桥接 (高级)";
 
 /* No comment provided by engineer. */
@@ -183,14 +194,15 @@
 /* No comment provided by engineer. */
 "Build" = "构建版本";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationTerminal
+UTMQemuConstants */
 "Built-in Terminal" = "内置终端";
 
 /* No comment provided by engineer. */
 "Busy…" = "正忙…";
 
 /* VMDisplayWindowController
-   VMQemuDisplayMetalWindowController */
+VMQemuDisplayMetalWindowController */
 "Cancel" = "取消";
 
 /* UTMAppleVirtualMachine */
@@ -233,7 +245,7 @@
 "CD/DVD" = "CD/DVD";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "CD/DVD (ISO) Image" = "CD/DVD (ISO) 映像";
 
 /* No comment provided by engineer. */
@@ -264,7 +276,7 @@
 "Confirm Delete" = "确认删除";
 
 /* AppDelegate
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Confirmation" = "确认";
 
 /* No comment provided by engineer. */
@@ -322,7 +334,7 @@
 "Debug Logging" = "调试日志记录";
 
 /* QEMUConstantGenerated
-   UTMQemuConstants */
+UTMQemuConstants */
 "Default" = "默认";
 
 /* VMWizardSummaryView */
@@ -337,7 +349,8 @@
 /* VMDisplayAppleWindowController */
 "Directory sharing" = "目录共享";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationDevices
+UTMQemuConstants */
 "Disabled" = "已停用";
 
 /* No comment provided by engineer. */
@@ -347,7 +360,7 @@
 "Discovered" = "已发现";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Disk Image" = "磁盘映像";
 
 /* VMDisplayAppleWindowController */
@@ -449,7 +462,8 @@
 /* UTMQemuVirtualMachine */
 "Failed to access drive image path." = "无法访问驱动器映像路径。";
 
-/* UTMRemoteServer */
+/* UTMRemoteClient
+UTMRemoteServer */
 "Failed to access file." = "无法访问文件。";
 
 /* UTMQemuVirtualMachine */
@@ -510,7 +524,7 @@
 "Failed to reconnect to the server." = "无法重新连接到服务器。";
 
 /* AppDelegate
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Failed to save suspend state" = "无法存储挂起状态。";
 
 /* UTMQemuVirtualMachine */
@@ -526,7 +540,7 @@
 "Fingerprint" = "指纹";
 
 /* Configuration boot device
-   UTMQemuConstants */
+UTMQemuConstants */
 "Floppy" = "软盘";
 
 /* No comment provided by engineer. */
@@ -622,6 +636,9 @@
 /* No comment provided by engineer. */
 "Information" = "信息";
 
+/* VMDisplayAppleWindowController */
+"Install Guest Tools…" = "安装客户机工具…";
+
 /* VMDisplayWindowController */
 "Install Windows Guest Tools…" = "安装 Windows 客户机工具…";
 
@@ -680,21 +697,21 @@
 "Linux" = "Linux";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux Device Tree Binary" = "Linux 设备树二进制文件";
 
 /* No comment provided by engineer. */
 "Linux initial ramdisk (optional)" = "Linux 初始 ramdisk (可选)";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux Kernel" = "Linux 内核";
 
 /* No comment provided by engineer. */
 "Linux kernel (required)" = "Linux 内核 (必选)";
 
 /* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+UTMQemuConstants */
 "Linux RAM Disk" = "Linux ramdisk";
 
 /* No comment provided by engineer. */
@@ -714,6 +731,9 @@
 
 /* UTMAppleConfigurationBoot */
 "macOS" = "macOS";
+
+/* UTMDownloadMacSupportToolsTask */
+"macOS Guest Support Tools" = "macOS 客户机支持工具";
 
 /* VMWizardOSMacView */
 "macOS guests are only supported on ARM64 devices." = "macOS 客户机仅支持 ARM64 设备。";
@@ -797,6 +817,9 @@
 "No empty removable drive found. Make sure you have at least one removable drive that is not in use." = "未找到空的可移动驱动器。确保你至少有一个未使用的可移动驱动器。";
 
 /* UTMScriptingAppDelegate */
+"No file specified in the command." = "命令中未指定文件。";
+
+/* UTMScriptingAppDelegate */
 "No name specified in the configuration." = "配置中未指定名称。";
 
 /* No comment provided by engineer. */
@@ -811,11 +834,14 @@
 /* No comment provided by engineer. */
 "No virtual machines found." = "未找到虚拟机。";
 
-/* VMToolbarDriveMenuView */
+/* VMDisplayAppleDisplayController
+VMDisplayQemuDisplayController
+VMToolbarDriveMenuView */
 "none" = "无";
 
-/* UTMLegacyQemuConfiguration
-   UTMQemuConstants */
+/* UTMAppleConfigurationBoot
+UTMLegacyQemuConfiguration
+UTMQemuConstants */
 "None" = "无";
 
 /* UTMQemuConstants */
@@ -851,7 +877,8 @@
 /* UTMScriptingVirtualMachineImpl */
 "Operation not available." = "操作不可用。";
 
-/* UTMData */
+/* UTMData
+UTMScriptingVirtualMachineImpl */
 "Operation not supported by the backend." = "操作不受后端支持。";
 
 /* No comment provided by engineer. */
@@ -923,7 +950,8 @@
 /* No comment provided by engineer. */
 "Prevent system from sleeping when any VM is running" = "当任何虚拟机运行时防止系统处于睡眠状态";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationTerminal
+UTMQemuConstants */
 "Pseudo-TTY Device" = "虚拟终端设备";
 
 /* No comment provided by engineer. */
@@ -1047,7 +1075,7 @@
 "Select Drive Image" = "选择驱动器映像";
 
 /* VMDisplayAppleWindowController
-   VMDisplayWindowController */
+VMDisplayWindowController */
 "Select Shared Folder" = "选择共享的文件夹";
 
 /* SavePanel */
@@ -1066,7 +1094,7 @@
 "Sends power down request to the guest. This simulates pressing the power button on a PC." = "向客户机发送关闭电源请求。此操作模拟了按下 PC 上的电源按钮。";
 
 /* VMDisplayAppleWindowController
-   VMDisplayQemuDisplayController */
+VMDisplayQemuDisplayController */
 "Serial %lld" = "串行端口 %lld";
 
 /* Server view */
@@ -1084,7 +1112,8 @@
 /* No comment provided by engineer. */
 "Shared Directory" = "共享目录";
 
-/* UTMQemuConstants */
+/* UTMAppleConfigurationNetwork
+UTMQemuConstants */
 "Shared Network" = "共享网络";
 
 /* No comment provided by engineer. */
@@ -1393,6 +1422,9 @@
 /* VMQemuDisplayMetalWindowController */
 "USB Device" = "USB 设备";
 
+/* VMDisplayAppleDisplayController */
+"USB Mass Storage: %@" = "USB大容量存储设备：%@";
+
 /* No comment provided by engineer. */
 "USB Sharing" = "USB 共享";
 
@@ -1409,7 +1441,7 @@
 "User Guide" = "用户指南";
 
 /* UTMScriptingAppDelegate
-   UTMScriptingUSBDeviceImpl */
+UTMScriptingUSBDeviceImpl */
 "UTM is not ready to accept commands." = "UTM 尚未准备好接受命令。";
 
 /* No comment provided by engineer. */
@@ -1422,7 +1454,8 @@
 "VirtIO" = "VirtIO";
 
 /* UTMConfigurationInfo
-   UTMData */
+UTMData
+VMMetalView */
 "Virtual Machine" = "虚拟机";
 
 /* No comment provided by engineer. */
@@ -1477,7 +1510,7 @@
 "Your device has %llu MB of memory and the estimated usage is %llu MB." = "你的设备有 %llu MB 的内存，估计使用量为 %llu MB。";
 
 /* VMConfigAppleBootView
-   VMWizardOSMacView */
+VMWizardOSMacView */
 "Your machine does not support running this IPSW." = "你的机器不支持运行此 IPSW。";
 
 /* UTMDonateView */

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -2095,6 +2095,7 @@
 		E68D492328AC018E00D34C54 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		E6F791192903EEC6000BAAC9 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		F65F1F472CEEB78D00D9655B /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Info-Remote-InfoPlist.strings"; sourceTree = "<group>"; };
+		F65F1F4A2CEEBC0900D9655B /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Info-Remote-InfoPlist.strings"; sourceTree = "<group>"; };
 		F6DA2DA52AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayMetalViewInputAccessory.strings"; sourceTree = "<group>"; };
 		F6DA2DA62AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayWindow.strings"; sourceTree = "<group>"; };
 		F6DA2DA72AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -4373,6 +4374,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				F65F1F472CEEB78D00D9655B /* zh-HK */,
+				F65F1F4A2CEEBC0900D9655B /* zh-Hans */,
 			);
 			name = "Info-Remote-InfoPlist.strings";
 			sourceTree = "<group>";

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -270,8 +270,8 @@
 		85EC516627CC8D10004A51DE /* VMConfigAdvancedNetworkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85EC516327CC8C98004A51DE /* VMConfigAdvancedNetworkView.swift */; };
 		B329049C270FE136002707AC /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = B329049B270FE136002707AC /* AltKit */; };
 		B3DDF57226E9BBA300CE47F0 /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = B3DDF57126E9BBA300CE47F0 /* AltKit */; };
-		CD77BE442CB38F060074ADD2 /* UTMScriptingImportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */; };
 		CD77BE422CAB51B40074ADD2 /* UTMScriptingExportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77BE412CAB519F0074ADD2 /* UTMScriptingExportCommand.swift */; };
+		CD77BE442CB38F060074ADD2 /* UTMScriptingImportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */; };
 		CE020BA324AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA424AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA724AEDEF000B44AB6 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = CE020BA624AEDEF000B44AB6 /* Logging */; };
@@ -1229,6 +1229,7 @@
 		CEFE96772B69A7CC000F00C9 /* VMRemoteSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE96762B69A7CC000F00C9 /* VMRemoteSessionState.swift */; };
 		CEFE98DF29485237007CB7A8 /* UTM.sdef in Resources */ = {isa = PBXBuildFile; fileRef = CEFE98DE29485237007CB7A8 /* UTM.sdef */; };
 		CEFE98E129485776007CB7A8 /* UTMScriptingVirtualMachineImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE98E029485776007CB7A8 /* UTMScriptingVirtualMachineImpl.swift */; };
+		F65F1F482CEEB78D00D9655B /* Info-Remote-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */; };
 		FF0307552A84E3B70049979B /* QEMULauncher-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FF0307532A84E3B70049979B /* QEMULauncher-InfoPlist.strings */; };
 		FFB02A8C266CB09C006CD71A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FFB02A8A266CB09C006CD71A /* InfoPlist.strings */; };
 		FFB02A8D266CB09C006CD71A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FFB02A8A266CB09C006CD71A /* InfoPlist.strings */; };
@@ -1777,8 +1778,8 @@
 		C03453AF2709E35100AD51AD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		C03453B02709E35200AD51AD /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		C8958B6D243634DA002D86B4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
-		CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingImportCommand.swift; sourceTree = "<group>"; };
 		CD77BE412CAB519F0074ADD2 /* UTMScriptingExportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingExportCommand.swift; sourceTree = "<group>"; };
+		CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingImportCommand.swift; sourceTree = "<group>"; };
 		CE020BA224AEDC7C00B44AB6 /* UTMData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMData.swift; sourceTree = "<group>"; };
 		CE020BAA24AEE00000B44AB6 /* UTMLoggingSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMLoggingSwift.swift; sourceTree = "<group>"; };
 		CE020BB524B14F8400B44AB6 /* UTMVirtualMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMVirtualMachine.swift; sourceTree = "<group>"; };
@@ -2093,6 +2094,7 @@
 		E68D492228AC018E00D34C54 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E68D492328AC018E00D34C54 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		E6F791192903EEC6000BAAC9 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
+		F65F1F472CEEB78D00D9655B /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Info-Remote-InfoPlist.strings"; sourceTree = "<group>"; };
 		F6DA2DA52AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayMetalViewInputAccessory.strings"; sourceTree = "<group>"; };
 		F6DA2DA62AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayWindow.strings"; sourceTree = "<group>"; };
 		F6DA2DA72AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -2736,6 +2738,7 @@
 				CE95877426D74C2A0086BDE8 /* iOS.entitlements */,
 				CE2D954F24AD4F980059923A /* Info.plist */,
 				CECF02572B70909900409FC0 /* Info-Remote.plist */,
+				F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */,
 				FFB02A8A266CB09C006CD71A /* InfoPlist.strings */,
 				CEB5C1192B8C4CD4008AAE5C /* Info-RemotePlist.strings */,
 				CEC1B00A2BBB211C0088119D /* PrivacyInfo.xcprivacy */,
@@ -3423,6 +3426,7 @@
 				CEF7F6792AEEDCC400E34952 /* Icons in Resources */,
 				CEB5C1172B8C4CD4008AAE5C /* Info-RemotePlist.strings in Resources */,
 				CEF7F67B2AEEDCC400E34952 /* Localizable.strings in Resources */,
+				F65F1F482CEEB78D00D9655B /* Info-Remote-InfoPlist.strings in Resources */,
 				CEF7F67C2AEEDCC400E34952 /* qemu in Resources */,
 				CEF7F67D2AEEDCC400E34952 /* VMDisplayMetalViewInputAccessory.xib in Resources */,
 				CEF7F67E2AEEDCC400E34952 /* Localizable.stringsdict in Resources */,
@@ -4363,6 +4367,14 @@
 				037DAA202B0B92580061ACB3 /* it */,
 			);
 			name = Localizable.stringsdict;
+			sourceTree = "<group>";
+		};
+		F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F65F1F472CEEB78D00D9655B /* zh-HK */,
+			);
+			name = "Info-Remote-InfoPlist.strings";
 			sourceTree = "<group>";
 		};
 		FF0307532A84E3B70049979B /* QEMULauncher-InfoPlist.strings */ = {

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -1229,7 +1229,6 @@
 		CEFE96772B69A7CC000F00C9 /* VMRemoteSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE96762B69A7CC000F00C9 /* VMRemoteSessionState.swift */; };
 		CEFE98DF29485237007CB7A8 /* UTM.sdef in Resources */ = {isa = PBXBuildFile; fileRef = CEFE98DE29485237007CB7A8 /* UTM.sdef */; };
 		CEFE98E129485776007CB7A8 /* UTMScriptingVirtualMachineImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFE98E029485776007CB7A8 /* UTMScriptingVirtualMachineImpl.swift */; };
-		F65F1F482CEEB78D00D9655B /* Info-Remote-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */; };
 		FF0307552A84E3B70049979B /* QEMULauncher-InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FF0307532A84E3B70049979B /* QEMULauncher-InfoPlist.strings */; };
 		FFB02A8C266CB09C006CD71A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FFB02A8A266CB09C006CD71A /* InfoPlist.strings */; };
 		FFB02A8D266CB09C006CD71A /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = FFB02A8A266CB09C006CD71A /* InfoPlist.strings */; };
@@ -2094,8 +2093,6 @@
 		E68D492228AC018E00D34C54 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		E68D492328AC018E00D34C54 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
 		E6F791192903EEC6000BAAC9 /* es-419 */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "es-419"; path = "es-419.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
-		F65F1F472CEEB78D00D9655B /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/Info-Remote-InfoPlist.strings"; sourceTree = "<group>"; };
-		F65F1F4A2CEEBC0900D9655B /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Info-Remote-InfoPlist.strings"; sourceTree = "<group>"; };
 		F6DA2DA52AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayMetalViewInputAccessory.strings"; sourceTree = "<group>"; };
 		F6DA2DA62AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/VMDisplayWindow.strings"; sourceTree = "<group>"; };
 		F6DA2DA72AAFED5F0070DCD1 /* zh-HK */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-HK"; path = "zh-HK.lproj/InfoPlist.strings"; sourceTree = "<group>"; };
@@ -2739,7 +2736,6 @@
 				CE95877426D74C2A0086BDE8 /* iOS.entitlements */,
 				CE2D954F24AD4F980059923A /* Info.plist */,
 				CECF02572B70909900409FC0 /* Info-Remote.plist */,
-				F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */,
 				FFB02A8A266CB09C006CD71A /* InfoPlist.strings */,
 				CEB5C1192B8C4CD4008AAE5C /* Info-RemotePlist.strings */,
 				CEC1B00A2BBB211C0088119D /* PrivacyInfo.xcprivacy */,
@@ -3427,7 +3423,6 @@
 				CEF7F6792AEEDCC400E34952 /* Icons in Resources */,
 				CEB5C1172B8C4CD4008AAE5C /* Info-RemotePlist.strings in Resources */,
 				CEF7F67B2AEEDCC400E34952 /* Localizable.strings in Resources */,
-				F65F1F482CEEB78D00D9655B /* Info-Remote-InfoPlist.strings in Resources */,
 				CEF7F67C2AEEDCC400E34952 /* qemu in Resources */,
 				CEF7F67D2AEEDCC400E34952 /* VMDisplayMetalViewInputAccessory.xib in Resources */,
 				CEF7F67E2AEEDCC400E34952 /* Localizable.stringsdict in Resources */,
@@ -4368,15 +4363,6 @@
 				037DAA202B0B92580061ACB3 /* it */,
 			);
 			name = Localizable.stringsdict;
-			sourceTree = "<group>";
-		};
-		F65F1F462CEEB78D00D9655B /* Info-Remote-InfoPlist.strings */ = {
-			isa = PBXVariantGroup;
-			children = (
-				F65F1F472CEEB78D00D9655B /* zh-HK */,
-				F65F1F4A2CEEBC0900D9655B /* zh-Hans */,
-			);
-			name = "Info-Remote-InfoPlist.strings";
 			sourceTree = "<group>";
 		};
 		FF0307532A84E3B70049979B /* QEMULauncher-InfoPlist.strings */ = {


### PR DESCRIPTION
p.s. I've also added simplified and traditional Chinese translations for in-app purchase (donation) items in `Platform/iOS/Donation.storekit`.

Sorry for not providing a zh-HK variant for that, because Apple doesn't offer the "Chinese (Hong Kong)" option in Xcode (see the screenshot below).

<img width="1512" alt="Screenshot 2024-11-21 09 29 38" src="https://github.com/user-attachments/assets/dbebcdf6-51cd-4186-97c3-6a23ed1c1883">
