### PR TITLE
Properly escape commas in disk paths

### DIFF
--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -864,7 +864,7 @@ import Virtualization // for getting network interfaces
         "id=drive\(drive.id)"
         if let imageURL = drive.imageURL {
             "file.filename="
-            imageURL
+            imageURL.path.replacingOccurrences(of: ",", with: ",,")
         } else if !isCd {
             "file.filename="
             placeholderUrl


### PR DESCRIPTION
This PR properly escapes commas in drive paths.

From QEMU documentation:

> If the filename contains comma, you must double it (for instance, “file=my,,file” to use file “my,file”).

