### PR TITLE
macOS: Add shared directory mount tag customization

### DIFF
--- a/Platform/macOS/VMConfigAppleSharingView.swift
+++ b/Platform/macOS/VMConfigAppleSharingView.swift
@@ -23,56 +23,100 @@ struct VMConfigAppleSharingView: View {
     @State private var selectedID: UUID?
     @State private var isImporterPresented: Bool = false
     @State private var isAddReadOnly: Bool = false
-    
+    @State private var mountTag: String = ""
+
     var body: some View {
+
         Form {
-            if config.system.boot.operatingSystem == .macOS {
-                Text("Shared directories in macOS VMs are only available in macOS 13 and later.")
-            }
-            Table(config.sharedDirectories, selection: $selectedID) {
-                TableColumn("Shared Path") { share in
-                    Text(share.directoryURL?.path ?? "")
-                }
-                TableColumn("Read Only?") { share in
-                    Toggle("", isOn: .constant(share.isReadOnly))
-                        .disabled(true)
-                }
-            }.frame(minHeight: 300)
-            HStack {
-                Spacer()
-                Button("Delete") {
-                    config.sharedDirectories.removeAll { share in
-                        share.id == selectedID
-                    }
-                }.disabled(selectedID == nil)
-                Button("Add") {
-                    isImporterPresented.toggle()
-                }
-            }.fileImporter(isPresented: $isImporterPresented, allowedContentTypes: [.folder]) { result in
-                data.busyWorkAsync {
-                    let url = try result.get()
-                    if await config.sharedDirectories.contains(where: { existing in
-                        url == existing.directoryURL
-                    }) {
-                        throw NSLocalizedString("This directory is already being shared.", comment: "VMConfigAppleSharingView")
-                    }
-                    await MainActor.run {
-                        config.sharedDirectories.append(UTMAppleConfigurationSharedDirectory(directoryURL: url, isReadOnly: isAddReadOnly))
+            VStack(alignment: .leading, spacing: 16.0) {
+                if #available(macOS 13.0, *) {
+                    // Information text
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Shared directories in macOS VMs are only available in macOS 13 and later.")
+                            .padding(.top, 4)
+                        LabeledContent("(Advanced) Custom mount tag") {
+                            TextField("", text: $mountTag)
+                                .textFieldStyle(.roundedBorder)
+                                .frame(width: 300)
+                                .onChange(of: mountTag) { newValue in
+                                    config.sharedDirectoryMountTag = newValue.isEmpty ? nil : newValue
+                                }
+                        }
+                        .help("The name that shared directories will use when mounted in the guest. Useful when applications have issues with spaces in paths.")
+                        .onAppear {
+                            mountTag = config.sharedDirectoryMountTag ?? ""
+                        }
+                        Text("note: This disable automatic mounting. You must use `mountfs_virtio tag path` in the guset.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+
+                        Text("e.g. $ mkdir ~/shared; mountfs_virtio \(mountTag.isEmpty ? "tag" : mountTag) ~/shared")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
                     }
                 }
+                // Table section
+                VStack(alignment: .leading, spacing: 9.0) {
+                    Table(config.sharedDirectories, selection: $selectedID) {
+                        TableColumn("Shared Path") { share in
+                            Text(share.directoryURL?.path ?? "")
+                        }
+                        TableColumn("Read Only?") { share in
+                            Toggle("", isOn: .constant(share.isReadOnly))
+                                .disabled(true)
+                                .labelsHidden()
+                        }
+                    }
+                    .frame(minHeight: 200)
+                    // Buttons
+                    HStack {
+                        Spacer()
+                        Button("Delete") {
+                            config.sharedDirectories.removeAll { share in
+                                share.id == selectedID
+                            }
+                        }
+                        .disabled(selectedID == nil)
+                        .buttonStyle(.bordered)
+
+                        Button("Add") {
+                            isImporterPresented.toggle()
+                        }
+                        .buttonStyle(.bordered)
+                    }
+                    .fileImporter(
+                        isPresented: $isImporterPresented,
+                        allowedContentTypes: [.folder]
+                    ) { result in
+                        data.busyWorkAsync {
+                            let url = try result.get()
+                            if await config.sharedDirectories.contains(where: { existing in
+                                url == existing.directoryURL
+                            }) {
+                                throw NSLocalizedString("This directory is already being shared.", comment: "VMConfigAppleSharingView")
+                            }
+                            await MainActor.run {
+                                config.sharedDirectories.append(UTMAppleConfigurationSharedDirectory(directoryURL: url, isReadOnly: isAddReadOnly))
+                            }
+                        }
+                    }
+                    // Read only toggle
+                    HStack {
+                        Spacer()
+                        Toggle("Add read only", isOn: $isAddReadOnly)
+                    }
+                }
             }
-            HStack {
-                Spacer()
-                Toggle("Add read only", isOn: $isAddReadOnly)
-            }
+            .padding([.horizontal, .bottom], 9.0)
         }
     }
+
 }
 
 @available(macOS 12, *)
 struct VMConfigAppleSharingView_Previews: PreviewProvider {
     @State static private var config = UTMAppleConfiguration()
-    
+
     static var previews: some View {
         VMConfigAppleSharingView(config: config)
     }


### PR DESCRIPTION
This change allows users to customize the mount tag name for shared directories in macOS guests. Some applications don't handle spaces in paths properly, so this provides more flexibility.

- Added sharedDirectoryMountTag property to UTMAppleConfiguration
- Updated shareDirectoryTag to use custom mount tag if set
- Added UI in VMConfigAppleSharingView to modify the mount tag

Addresses #7026 

![Screenshot 2025-03-11 at 3 02 06 AM](https://github.com/user-attachments/assets/11f12049-8147-460b-8956-732befbc7469)

