### PR TITLE
Show localized bridge network name when available

### DIFF
--- a/Platform/Shared/VMConfigNetworkView.swift
+++ b/Platform/Shared/VMConfigNetworkView.swift
@@ -41,7 +41,7 @@ struct VMConfigNetworkView: View {
                             Text("Automatic")
                                 .tag(nil as String?)
                             ForEach(VZBridgedNetworkInterface.networkInterfaces, id: \.identifier) { interface in
-                                Text(interface.identifier)
+                                Text(interface.localizedDisplayName.map { "\($0) (\(interface.identifier))" } ?? interface.identifier)
                                     .tag(interface.identifier as String?)
                             }
                         }

--- a/Platform/macOS/VMConfigAppleNetworkingView.swift
+++ b/Platform/macOS/VMConfigAppleNetworkingView.swift
@@ -44,7 +44,7 @@ struct VMConfigAppleNetworkingView: View {
                         Text("Automatic")
                             .tag(nil as String?)
                         ForEach(VZBridgedNetworkInterface.networkInterfaces, id: \.identifier) { interface in
-                            Text(interface.identifier)
+                            Text(interface.localizedDisplayName.map { "\($0) (\(interface.identifier))" } ?? interface.identifier)
                                 .tag(interface.identifier as String?)
                         }
                     }


### PR DESCRIPTION
This adds the localized interface name in bridge network configuration, which makes them a little easier to recognize.

QEMU configuration:
<img width="277" alt="image" src="https://github.com/user-attachments/assets/32a7c7df-4243-4f59-86d9-b4f95412a29b" />

Apple configuration:
<img width="273" alt="image" src="https://github.com/user-attachments/assets/a0fe6751-bd08-408a-b0ee-de411aa443c8" />
