### PR TITLE
Add support for host networking with Apple Virtualization

### DIFF
--- a/Scripting/UTMScripting.swift
+++ b/Scripting/UTMScripting.swift
@@ -142,6 +142,7 @@ import ScriptingBridge
 @objc public enum UTMScriptingAppleNetworkMode : AEKeyword {
     case shared = 0x53685264 /* 'ShRd' */
     case bridged = 0x42724764 /* 'BrGd' */
+    case host = 0x486f5374 /* 'HoSt' */
 }
 
 // MARK: UTMScriptingModifierKey

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -255,6 +255,7 @@ extension UTMScriptingConfigImpl {
         switch mode {
         case .shared: return .shared
         case .bridged: return .bridged
+        case .host: return .host
         }
     }
     


### PR DESCRIPTION
This is untested (and thus a draft) because I do not have access to a host machine running Tahoe at the moment (and I couldn't get nested virtualization to work).

In the vmnet documentation I noticed a new feature in Tahoe: https://developer.apple.com/documentation/virtualization/vzvmnetnetworkdeviceattachment
There's not a ton of documentation available, but I assume this works similarly to how you can attach to a specific vmnet with QEMU.

If that is indeed how that API works, then this should allow VMs running with Apple Virtualization to be networked with custom host defined networks (as an extension to https://github.com/utmapp/UTM/pull/6186).