### PR TITLE
Fix "Started" in ru.lproj

### DIFF
--- a/Platform/ru.lproj/Localizable.strings
+++ b/Platform/ru.lproj/Localizable.strings
@@ -1526,7 +1526,7 @@
 "Start" = "Запуск";
 
 /* UTMVirtualMachine */
-"Started" = "Запущенно";
+"Started" = "Запущена";
 
 /* UTMVirtualMachine */
 "Starting" = "Запускается";


### PR DESCRIPTION
It should say "Запущена" in this case - since "Запущенно" doesn't fit this context and we're talking about VM (машина is a feminine noun, and "Запущено" is for masculine nouns).