### PR TITLE
utmctl: support booting into recovery mode

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -61,6 +61,9 @@
           <parameter name="saving" code="SaVe" description="When false, do not save the VM changes to disk. Default value is true." type="boolean" optional="yes">
             <cocoa key="saveFlag"/>
           </parameter>
+          <parameter name="recovery" code="ReCo" description="When true, start the VM in recovery mode. Default value is false." type="boolean" optional="yes">
+            <cocoa key="bootRecoveryFlag"/>
+          </parameter>
         </command>
         
         <command name="suspend" code="UTMvsusp" description="Suspend a running virtual machine to memory.">

--- a/Scripting/UTMScripting.swift
+++ b/Scripting/UTMScripting.swift
@@ -210,7 +210,7 @@ extension SBObject: UTMScriptingWindow {}
     @objc optional var name: String { get } // The name of the VM.
     @objc optional var backend: UTMScriptingBackend { get } // Emulation/virtualization engine used.
     @objc optional var status: UTMScriptingStatus { get } // Current running status.
-    @objc optional func startSaving(_ saving: Bool) // Start a virtual machine or resume a suspended virtual machine.
+    @objc optional func startSaving(_ saving: Bool, recovery: Bool) // Start a virtual machine or resume a suspended virtual machine.
     @objc optional func suspendSaving(_ saving: Bool) // Suspend a running virtual machine to memory.
     @objc optional func stopBy(_ by: UTMScriptingStopMethod) // Shuts down a running virtual machine.
     @objc optional func delete() // Delete a virtual machine. All data will be deleted, there is no confirmation!

--- a/utmctl/UTMCtl.swift
+++ b/utmctl/UTMCtl.swift
@@ -226,10 +226,13 @@ extension UTMCtl {
         
         @Flag(help: "Run VM as a snapshot and do not save changes to disk.")
         var disposable: Bool = false
-        
+
+        @Flag(help: "Boot a VM in recovery mode.")
+        var recovery: Bool = false
+
         func run(with application: UTMScriptingApplication) throws {
             let vm = try virtualMachine(forIdentifier: identifer, in: application)
-            vm.startSaving!(!disposable)
+            vm.startSaving!(!disposable, recovery: recovery)
             if attach {
                 print("WARNING: attach command is not implemented yet!")
             }


### PR DESCRIPTION
Add an optional flag to `utmctl start` to boot a VM into recovery mode, eg `utmctl start --recovery macOS`.

 - defaults to False
 - verifies the VM supports recovery mode