### PR TITLE
scripting : add vm registry suite

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -712,4 +712,27 @@
           <direct-parameter description="The USB device to disconnect." type="usb device"/>
         </command>
     </suite>
+    
+    <suite name="UTM Registry Suite" code="UTMr" description="UTM virtual machine registry suite. Use this to update virtual machine registry.">
+           <access-group identifier="com.utmapp.UTM.vm-access" />
+           
+           <class-extension extends="virtual machine" description="Virtual machine registry.">
+               <property name="registry" code="ReGs" access="r"
+                   description="The registry of the virtual machine.">
+                   <type type="file" list="yes"/>
+               </property>
+               
+               <responds-to command="update registry">
+                   <cocoa method="updateRegistry:"/>
+               </responds-to>
+           </class-extension>
+           
+           <command name="update registry" code="UTMrUpDt" description="Update the registry of the virtual machine.">
+               <direct-parameter description="Virtual machine to update." type="virtual machine"/>
+               <parameter name="with" code="UpRg" description="The registry to update the virtual machine. Currently you can only change the shared directory with this!">
+                   <cocoa key="newRegistry"/>
+                   <type type="file" list="yes"/>
+               </parameter>
+           </command>
+    </suite>
 </dictionary>

--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -561,6 +561,10 @@
         <record-type name="qemu argument" code="QeAr" description="QEMU argument configuration.">
           <property name="argument string" code="ArSt" type="text"
             description="The QEMU argument as a string."/>
+          <property name="file urls" code="FlUr" 
+            description="Optional URLs associated with this argument.">
+            <type type="file" list="yes"/>
+          </property>
         </record-type>
         
         <record-type name="apple configuration" code="ApCf" description="Apple virtual machine configuration.">

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -193,6 +193,10 @@ extension UTMScriptingConfigImpl {
         var serializedArgument: [AnyHashable: Any] = [
             "argumentString": argument.string
         ]
+        // Only add fileUrls if it is not nil and contains URLs
+        if let fileUrls = argument.fileUrls, !fileUrls.isEmpty {
+            serializedArgument["fileUrls"] = fileUrls.map({ $0 as AnyHashable })
+        }
         
         return serializedArgument
     }
@@ -517,7 +521,10 @@ extension UTMScriptingConfigImpl {
         let additionalArguments = records.compactMap { record -> QEMUArgument? in
             guard let argumentString = record["argumentString"] as? String else { return nil }
             var argument = QEMUArgument(argumentString)
-            
+            // fileUrls are used as required resources by QEMU.
+            if let fileUrls = record["fileUrls"] as? [URL] {
+                argument.fileUrls = fileUrls
+            }
             return argument
         }
         // Update entire additional arguments with new one.

--- a/Scripting/UTMScriptingRegistryEntryImpl.swift
+++ b/Scripting/UTMScriptingRegistryEntryImpl.swift
@@ -1,0 +1,77 @@
+//
+// Copyright © 2025 naveenrajm7. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import Foundation
+
+@objc extension UTMScriptingVirtualMachineImpl {
+    @objc var registry: [URL] {
+        let wrapper = UTMScriptingRegistryEntryImpl(vm.registryEntry)
+        return wrapper.serializeRegistry()
+    }
+    
+    @objc func updateRegistry(_ command: NSScriptCommand) {
+        let newRegistry = command.evaluatedArguments?["newRegistry"] as? [URL]
+        withScriptCommand(command) { [self] in
+            guard let newRegistry = newRegistry else {
+                throw ScriptingError.invalidParameter
+            }
+            let wrapper = UTMScriptingRegistryEntryImpl(vm.registryEntry)
+            try await wrapper.updateRegistry(from: newRegistry, qemuProcess)
+        }
+    }
+}
+
+@MainActor
+class UTMScriptingRegistryEntryImpl {
+    private(set) var registry: UTMRegistryEntry
+    
+    init(_ registry: UTMRegistryEntry) {
+        self.registry = registry
+    }
+    
+    func serializeRegistry() -> [URL] {
+        return registry.sharedDirectories.compactMap { $0.url }
+    }
+    
+    func updateRegistry(from fileUrls: [URL], _ system: UTMQemuSystem?) async throws {
+        // Clear all shared directories, we add all directories here
+        registry.removeAllSharedDirectories()
+        
+        // Add urls to the registry
+        for url in fileUrls {
+            // Start scoped access
+            let isScopedAccess = url.startAccessingSecurityScopedResource()
+            defer {
+                if isScopedAccess {
+                    url.stopAccessingSecurityScopedResource()
+                }
+            }
+            
+            // Get bookmark from UTM process
+            let standardBookmark = try url.bookmarkData()
+            let system = system ?? UTMProcess()
+            let (success, bookmark, path) = await system.accessData(withBookmark: standardBookmark, securityScoped: false)
+            guard let bookmark = bookmark, let _ = path, success else {
+                throw UTMQemuVirtualMachineError.accessDriveImageFailed
+            }
+            
+            // Store bookmark in registry
+            let file = UTMRegistryEntry.File(dummyFromPath: url.path, remoteBookmark: bookmark)
+            registry.appendSharedDirectory(file)
+        }
+        
+    }
+}

--- a/Scripting/UTMScriptingVirtualMachineImpl.swift
+++ b/Scripting/UTMScriptingVirtualMachineImpl.swift
@@ -90,6 +90,12 @@ class UTMScriptingVirtualMachineImpl: NSObject, UTMScriptable {
         }
     }
     
+    var qemuProcess: UTMQemuSystem? {
+        get async {
+            await (vm as? UTMQemuVirtualMachine)?.system
+        }
+    }
+    
     override var objectSpecifier: NSScriptObjectSpecifier? {
         let appDescription = NSApplication.classDescription() as! NSScriptClassDescription
         return NSUniqueIDSpecifier(containerClassDescription: appDescription,

--- a/Services/UTMQemuVirtualMachine.swift
+++ b/Services/UTMQemuVirtualMachine.swift
@@ -129,7 +129,8 @@ final class UTMQemuVirtualMachine: UTMSpiceVirtualMachine {
 
     private let qemuVM = QEMUVirtualMachine()
     
-    private var system: UTMQemuSystem? {
+    /// QEMU Process interface
+    var system: UTMQemuSystem? {
         get async {
             await qemuVM.launcher as? UTMQemuSystem
         }

--- a/Services/UTMRegistryEntry.swift
+++ b/Services/UTMRegistryEntry.swift
@@ -260,6 +260,10 @@ extension UTMRegistryEntry: UTMRegistryEntryDecodable {}
         }
     }
     
+    func appendSharedDirectory(_ file: File) {
+        sharedDirectories.append(file)
+    }
+    
     func removeAllSharedDirectories() {
         sharedDirectories = []
     }

--- a/UTM.xcodeproj/project.pbxproj
+++ b/UTM.xcodeproj/project.pbxproj
@@ -272,6 +272,7 @@
 		B3DDF57226E9BBA300CE47F0 /* AltKit in Frameworks */ = {isa = PBXBuildFile; productRef = B3DDF57126E9BBA300CE47F0 /* AltKit */; };
 		CD77BE422CAB51B40074ADD2 /* UTMScriptingExportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77BE412CAB519F0074ADD2 /* UTMScriptingExportCommand.swift */; };
 		CD77BE442CB38F060074ADD2 /* UTMScriptingImportCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */; };
+		CD84C2092D3B446D00829850 /* UTMScriptingRegistryEntryImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD84C2082D3B446D00829850 /* UTMScriptingRegistryEntryImpl.swift */; };
 		CE020BA324AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA424AEDC7C00B44AB6 /* UTMData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE020BA224AEDC7C00B44AB6 /* UTMData.swift */; };
 		CE020BA724AEDEF000B44AB6 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = CE020BA624AEDEF000B44AB6 /* Logging */; };
@@ -1779,6 +1780,7 @@
 		C8958B6D243634DA002D86B4 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		CD77BE412CAB519F0074ADD2 /* UTMScriptingExportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingExportCommand.swift; sourceTree = "<group>"; };
 		CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingImportCommand.swift; sourceTree = "<group>"; };
+		CD84C2082D3B446D00829850 /* UTMScriptingRegistryEntryImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMScriptingRegistryEntryImpl.swift; sourceTree = "<group>"; };
 		CE020BA224AEDC7C00B44AB6 /* UTMData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMData.swift; sourceTree = "<group>"; };
 		CE020BAA24AEE00000B44AB6 /* UTMLoggingSwift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMLoggingSwift.swift; sourceTree = "<group>"; };
 		CE020BB524B14F8400B44AB6 /* UTMVirtualMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMVirtualMachine.swift; sourceTree = "<group>"; };
@@ -3027,6 +3029,7 @@
 				CEC794B9294924E300121A9F /* UTMScriptingSerialPortImpl.swift */,
 				CE25124829BFDBA6000790AB /* UTMScriptingGuestFileImpl.swift */,
 				CE25124629BFDB87000790AB /* UTMScriptingGuestProcessImpl.swift */,
+				CD84C2082D3B446D00829850 /* UTMScriptingRegistryEntryImpl.swift */,
 				CE25124C29C55816000790AB /* UTMScriptingConfigImpl.swift */,
 				CE25125429C80CD4000790AB /* UTMScriptingCreateCommand.swift */,
 				CD77BE432CB38F060074ADD2 /* UTMScriptingImportCommand.swift */,
@@ -3724,6 +3727,7 @@
 				CEBE820D26A4C8E0007AAB12 /* VMWizardSummaryView.swift in Sources */,
 				8401FDB2269E602000265F0D /* VMConfigAppleDriveDetailsView.swift in Sources */,
 				841619B428431DA5000034B2 /* UTMQemuConfigurationQEMU.swift in Sources */,
+				CD84C2092D3B446D00829850 /* UTMScriptingRegistryEntryImpl.swift in Sources */,
 				CEF0307626A2B40B00667B63 /* VMWizardHardwareView.swift in Sources */,
 				CED234EE254796E500ED0A57 /* NumberTextField.swift in Sources */,
 				841619B028431952000034B2 /* UTMQemuConfigurationSystem.swift in Sources */,


### PR DESCRIPTION
Fixes #6899

The registry suite is used to read and update vm registry.
All configs saved to disk is exposed by Configuration suite, similarly those that are not saved to disk are stored in RegistryEntry of a VM, they will now be exposed by Registry suite.

Users will now be able to give UTM→QEMU access to their custom path by updating registry, which can then be used in qemu additional args.

Added

- UTMScriptingRegistryEntryImpl will control what will be exposed from RegistryEntry to scripting bridge, currently only shared directory is exposed in the form of [URL].
    
    Since we have a separate suite for handling registry , this suite can grow on what will be exposed. Eg: externalDrives  (Not everything in RegistryEntry is suitable to be exposed)
    
- Added file urls to qemu addtional args, QEMU launcher looks at file urls of args to collect required resources. These files urls are not stored to the disk, meaning they will be lost .
    
    However, they exists only for QEMU to figure out permission for these resources. Since the permission should actually come from registry, it is okay to lose these entries in qemu args.


### Usage: Registry Suite

registry_add.applescript
```applescript
on run argv
  set vmName to item 1 of argv
  -- Define the directory path
  set dir1Path to POSIX file "/Users/utm/Dir1"
  set dir2Path to POSIX file "/Users/utm/Dir2"

  tell application "UTM"
      set vm to virtual machine named vmName
      
      -- get current registry
      set reg to registry of vm
      -- add new entries
      set newEntry to {dir1Path,dir2Path}
      set reg to reg & newEntry
      -- update registry  ( No need for the VM to be stopped )
      update registry of vm with reg -- QEMU now has access to Dir1, Dir2
  end tell
end run
```

`osascript registry_add.applescript testVM`

### Example use-case for registry: directory share

```applescript
on run argv
    set vmName to item 1 of argv
     -- share id to support multiple shares and avoid conflict with UTM's default share (id=0)
    set dirId to "1" 
    set dirPath to "/Users/utm/Dir1"
    set dirURL to POSIX file dirPath
    
    -- Prepare the QEMU argument strings
    set fsdevArgStr to "-fsdev local,id=virtfs" & dirId & ",path=" & dirPath & ",security_model=mapped-xattr"
    set deviceArgStr to "-device virtio-9p-pci,fsdev=virtfs" & dirId & ",mount_tag=share" & dirId

    tell application "UTM"
        -- Get the VM and its configuration
        set vm to virtual machine named vmName
        set config to configuration of vm

        -- Get the current QEMU additional arguments
        set qemuAddArgs to qemu additional arguments of config

        -- Add the new arguments to the existing ones
        set end of qemuAddArgs to {argument string:fsdevArgStr, file urls:{dirURL}}
        set end of qemuAddArgs to {argument string:deviceArgStr}

        -- Update the configuration with the new arguments list
        set qemu additional arguments of config to qemuAddArgs
        update configuration of vm with config
				
	-- Give UTM access to the shared directory by updating registry
        -- Get the current directory shares in registry
        set reg to registry of vm
        -- Add new directory shares to the registry
        set reg to reg & {dirURL}
        -- Update registry of vm with new directory shares
        update registry of vm with reg
	
    end tell
end run
```

Mount inside VM

```
sudo mkdir -p /mnt/share1
sudo mount -t 9p -o trans=virtio,version=9p2000.L share1 /mnt/share1
```

