### PR TITLE
scripting: expose display config

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -445,6 +445,11 @@
             <type type="qemu serial configuration" list="yes"/>
           </property>
           
+          <property name="displays" code="DiPs"
+            description="List of display configuration.">
+            <type type="qemu display configuration" list="yes"/>
+          </property>
+          
           <property name="qemu additional arguments" code="QeAd"
             description="List of qemu arguments.">
             <type type="qemu argument" list="yes"/>
@@ -558,6 +563,31 @@
               description="The port number to listen on when the interface is a TCP server."/>
         </record-type>
         
+        <record-type name="qemu display configuration" code="QdYc" description="QEMU virtual display configuration.">
+          <property name="id" code="ID  " type="text" access="r"
+            description="The unique identifier for this display (if empty, a new display will be created)."/>
+            
+          <property name="hardware" code="HaWe" type="text"
+            description="Name of the emulated display card (required. if given hardware not found, the default will be used)."/>
+            
+          <property name="dynamic resolution" code="DyRe" type="boolean"
+            description="If true, attempt to use SPICE guest agent to change the display resolution automatically."/>
+            
+          <property name="native resolution" code="NaRe" type="boolean"
+            description="If true, use the true (retina) resolution of the display. Otherwise, use the percieved resolution."/>
+
+          <property name="upscaling filter" code="UpFi" type="qemu scaler"
+            description="Filter to use when upscaling."/>
+            
+          <property name="downscaling filter" code="DoFi" type="qemu scaler"
+            description="Filter to use when downscaling."/>
+        </record-type>
+        
+        <enumeration name="qemu scaler" code="QeSc" description="QEMU Scaler.">
+            <enumerator name="linear" code="QsLi"/>
+            <enumerator name="nearest" code="QsNe"/>
+        </enumeration>
+        
         <record-type name="qemu argument" code="QeAr" description="QEMU argument configuration.">
           <property name="argument string" code="ArSt" type="text"
             description="The QEMU argument as a string."/>
@@ -594,6 +624,11 @@
           <property name="serial ports" code="SrPt"
             description="List of serial configuration.">
             <type type="apple serial configuration" list="yes"/>
+          </property>
+          
+          <property name="displays" code="DiPs"
+            description="List of display configuration.">
+            <type type="apple display configuration" list="yes"/>
           </property>
         </record-type>
         
@@ -647,6 +682,14 @@
               
             <property name="interface" code="InTf" type="serial interface"
               description="The type of serial interface on the host (only PTTY is supported)."/>
+        </record-type>
+        
+        <record-type name="apple display configuration" code="AdYc" description="Apple virtual display configuration.">
+          <property name="id" code="ID  " type="text" access="r"
+            description="The unique identifier for this display (if empty, a new display will be created)."/>
+            
+          <property name="dynamic resolution" code="DyRe" type="boolean"
+            description="Dynamic Resolution."/>
         </record-type>
     </suite>
     

--- a/Scripting/UTMScripting.swift
+++ b/Scripting/UTMScripting.swift
@@ -132,6 +132,12 @@ import ScriptingBridge
     case udp = 0x55645070 /* 'UdPp' */
 }
 
+// MARK: UTMScriptingQemuScaler
+@objc public enum UTMScriptingQemuScaler : AEKeyword {
+    case linear = 0x51734c69 /* 'QsLi' */
+    case nearest = 0x51734e65 /* 'QsNe' */
+}
+
 // MARK: UTMScriptingAppleNetworkMode
 @objc public enum UTMScriptingAppleNetworkMode : AEKeyword {
     case shared = 0x53685264 /* 'ShRd' */


### PR DESCRIPTION
Fixes #6660 

* qemu display
  - All fields , except vga ram is exposed 
* apple display
  - only dynamic resolution property is exposed.
  - From GUI , the height, width and pixel of resolution is in pre-defined ratio and hence not exposed.

Both displays will have ids, which can be used to track and detach the displays.

## Usage:

add_qemu_display.applescript
```applescript
on run argv
  set vmName to item 1 of argv
  tell application "UTM"
      set vm to virtual machine named vmName
      set config to configuration of vm
      set currentDisplay to displays of config

      set newDisplay to ¬
          { ¬
              hardware: "virtio-gpu-pci", ¬
              dynamic resolution: false, ¬
              native resolution: true, ¬
              upscaling filter: "QsLi", ¬
              downscaling filter: "QsNe" ¬
          }
      
      set end of currentDisplay to newDisplay
      set displays of config to currentDisplay
      update configuration of vm with config
  end tell
end run
```

clear_qemu_display.applescript
```applescript
on run argv
  set vmName to item 1 of argv
  tell application "UTM"
      set vm to virtual machine named vmName
      set config to configuration of vm
      -- clear all displays      
      set displays of config to {}
      update configuration of vm with config
  end tell
end run
```

add_apple_display.applescript
```applescript
on run argv
  set vmName to item 1 of argv
  tell application "UTM"
      set vm to virtual machine named vmName
      set config to configuration of vm
      set newDisplay to {dynamic resolution: true}
      -- Apple Configuration supports only one display
      set displays of config to newDisplay
      update configuration of vm with config
  end tell
end run
```
