### PR TITLE
fix: correct typo 'Disposible' -> 'Disposable'

### DIFF
--- a/Intents/UTMActionIntent.swift
+++ b/Intents/UTMActionIntent.swift
@@ -46,7 +46,7 @@ struct UTMStartActionIntent: AppIntent, UTMIntent {
     static var parameterSummary: some ParameterSummary {
         Summary("Start \(\.$vmEntity)") {
             \.$isRecovery
-            \.$isDisposible
+            \.$isDisposable
         }
     }
 
@@ -59,8 +59,8 @@ struct UTMStartActionIntent: AppIntent, UTMIntent {
     @Parameter(title: "Recovery", description: "Boot into recovery mode. Only supported on Apple Virtualization backend.", default: false)
     var isRecovery: Bool
 
-    @Parameter(title: "Disposible", description: "Do not save any changes to disk. Only supported on QEMU backend.", default: false)
-    var isDisposible: Bool
+    @Parameter(title: "Disposable", description: "Do not save any changes to disk. Only supported on QEMU backend.", default: false)
+    var isDisposable: Bool
 
     @MainActor
     func perform(with vm: any UTMVirtualMachine, boxed: VMData) async throws -> some IntentResult {
@@ -75,11 +75,11 @@ struct UTMStartActionIntent: AppIntent, UTMIntent {
             throw UTMIntentError.unsupportedBackend
             #endif
         }
-        if isDisposible {
+        if isDisposable {
             guard vm is UTMQemuVirtualMachine else {
                 throw UTMIntentError.unsupportedBackend
             }
-            options.insert(.bootDisposibleMode)
+            options.insert(.bootDisposableMode)
         }
         #if os(macOS)
         // Ensure the app comes to the foreground before presenting VM UI

--- a/Platform/Shared/VMContextMenuModifier.swift
+++ b/Platform/Shared/VMContextMenuModifier.swift
@@ -103,7 +103,7 @@ struct VMContextMenuModifier: ViewModifier {
                 
                 if let _ = vm.config as? UTMQemuConfiguration {
                     Button {
-                        data.run(vm: vm, options: .bootDisposibleMode)
+                        data.run(vm: vm, options: .bootDisposableMode)
                     } label: {
                         Label("Run without saving changes", systemImage: "memories")
                     }.help("Run the VM in the foreground, without saving data changes to disk.")

--- a/Platform/iOS/VMSessionState.swift
+++ b/Platform/iOS/VMSessionState.swift
@@ -505,7 +505,7 @@ extension VMSessionState {
     }
     
     func pauseResume() {
-        let shouldSaveState = !vm.isRunningAsDisposible
+        let shouldSaveState = !vm.isRunningAsDisposable
         if vm.state == .started {
             vm.requestVmPause(save: shouldSaveState)
         } else if vm.state == .paused {

--- a/Platform/macOS/Display/VMDisplayQemuDisplayController.swift
+++ b/Platform/macOS/Display/VMDisplayQemuDisplayController.swift
@@ -34,7 +34,7 @@ class VMDisplayQemuWindowController: VMDisplayWindowController {
     }
     
     var defaultSubtitle: String {
-        if qemuVM.isRunningAsDisposible {
+        if qemuVM.isRunningAsDisposable {
             return NSLocalizedString("Disposable Mode", comment: "VMDisplayQemuDisplayController")
         } else {
             return ""

--- a/Platform/macOS/UTMMenuBarExtraScene.swift
+++ b/Platform/macOS/UTMMenuBarExtraScene.swift
@@ -66,7 +66,7 @@ private struct VMMenuItem: View {
                     data.stop(vm: vm)
                 }
                 Button("Suspend") {
-                    let isSnapshot = (vm.wrapped as? UTMQemuVirtualMachine)?.isRunningAsDisposible ?? false
+                    let isSnapshot = (vm.wrapped as? UTMQemuVirtualMachine)?.isRunningAsDisposable ?? false
                     vm.wrapped!.requestVmPause(save: !isSnapshot)
                 }
                 Button("Reset") {

--- a/Remote/UTMRemoteSpiceVirtualMachine.swift
+++ b/Remote/UTMRemoteSpiceVirtualMachine.swift
@@ -30,7 +30,7 @@ final class UTMRemoteSpiceVirtualMachine: UTMSpiceVirtualMachine {
             true
         }
 
-        var supportsDisposibleMode: Bool {
+        var supportsDisposableMode: Bool {
             true
         }
 
@@ -63,7 +63,7 @@ final class UTMRemoteSpiceVirtualMachine: UTMSpiceVirtualMachine {
 
     private(set) var isShortcut: Bool = false
 
-    private(set) var isRunningAsDisposible: Bool = false
+    private(set) var isRunningAsDisposable: Bool = false
 
     weak var delegate: (UTMVirtualMachineDelegate)?
 

--- a/Scripting/UTMScriptingVirtualMachineImpl.swift
+++ b/Scripting/UTMScriptingVirtualMachineImpl.swift
@@ -117,10 +117,10 @@ class UTMScriptingVirtualMachineImpl: NSObject, UTMScriptable {
             var options: UTMVirtualMachineStartOptions = []
 
             if !shouldSaveState {
-                guard type(of: vm).capabilities.supportsDisposibleMode else {
+                guard type(of: vm).capabilities.supportsDisposableMode else {
                     throw ScriptingError.operationNotSupported
                 }
-                options.insert(.bootDisposibleMode)
+                options.insert(.bootDisposableMode)
             }
             if bootRecoveryMode {
                 guard type(of: vm).capabilities.supportsRecoveryMode else {

--- a/Services/UTMAppleVirtualMachine.swift
+++ b/Services/UTMAppleVirtualMachine.swift
@@ -33,7 +33,7 @@ final class UTMAppleVirtualMachine: UTMVirtualMachine {
             true
         }
         
-        var supportsDisposibleMode: Bool {
+        var supportsDisposableMode: Bool {
             false
         }
         
@@ -59,7 +59,7 @@ final class UTMAppleVirtualMachine: UTMVirtualMachine {
     
     private(set) var isShortcut: Bool = false
     
-    let isRunningAsDisposible: Bool = false
+    let isRunningAsDisposable: Bool = false
     
     weak var delegate: (any UTMVirtualMachineDelegate)?
     

--- a/Services/UTMQemuVirtualMachine.swift
+++ b/Services/UTMQemuVirtualMachine.swift
@@ -39,7 +39,7 @@ final class UTMQemuVirtualMachine: UTMSpiceVirtualMachine {
             true
         }
         
-        var supportsDisposibleMode: Bool {
+        var supportsDisposableMode: Bool {
             true
         }
         
@@ -65,7 +65,7 @@ final class UTMQemuVirtualMachine: UTMSpiceVirtualMachine {
     
     private(set) var isShortcut: Bool = false
     
-    private(set) var isRunningAsDisposible: Bool = false
+    private(set) var isRunningAsDisposable: Bool = false
     
     weak var delegate: (any UTMVirtualMachineDelegate)?
     
@@ -267,7 +267,7 @@ extension UTMQemuVirtualMachine {
     
     private func determineSnapshotSupport() async -> Error? {
         // predetermined reasons
-        if isRunningAsDisposible {
+        if isRunningAsDisposable {
             return UTMQemuVirtualMachineError.qemuError(NSLocalizedString("Suspend state cannot be saved when running in disposible mode.", comment: "UTMQemuVirtualMachine"))
         }
         #if arch(x86_64)
@@ -306,7 +306,7 @@ extension UTMQemuVirtualMachine {
         } else {
             await qemuVM.setRedirectLog(url: nil)
         }
-        let isRunningAsDisposible = options.contains(.bootDisposibleMode)
+        let isRunningAsDisposable = options.contains(.bootDisposableMode)
         let isRemoteSession = options.contains(.remoteSession)
         #if WITH_SERVER
         let spicePassword = isRemoteSession ? String.random(length: 32) : nil
@@ -317,7 +317,7 @@ extension UTMQemuVirtualMachine {
         }
         #endif
         await MainActor.run {
-            config.qemu.isDisposable = isRunningAsDisposible
+            config.qemu.isDisposable = isRunningAsDisposable
             #if WITH_SERVER
             config.qemu.spiceServerPort = spicePort?.internalPort
             config.qemu.spiceServerPassword = spicePassword
@@ -420,7 +420,7 @@ extension UTMQemuVirtualMachine {
         
         // load saved state if requested
         let isSuspended = await registryEntry.isSuspended
-        if !isRunningAsDisposible && isSuspended {
+        if !isRunningAsDisposable && isSuspended {
             try await monitor.qemuRestoreSnapshot(kSuspendSnapshotName)
             try Task.checkCancellation()
         }
@@ -445,7 +445,7 @@ extension UTMQemuVirtualMachine {
         // save ioService and let it set the delegate
         self.ioService = interface as? UTMSpiceIO
         self.pipeInterface = interface as? UTMPipeInterface
-        self.isRunningAsDisposible = isRunningAsDisposible
+        self.isRunningAsDisposable = isRunningAsDisposable
         
         // test out snapshots
         self.snapshotUnsupportedError = await determineSnapshotSupport()
@@ -463,7 +463,7 @@ extension UTMQemuVirtualMachine {
         #endif
 
         // update timestamp
-        if !isRunningAsDisposible {
+        if !isRunningAsDisposable {
             try? updateLastModified()
         }
     }
@@ -521,7 +521,7 @@ extension UTMQemuVirtualMachine {
         } else {
             try await qemuVM.stop()
         }
-        isRunningAsDisposible = false
+        isRunningAsDisposable = false
     }
     
     private func _restart() async throws {

--- a/Services/UTMSpiceVirtualMachine.swift
+++ b/Services/UTMSpiceVirtualMachine.swift
@@ -19,7 +19,7 @@ import Foundation
 /// Common methods for all SPICE virtual machines
 protocol UTMSpiceVirtualMachine: UTMVirtualMachine where Configuration == UTMQemuConfiguration {
     /// Set when VM is running with saving changes
-    var isRunningAsDisposible: Bool { get }
+    var isRunningAsDisposable: Bool { get }
     
     /// Get and set screenshot
     var screenshot: UTMVirtualMachineScreenshot? { get set }

--- a/Services/UTMVirtualMachine.swift
+++ b/Services/UTMVirtualMachine.swift
@@ -43,7 +43,7 @@ protocol UTMVirtualMachine: AnyObject, Identifiable {
     /// The VM is running in disposible mode
     ///
     /// This indicates that changes should not be saved.
-    var isRunningAsDisposible: Bool { get }
+    var isRunningAsDisposable: Bool { get }
     
     /// Set by caller to handle VM events
     var delegate: (any UTMVirtualMachineDelegate)? { get set }
@@ -169,7 +169,7 @@ protocol UTMVirtualMachineCapabilities {
     var supportsScreenshots: Bool { get }
     
     /// The backend supports running without persisting changes.
-    var supportsDisposibleMode: Bool { get }
+    var supportsDisposableMode: Bool { get }
     
     /// The backend supports booting into recoveryOS.
     var supportsRecoveryMode: Bool { get }
@@ -227,7 +227,7 @@ struct UTMVirtualMachineStartOptions: OptionSet, Codable {
     let rawValue: UInt
     
     /// Boot without persisting any changes.
-    static let bootDisposibleMode = Self(rawValue: 1 << 0)
+    static let bootDisposableMode = Self(rawValue: 1 << 0)
     /// Boot into recoveryOS (when supported).
     static let bootRecovery = Self(rawValue: 1 << 1)
     /// Start VDI session where a remote client will connect to.
@@ -345,7 +345,7 @@ extension UTMVirtualMachine {
     
     func startScreenshotTimer() -> Timer {
         // delete existing screenshot if required
-        if !isScreenshotSaveEnabled && !isRunningAsDisposible {
+        if !isScreenshotSaveEnabled && !isRunningAsDisposable {
             try? deleteScreenshot()
         }
         let timer = Timer(timeInterval: kScreenshotPeriodSeconds, repeats: true) { [weak self] timer in
@@ -371,7 +371,7 @@ extension UTMVirtualMachine {
     }
     
     func saveScreenshot() throws {
-        guard isScreenshotSaveEnabled && !isRunningAsDisposible else {
+        guard isScreenshotSaveEnabled && !isRunningAsDisposable else {
             return
         }
         guard let screenshot = screenshot else {


### PR DESCRIPTION
## Summary
Closes #7557

Fixed the spelling of `Disposible` to `Disposable` throughout the codebase.

## Changes
This PR corrects the typo in 11 files:
- Intents/UTMActionIntent.swift
- Platform/Shared/VMContextMenuModifier.swift
- Platform/iOS/VMSessionState.swift
- Platform/macOS/Display/VMDisplayQemuDisplayController.swift
- Platform/macOS/UTMMenuBarExtraScene.swift
- Remote/UTMRemoteSpiceVirtualMachine.swift
- Scripting/UTMScriptingVirtualMachineImpl.swift
- Services/UTMAppleVirtualMachine.swift
- Services/UTMQemuVirtualMachine.swift
- Services/UTMSpiceVirtualMachine.swift
- Services/UTMVirtualMachine.swift

## Note
This renames public API symbols. If backward compatibility is needed, deprecation aliases could be added.