### PR TITLE
[WIP] Get SPICEDAV to work reliabily with M-Series Hosts

### DIFF
--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -505,6 +505,10 @@ import Virtualization // for getting network interfaces
             if system.architecture == .aarch64 && emulatedCpuCount.0 > 8 {
                 properties = properties.appendingDefaultPropertyName("gic-version", value: "3")
             }
+            // Workaround for SPICE WebDAV crashes on ARM64 virtualization
+            if system.architecture == .aarch64 && isHypervisorUsed {
+                properties = properties.appendingDefaultPropertyName("its", value: "off")
+            }
         }
         if isClassicMacM68K {
             if sound.contains(where: { $0.hardware.rawValue == QEMUSoundDevice_m68k.asc.rawValue }) {

--- a/Services/UTMSpiceIO.m
+++ b/Services/UTMSpiceIO.m
@@ -299,6 +299,8 @@ NSString *const kUTMErrorDomain = @"com.utmapp.utm";
 - (void)startSharingDirectory {
     if (self.sharedDirectory) {
         UTMLog(@"setting share directory to %@", self.sharedDirectory.path);
+        UTMLog(@"directory exists: %@", [[NSFileManager defaultManager] fileExistsAtPath:self.sharedDirectory.path] ? @"YES" : @"NO");
+        UTMLog(@"read-only mode: %@", (self.options & UTMSpiceIOOptionsIsShareReadOnly) ? @"YES" : @"NO");
         [self.sharedDirectory startAccessingSecurityScopedResource];
         [self.spiceConnection.session setSharedDirectory:self.sharedDirectory.path readOnly:(self.options & UTMSpiceIOOptionsIsShareReadOnly) == UTMSpiceIOOptionsIsShareReadOnly];
     }


### PR DESCRIPTION
Disable the ITS (Interrupt Translation Service) for ARM64 virtualization.
Fixes: https://github.com/utmapp/UTM/issues/3800