### PR TITLE
chore: fix grammar in code comments

### DIFF
--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -61,22 +61,22 @@ import Virtualization // for getting network interfaces
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("swtpm")
     }
     
-    /// Used only if in remote sever mode.
+    /// Used only if in remote server mode.
     var monitorPipeURL: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("qmp")
     }
 
-    /// Used only if in remote sever mode.
+    /// Used only if in remote server mode.
     var guestAgentPipeURL: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("qga")
     }
 
-    /// Used only if in remote sever mode.
+    /// Used only if in remote server mode.
     var spiceTlsKeyUrl: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("pem")
     }
 
-    /// Used only if in remote sever mode.
+    /// Used only if in remote server mode.
     var spiceTlsCertUrl: URL {
         socketURL.appendingPathComponent(information.uuid.uuidString).appendingPathExtension("crt")
     }

--- a/Intents/UTMInputIntent.swift
+++ b/Intents/UTMInputIntent.swift
@@ -111,7 +111,7 @@ struct UTMSendKeystrokesIntent: UTMIntent {
     @Parameter(title: "Virtual Machine", requestValueDialog: "Select a virtual machine")
     var vmEntity: UTMVirtualMachineEntity
 
-    @Parameter(title: "Keystrokes", description: "Text will be converted to a sequnce of keystrokes.")
+    @Parameter(title: "Keystrokes", description: "Text will be converted to a sequence of keystrokes.")
     var keystrokes: String
 
     @Parameter(title: "Modifiers", description: "The modifier keys will be held down while the keystroke sequence is sent.", default: [])

--- a/Platform/Shared/VMWizardHardwareView.swift
+++ b/Platform/Shared/VMWizardHardwareView.swift
@@ -269,7 +269,7 @@ struct VMWizardHardwareView: View {
             
             
             if !wizardState.useAppleVirtualization && wizardState.operatingSystem == .Linux {
-                DetailedSection("Disply Output", description: "There are known issues in some newer Linux drivers including black screen, broken compositing, and apps failing to render.") {
+                DetailedSection("Display Output", description: "There are known issues in some newer Linux drivers including black screen, broken compositing, and apps failing to render.") {
                     Toggle("Enable display output", isOn: $wizardState.isDisplayEnabled)
                         .onChange(of: wizardState.isDisplayEnabled) { newValue in
                             if !newValue {


### PR DESCRIPTION
### Summary

Fixes typos in comments across multiple Swift files.

### Changes

- Corrected minor spelling errors (e.g. "Disply" → "Display", "sever" → "server", “sequnce” → “sequence”)

### Motivation

These fixes improve readability and maintain professionalism in the codebase.

---

Let me know if you'd prefer a more granular set of commits or changes.