### PR TITLE
scripting: expose icon in config

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -405,6 +405,9 @@
         <record-type name="qemu configuration" code="QeCf" description="QEMU virtual machine configuration.">
           <property name="name" code="pnam" type="text"
             description="Virtual machine name."/>
+        
+          <property name="icon" code="IcOn" type="text"
+            description="Virtual machine icon."/>
             
           <property name="notes" code="NoTe" type="text"
             description="User-specified notes."/>
@@ -566,6 +569,9 @@
         <record-type name="apple configuration" code="ApCf" description="Apple virtual machine configuration.">
           <property name="name" code="pnam" type="text"
             description="Virtual machine name."/>
+            
+          <property name="icon" code="IcOn" type="text"
+            description="Virtual machine icon."/>
             
           <property name="notes" code="NoTe" type="text"
             description="User-specified notes."/>

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -96,6 +96,7 @@ extension UTMScriptingConfigImpl {
     private func serializeQemuConfiguration(_ config: UTMQemuConfiguration) -> [AnyHashable : Any] {
         [
             "name": config.information.name,
+            "icon": config.information.iconURL?.deletingPathExtension().lastPathComponent ?? "",
             "notes": config.information.notes ?? "",
             "architecture": config.system.architecture.rawValue,
             "machine": config.system.target.rawValue,
@@ -200,6 +201,7 @@ extension UTMScriptingConfigImpl {
     private func serializeAppleConfiguration(_ config: UTMAppleConfiguration) -> [AnyHashable : Any] {
         [
             "name": config.information.name,
+            "icon": config.information.iconURL?.deletingPathExtension().lastPathComponent ?? "",
             "notes": config.information.notes ?? "",
             "memory": config.system.memorySize,
             "cpuCores": config.system.cpuCount,
@@ -306,6 +308,13 @@ extension UTMScriptingConfigImpl {
         let config = config as! UTMQemuConfiguration
         if let name = record["name"] as? String, !name.isEmpty {
             config.information.name = name
+        }
+        if let icon = record["icon"] as? String, !icon.isEmpty {
+            if let url = UTMConfigurationInfo.builtinIcon(named: icon) {
+                config.information.iconURL = url
+            } else {
+                throw ConfigurationError.iconNotFound(icon: icon)
+            }
         }
         if let notes = record["notes"] as? String, !notes.isEmpty {
             config.information.notes = notes
@@ -530,6 +539,13 @@ extension UTMScriptingConfigImpl {
         if let name = record["name"] as? String, !name.isEmpty {
             config.information.name = name
         }
+        if let icon = record["icon"] as? String, !icon.isEmpty {
+            if let url = UTMConfigurationInfo.builtinIcon(named: icon) {
+                config.information.iconURL = url
+            } else {
+                throw ConfigurationError.iconNotFound(icon: icon)
+            }
+        }
         if let notes = record["notes"] as? String, !notes.isEmpty {
             config.information.notes = notes
         }
@@ -652,6 +668,7 @@ extension UTMScriptingConfigImpl {
         case invalidDriveDescription
         case indexNotFound(index: Int)
         case deviceNotSupported
+        case iconNotFound(icon: String)
         
         var errorDescription: String? {
             switch self {
@@ -659,6 +676,7 @@ extension UTMScriptingConfigImpl {
             case .invalidDriveDescription: return NSLocalizedString("Drive description is invalid.", comment: "UTMScriptingConfigImpl")
             case .indexNotFound(let index): return String.localizedStringWithFormat(NSLocalizedString("Index %lld cannot be found.", comment: "UTMScriptingConfigImpl"), index)
             case .deviceNotSupported: return NSLocalizedString("This device is not supported by the target.", comment: "UTMScriptingConfigImpl")
+            case .iconNotFound(let icon): return String.localizedStringWithFormat(NSLocalizedString("The icon named '%@' cannot be found in the built-in icons.", comment: "UTMScriptingConfigImpl"), icon)
             }
         }
     }


### PR DESCRIPTION
* Allows to get/set built-in icons 
iconURL is URL in UTMConfig, but stored as string in config.plist, same is done for scripting interface.

Usage:

```applescript
tell application "UTM"
  set vm to virtual machine named "OpenBSD"
  set config to configuration of vm
  set icon of config to "openbsd"
  update configuration of vm with config
end tell
```

>Say hi to puffy!

For reference :
All available icons are in https://github.com/utmapp/UTM/tree/main/Icons
corresponding icon keys in https://github.com/utmapp/UTM/blob/8ef19ff661c628f3e9075de81f3051471d54de10/Platform/Shared/VMConfigInfoView.swift#L321