### PR TITLE
macOS: fix issue where the Settings window (via cmd+,) was scaled to be too short when showing the inputs tab

### DIFF
--- a/Platform/macOS/SettingsView.swift
+++ b/Platform/macOS/SettingsView.swift
@@ -41,7 +41,7 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Server", systemImage: "server.rack")
                 }
-        }.frame(minWidth: 600, minHeight: 350, alignment: .topLeading)
+        }.frame(minWidth: 600, minHeight: 400, alignment: .topLeading)
     }
 }
 

--- a/Platform/macOS/SettingsView.swift
+++ b/Platform/macOS/SettingsView.swift
@@ -41,7 +41,7 @@ struct SettingsView: View {
                 .tabItem {
                     Label("Server", systemImage: "server.rack")
                 }
-        }.frame(minWidth: 600, minHeight: 400, alignment: .topLeading)
+        }.frame(minWidth: 600, minHeight: 370, alignment: .topLeading)
     }
 }
 


### PR DESCRIPTION
This pull request adds a workaround to this issue by increasing the vertical window size of the settings screen as a whole by 20 pixels.

Here's a screenshot of the previous setting screen with the inputs tab (where some settings got cut out):
<img width="712" alt="Screenshot 2025-04-11 at 9 48 12 AM" src="https://github.com/user-attachments/assets/8ef89e36-45a1-433b-b188-87045cbc6a9f" />
And here's the screenshot with the fix:
<img width="712" alt="Screenshot 2025-04-11 at 9 48 05 AM" src="https://github.com/user-attachments/assets/94480071-6c5b-479d-acdf-a537118782e1" />