### PR TITLE
apple: configure both trackpad and USB mouse for macOS guests

### DIFF
--- a/Configuration/UTMAppleConfigurationVirtualization.swift
+++ b/Configuration/UTMAppleConfigurationVirtualization.swift
@@ -164,8 +164,12 @@ extension UTMAppleConfigurationVirtualization {
                 vzconfig.pointingDevices = [VZUSBScreenCoordinatePointingDeviceConfiguration()]
                 #if arch(arm64)
                 if #available(macOS 13, *), isMacOSGuest && pointer == .trackpad {
-                    // replace with trackpad device
-                    vzconfig.pointingDevices = [VZMacTrackpadConfiguration()]
+                    // Use both devices as Apple recommends for macOS 13+ trackpad support
+                    // Trackpad first (primary for macOS 13+), USB mouse second (fallback)
+                    vzconfig.pointingDevices = [
+                        VZMacTrackpadConfiguration(),
+                        VZUSBScreenCoordinatePointingDeviceConfiguration()
+                    ]
                 }
                 #endif
             }


### PR DESCRIPTION
## Summary
Include both [`VZMacTrackpadConfiguration`](https://developer.apple.com/documentation/virtualization/vzmactrackpadconfiguration) and [`VZUSBScreenCoordinatePointingDeviceConfiguration`](https://developer.apple.com/documentation/virtualization/vzusbscreencoordinatepointingdeviceconfiguration) when trackpad mode is selected for macOS guests.

## Details
Apple's documentation for `VZMacTrackpadConfiguration` states:

> To support both macOS 13.0 and earlier guests, set pointingDevices to an array that contains **both** a VZMacTrackpadConfiguration **and** a VZUSBScreenCoordinatePointingDeviceConfiguration object.

With both devices present, the framework can route input through the optimal device, which fixes scrolling latency.

Fixes [#4636](https://github.com/utmapp/UTM/issues/4636)