### PR TITLE
config(qemu): add experimental Raspberry Pi support

### DIFF
--- a/Configuration/QEMUConstant.swift
+++ b/Configuration/QEMUConstant.swift
@@ -478,9 +478,24 @@ extension QEMUTarget {
         }
     }
     
+    var hasUsbSharingSupport: Bool {
+        switch self.rawValue {
+        case let x where x.hasPrefix("raspi"): return false
+        default: return true
+        }
+    }
+    
     var hasAgentSupport: Bool {
         switch self.rawValue {
         case "isapc": return false
+        case let x where x.hasPrefix("raspi"): return false
+        default: return true
+        }
+    }
+    
+    var hasUefiSupport: Bool {
+        switch self.rawValue {
+        case let x where x.hasPrefix("raspi"): return false
         default: return true
         }
     }
@@ -489,6 +504,37 @@ extension QEMUTarget {
         switch self.rawValue {
         case "microvm": return false
         default: return true
+        }
+    }
+    
+    var hasHypervisorSupport: Bool {
+        switch self.rawValue {
+        case let x where x.hasPrefix("raspi"): return false
+        default: return true
+        }
+    }
+    
+    var hasBuiltinFramebuffer: Bool {
+        switch self.rawValue {
+        case let x where x.hasPrefix("raspi"): return true
+        default: return false
+        }
+    }
+    
+    var fixedMemorySize: Int? {
+        switch self.rawValue {
+        case "raspi0", "raspi1ap", "raspi3ap": return 512
+        case "raspi2b", "raspi3b": return 1024
+        case "raspi4b": return 2048
+        default: return nil
+        }
+    }
+    
+    var fixedCPUCount: (Int, Int)? {
+        switch self.rawValue {
+        case "raspi0", "raspi1ap": return (1, 1)
+        case "raspi2b", "raspi3ap", "raspi3b", "raspi4b": return (4, 4)
+        default: return nil
         }
     }
 }

--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -264,6 +264,8 @@ import Virtualization // for getting network interfaces
                 "vgamem_mb=\(vgaRamSize)"
             }
             f()
+        } else if system.target.hasBuiltinFramebuffer {
+            // Use the board's built-in framebuffer (no arguments)
         } else {
             for display in displays {
                 if !shouldSkipDisplay(display) {
@@ -450,6 +452,9 @@ import Virtualization // for getting network interfaces
         // SPARC5 defaults to single CPU
         if isSparc {
             return singleCpu
+        }
+        if let fixedCpu = system.target.fixedCPUCount {
+            return fixedCpu
         }
         #if arch(arm64)
         let hostPcorePhysicalCpu = Int(Self.sysctlIntRead("hw.perflevel0.physicalcpu"))
@@ -951,35 +956,37 @@ import Virtualization // for getting network interfaces
             f("usb-kbd,bus=usb-bus.0")
         }
         #if WITH_USB
-        let maxDevices = input.maximumUsbShare
-        let buses = (maxDevices + 2) / 3
-        if input.usbBusSupport == .usb3_0 {
-            var controller = "qemu-xhci"
-            if isPcCompatible {
-                controller = "nec-usb-xhci"
+        if system.target.hasUsbSharingSupport {
+            let maxDevices = input.maximumUsbShare
+            let buses = (maxDevices + 2) / 3
+            if input.usbBusSupport == .usb3_0 {
+                var controller = "qemu-xhci"
+                if isPcCompatible {
+                    controller = "nec-usb-xhci"
+                }
+                for i in 0..<buses {
+                    f("-device")
+                    f("\(controller),id=usb-controller-\(i)")
+                }
+            } else {
+                for i in 0..<buses {
+                    f("-device")
+                    f("ich9-usb-ehci1,id=usb-controller-\(i)")
+                    f("-device")
+                    f("ich9-usb-uhci1,masterbus=usb-controller-\(i).0,firstport=0,multifunction=on")
+                    f("-device")
+                    f("ich9-usb-uhci2,masterbus=usb-controller-\(i).0,firstport=2,multifunction=on")
+                    f("-device")
+                    f("ich9-usb-uhci3,masterbus=usb-controller-\(i).0,firstport=4,multifunction=on")
+                }
             }
-            for i in 0..<buses {
+            // set up usb forwarding
+            for i in 0..<maxDevices {
+                f("-chardev")
+                f("spicevmc,name=usbredir,id=usbredirchardev\(i)")
                 f("-device")
-                f("\(controller),id=usb-controller-\(i)")
+                f("usb-redir,chardev=usbredirchardev\(i),id=usbredirdev\(i),bus=usb-controller-\(i/3).0")
             }
-        } else {
-            for i in 0..<buses {
-                f("-device")
-                f("ich9-usb-ehci1,id=usb-controller-\(i)")
-                f("-device")
-                f("ich9-usb-uhci1,masterbus=usb-controller-\(i).0,firstport=0,multifunction=on")
-                f("-device")
-                f("ich9-usb-uhci2,masterbus=usb-controller-\(i).0,firstport=2,multifunction=on")
-                f("-device")
-                f("ich9-usb-uhci3,masterbus=usb-controller-\(i).0,firstport=4,multifunction=on")
-            }
-        }
-        // set up usb forwarding
-        for i in 0..<maxDevices {
-            f("-chardev")
-            f("spicevmc,name=usbredir,id=usbredirchardev\(i)")
-            f("-device")
-            f("usb-redir,chardev=usbredirchardev\(i),id=usbredirdev\(i),bus=usb-controller-\(i/3).0")
         }
         #endif
     }

--- a/Configuration/UTMQemuConfiguration+Arguments.swift
+++ b/Configuration/UTMQemuConfiguration+Arguments.swift
@@ -272,6 +272,8 @@ import Virtualization // for getting network interfaces
                 "vgamem_mb=\(vgaRamSize)"
             }
             f()
+        } else if system.target.hasBuiltinFramebuffer {
+            // Use the board's built-in framebuffer (no arguments)
         } else {
             for display in displays {
                 if !shouldSkipDisplay(display) {
@@ -480,6 +482,9 @@ import Virtualization // for getting network interfaces
         // SPARC5 defaults to single CPU
         if isSparc {
             return singleCpu
+        }
+        if let fixedCpu = system.target.fixedCPUCount {
+            return fixedCpu
         }
         #if arch(arm64)
         let hostPcorePhysicalCpu = Int(Self.sysctlIntRead("hw.perflevel0.physicalcpu"))
@@ -981,35 +986,37 @@ import Virtualization // for getting network interfaces
             f("usb-kbd,bus=usb-bus.0")
         }
         #if WITH_USB
-        let maxDevices = input.maximumUsbShare
-        let buses = (maxDevices + 2) / 3
-        if input.usbBusSupport == .usb3_0 {
-            var controller = "qemu-xhci"
-            if isPcCompatible {
-                controller = "nec-usb-xhci"
+        if system.target.hasUsbSharingSupport {
+            let maxDevices = input.maximumUsbShare
+            let buses = (maxDevices + 2) / 3
+            if input.usbBusSupport == .usb3_0 {
+                var controller = "qemu-xhci"
+                if isPcCompatible {
+                    controller = "nec-usb-xhci"
+                }
+                for i in 0..<buses {
+                    f("-device")
+                    f("\(controller),id=usb-controller-\(i)")
+                }
+            } else {
+                for i in 0..<buses {
+                    f("-device")
+                    f("ich9-usb-ehci1,id=usb-controller-\(i)")
+                    f("-device")
+                    f("ich9-usb-uhci1,masterbus=usb-controller-\(i).0,firstport=0,multifunction=on")
+                    f("-device")
+                    f("ich9-usb-uhci2,masterbus=usb-controller-\(i).0,firstport=2,multifunction=on")
+                    f("-device")
+                    f("ich9-usb-uhci3,masterbus=usb-controller-\(i).0,firstport=4,multifunction=on")
+                }
             }
-            for i in 0..<buses {
+            // set up usb forwarding
+            for i in 0..<maxDevices {
+                f("-chardev")
+                f("spicevmc,name=usbredir,id=usbredirchardev\(i)")
                 f("-device")
-                f("\(controller),id=usb-controller-\(i)")
+                f("usb-redir,chardev=usbredirchardev\(i),id=usbredirdev\(i),bus=usb-controller-\(i/3).0")
             }
-        } else {
-            for i in 0..<buses {
-                f("-device")
-                f("ich9-usb-ehci1,id=usb-controller-\(i)")
-                f("-device")
-                f("ich9-usb-uhci1,masterbus=usb-controller-\(i).0,firstport=0,multifunction=on")
-                f("-device")
-                f("ich9-usb-uhci2,masterbus=usb-controller-\(i).0,firstport=2,multifunction=on")
-                f("-device")
-                f("ich9-usb-uhci3,masterbus=usb-controller-\(i).0,firstport=4,multifunction=on")
-            }
-        }
-        // set up usb forwarding
-        for i in 0..<maxDevices {
-            f("-chardev")
-            f("spicevmc,name=usbredir,id=usbredirchardev\(i)")
-            f("-device")
-            f("usb-redir,chardev=usbredirchardev\(i),id=usbredirdev\(i),bus=usb-controller-\(i/3).0")
         }
         #endif
     }

--- a/Configuration/UTMQemuConfiguration.swift
+++ b/Configuration/UTMQemuConfiguration.swift
@@ -260,6 +260,9 @@ extension UTMQemuConfiguration {
         input = .init(forArchitecture: architecture, target: target)
         sharing = .init(forArchitecture: architecture, target: target)
         system.cpu = architecture.cpuType.default
+        if let fixedMemorySize = target.fixedMemorySize {
+            system.memorySize = fixedMemorySize
+        }
         if let display = UTMQemuConfigurationDisplay(forArchitecture: architecture, target: target) {
             displays = [display]
         } else {

--- a/Configuration/UTMQemuConfigurationNetwork.swift
+++ b/Configuration/UTMQemuConfigurationNetwork.swift
@@ -180,6 +180,8 @@ extension UTMQemuConfigurationNetwork {
             hardware = QEMUNetworkDevice_ppc.sungem
         } else if architecture == .m68k && rawTarget == QEMUTarget_m68k.q800.rawValue {
             hardware = QEMUNetworkDevice_m68k.dp8393x
+        } else if rawTarget.hasPrefix("raspi") {
+            return nil
         } else {
             let cards = architecture.networkDeviceType.allRawValues
             if let first = cards.first {

--- a/Configuration/UTMQemuConfigurationQEMU.swift
+++ b/Configuration/UTMQemuConfigurationQEMU.swift
@@ -157,7 +157,7 @@ extension UTMQemuConfigurationQEMU {
             hasUefiBoot = true
             hasRNGDevice = true
         }
-        hasHypervisor = architecture.hasHypervisorSupport
+        hasHypervisor = architecture.hasHypervisorSupport && target.hasHypervisorSupport
     }
 }
 

--- a/Configuration/UTMQemuConfigurationSound.swift
+++ b/Configuration/UTMQemuConfigurationSound.swift
@@ -57,6 +57,8 @@ extension UTMQemuConfigurationSound {
             hardware = QEMUSoundDevice_ppc.screamer
         } else if architecture == .m68k && rawTarget == QEMUTarget_m68k.q800.rawValue {
             hardware = QEMUSoundDevice_m68k.asc
+        } else if rawTarget.hasPrefix("raspi") {
+            return nil
         } else {
             let cards = architecture.soundDeviceType.allRawValues
             if let first = cards.first {

--- a/Platform/Shared/VMConfigDisplayView.swift
+++ b/Platform/Shared/VMConfigDisplayView.swift
@@ -28,7 +28,16 @@ struct VMConfigDisplayView: View {
         VStack {
             Form {
                 Section(header: Text("Hardware")) {
-                    VMConfigConstantPicker("Emulated Display Card", selection: $config.hardware, type: system.architecture.displayDeviceType)
+                    if system.target.hasBuiltinFramebuffer {
+                        HStack {
+                            Text("Emulated Display Card")
+                            Spacer()
+                            Text("Built-in Framebuffer")
+                                .foregroundColor(.secondary)
+                        }
+                    } else {
+                        VMConfigConstantPicker("Emulated Display Card", selection: $config.hardware, type: system.architecture.displayDeviceType)
+                    }
                     
                     Toggle("GPU Acceleration Supported", isOn: .constant(isGLSupported)).disabled(true)
                     if isGLSupported {

--- a/Platform/Shared/VMConfigInputView.swift
+++ b/Platform/Shared/VMConfigInputView.swift
@@ -19,6 +19,7 @@ import SwiftUI
 struct VMConfigInputView: View {
     @Binding var config: UTMQemuConfigurationInput
     let hasUsbSupport: Bool
+    let hasUsbSharingSupport: Bool
 
     var body: some View {
         VStack {
@@ -29,7 +30,7 @@ struct VMConfigInputView: View {
                 }
                 
                 #if WITH_USB
-                if config.usbBusSupport != .disabled {
+                if config.usbBusSupport != .disabled && hasUsbSharingSupport {
                     Section(header: Text("USB Sharing")) {
                         if !jb_has_usb_entitlement() {
                             Text("USB sharing not supported in this build of UTM.")
@@ -101,7 +102,7 @@ struct VMConfigInputView_Previews: PreviewProvider {
     @State static private var config = UTMQemuConfigurationInput()
     
     static var previews: some View {
-        VMConfigInputView(config: $config, hasUsbSupport: true)
+        VMConfigInputView(config: $config, hasUsbSupport: true, hasUsbSharingSupport: true)
             #if os(macOS)
             .scrollable()
             #endif

--- a/Platform/Shared/VMConfigQEMUView.swift
+++ b/Platform/Shared/VMConfigQEMUView.swift
@@ -38,6 +38,7 @@ struct VMConfigQEMUView: View {
     
     private var supportsUefi: Bool {
         UTMQemuConfigurationQEMU.uefiImagePrefix(forArchitecture: system.architecture) != nil
+            && system.target.hasUefiSupport
     }
     
     private var supportsPs2: Bool {
@@ -80,7 +81,7 @@ struct VMConfigQEMUView: View {
                         }
                     Toggle("Use Hypervisor", isOn: $config.hasHypervisor)
                         .help("Only available if host architecture matches the target. Otherwise, TCG emulation is used.")
-                        .disabled(!system.architecture.hasHypervisorSupport)
+                        .disabled(!system.architecture.hasHypervisorSupport || !system.target.hasHypervisorSupport)
                     if config.hasHypervisor {
                         Toggle("Use TSO", isOn: $config.hasTSO)
                             .help("Only available when Hypervisor is used on supported hardware. TSO speeds up Intel emulation in the guest at the cost of decreased performance in general.")

--- a/Platform/Shared/VMConfigSystemView.swift
+++ b/Platform/Shared/VMConfigSystemView.swift
@@ -34,6 +34,7 @@ struct VMConfigSystemView: View {
             Form {
                 HardwareOptions(config: $config, architecture: $architecture, target: $target, warningMessage: $warningMessage)
                 RAMSlider(systemMemory: $config.memorySize, onValidate: validateMemorySize)
+                    .disabled(target.fixedMemorySize != nil)
                 Section(header: Text("CPU")) {
                     VMConfigConstantPicker(selection: $config.cpu, type: config.architecture.cpuType)
                 }
@@ -201,6 +202,9 @@ private struct HardwareOptions: View {
                 .onChange(of: config.target.rawValue) { newValue in
                     if newValue != target.rawValue {
                         target = AnyQEMUConstant(rawValue: newValue)!
+                        if let fixedMemorySize = target.fixedMemorySize {
+                            config.memorySize = fixedMemorySize
+                        }
                     }
                 }
         }

--- a/Platform/Shared/VMWizardHardwareView.swift
+++ b/Platform/Shared/VMWizardHardwareView.swift
@@ -206,6 +206,12 @@ struct VMWizardHardwareView: View {
                 
                 Section {
                     VMConfigConstantPicker(selection: $wizardState.systemTarget, type: wizardState.systemArchitecture.targetType)
+                        .onChange(of: wizardState.systemTarget.rawValue) { newValue in
+                            let target = AnyQEMUConstant(rawValue: newValue)!
+                            if let fixedMemorySize = target.fixedMemorySize {
+                                wizardState.systemMemoryMib = fixedMemorySize
+                            }
+                        }
                 } header: {
                     Text("System")
                 }
@@ -240,6 +246,7 @@ struct VMWizardHardwareView: View {
                         wizardState.systemMemoryMib = validMin
                     }
                 }
+                .disabled(wizardState.systemTarget.fixedMemorySize != nil)
             } header: {
                 Text("Memory")
             }

--- a/Platform/Shared/VMWizardOSOtherView.swift
+++ b/Platform/Shared/VMWizardOSOtherView.swift
@@ -22,6 +22,7 @@ struct VMWizardOSOtherView: View {
 
     private var supportsUefi: Bool {
         UTMQemuConfigurationQEMU.uefiImagePrefix(forArchitecture: wizardState.systemArchitecture) != nil
+            && wizardState.systemTarget.hasUefiSupport
     }
 
     var body: some View {

--- a/Platform/ar.lproj/Localizable.strings
+++ b/Platform/ar.lproj/Localizable.strings
@@ -168,6 +168,10 @@
 /* No comment provided by engineer. */
 "Build" = "بناء";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "مخزن الإطار المدمج";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "وحدة طرفية مدمجة";
 

--- a/Platform/de.lproj/Localizable.strings
+++ b/Platform/de.lproj/Localizable.strings
@@ -136,6 +136,10 @@
 /* No comment provided by engineer. */
 "Browse…" = "Durchsuchen…";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "Integrierter Framebuffer";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "Integriertes Terminal";
 

--- a/Platform/es-419.lproj/Localizable.strings
+++ b/Platform/es-419.lproj/Localizable.strings
@@ -196,6 +196,10 @@
 /* No comment provided by engineer. */
 "Browse…" = "Buscar...";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "Búfer de imagen integrado";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "Terminal incorporado";
 

--- a/Platform/fi.lproj/Localizable.strings
+++ b/Platform/fi.lproj/Localizable.strings
@@ -1323,6 +1323,10 @@
 /* Left pane. */
 "Devices" = "Laitteet";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "Sisäänrakennettu kuvapuskuri";
+
 /* Serial pane. */
 "Built-in Terminal" = "Sisäänrakennettu terminaali";
 

--- a/Platform/fr.lproj/Localizable.strings
+++ b/Platform/fr.lproj/Localizable.strings
@@ -492,6 +492,7 @@
 "Upscaling" = "Augmentation de la définition (Upscaling)";
 "Downscaling" = "Réduction de définition";
 "Retina Mode" = "Mode Retina";
+"Built-in Framebuffer" = "Tampon d’image intégré";
 
 // VMConfigDisplayConsoleView.swift
 "Style" = "Style";

--- a/Platform/iOS/VMSessionState.swift
+++ b/Platform/iOS/VMSessionState.swift
@@ -195,6 +195,10 @@ extension VMSessionState: UTMSpiceIODelegate {
     
     nonisolated func spiceDidCreateDisplay(_ display: CSDisplay) {
         Task { @MainActor in
+            guard !self.qemuConfig.system.target.hasBuiltinFramebuffer || !qemuConfig.displays.isEmpty else {
+                // A `CSDisplay` instance is created if the machine has a built-in framebuffer even if `qemuConfig.displays` is empty.
+                return
+            }
             assert(display.monitorID < qemuConfig.displays.count)
             let device = VMWindowState.Device.display(display, display.monitorID)
             devices.append(device)

--- a/Platform/iOS/VMSettingsView.swift
+++ b/Platform/iOS/VMSettingsView.swift
@@ -59,7 +59,11 @@ struct VMSettingsView: View {
                                 .labelStyle(.roundRectIcon)
                         })
                     NavigationLink(
-                        destination: VMConfigInputView(config: $config.input, hasUsbSupport: config.system.architecture.hasUsbSupport).navigationTitle("Input"),
+                        destination: VMConfigInputView(
+                            config: $config.input,
+                            hasUsbSupport: config.system.architecture.hasUsbSupport,
+                            hasUsbSharingSupport: config.system.target.hasUsbSharingSupport
+                        ).navigationTitle("Input"),
                         label: {
                             Label("Input", systemImage: "keyboard")
                                 .labelStyle(.roundRectIcon)

--- a/Platform/iOS/VMToolbarDisplayMenuView.swift
+++ b/Platform/iOS/VMToolbarDisplayMenuView.swift
@@ -38,6 +38,9 @@ struct VMToolbarDisplayMenuView: View {
                         switch device {
                         case .serial(_, let index):
                             MenuLabel("Serial \(index): \(session.qemuConfig.serials[index].target.prettyValue)", systemImage: "rectangle.connected.to.line.below").tag(device as VMWindowState.Device?)
+                        case .display(_, let index) where session.qemuConfig.system.target.hasBuiltinFramebuffer:
+                            let prettyValue = NSLocalizedString("Built-in Framebuffer", comment: "VMToolbarDisplayMenuView")
+                            MenuLabel("Display \(index): \(prettyValue)", systemImage: "display").tag(device as VMWindowState.Device?)
                         case .display(_, let index):
                             MenuLabel("Display \(index): \(session.qemuConfig.displays[index].hardware.prettyValue)", systemImage: "display").tag(device as VMWindowState.Device?)
                         }
@@ -59,6 +62,9 @@ struct VMToolbarDisplayMenuView: View {
                             switch device {
                             case .serial(_, let index):
                                 MenuLabel("Serial \(index): \(session.qemuConfig.serials[index].target.prettyValue)", systemImage: "rectangle.connected.to.line.below").tag(device as VMWindowState.Device?)
+                            case .display(_, let index) where session.qemuConfig.system.target.hasBuiltinFramebuffer:
+                                let prettyValue = NSLocalizedString("Built-in Framebuffer", comment: "VMToolbarDisplayMenuView")
+                                MenuLabel("Display \(index): \(prettyValue)", systemImage: "display").tag(device as VMWindowState.Device?)
                             case .display(_, let index):
                                 MenuLabel("Display \(index): \(session.qemuConfig.displays[index].hardware.prettyValue)", systemImage: "display").tag(device as VMWindowState.Device?)
                             }

--- a/Platform/it.lproj/Localizable.strings
+++ b/Platform/it.lproj/Localizable.strings
@@ -214,6 +214,10 @@
 /* No comment provided by engineer. */
 "Browse…" = "Scegli...";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "Framebuffer integrato";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "Terminale Integrato";
 

--- a/Platform/ja.lproj/Localizable.strings
+++ b/Platform/ja.lproj/Localizable.strings
@@ -605,6 +605,7 @@
 "Upscaling" = "拡大";
 "Downscaling" = "縮小";
 "Retina Mode" = "Retinaモード";
+"Built-in Framebuffer" = "内蔵フレームバッファ";
 
 // VMConfigDisplayConsoleView.swift
 "Style" = "スタイル";

--- a/Platform/ko.lproj/Localizable.strings
+++ b/Platform/ko.lproj/Localizable.strings
@@ -605,6 +605,7 @@
 "Upscaling" = "확대";
 "Downscaling" = "축소";
 "Retina Mode" = "레티나 모드";
+"Built-in Framebuffer" = "내장 프레임버퍼";
 
 // VMConfigDisplayConsoleView.swift
 "Style" = "스타일";

--- a/Platform/macOS/VMQEMUSettingsView.swift
+++ b/Platform/macOS/VMQEMUSettingsView.swift
@@ -59,9 +59,13 @@ struct VMQEMUSettingsView: View {
             }
         }
         NavigationLink {
-            VMConfigInputView(config: $config.input, hasUsbSupport: config.system.architecture.hasUsbSupport)
-                .scrollable()
-                .settingsToolbar()
+            VMConfigInputView(
+                config: $config.input,
+                hasUsbSupport: config.system.architecture.hasUsbSupport,
+                hasUsbSharingSupport: config.system.target.hasUsbSharingSupport
+            )
+            .scrollable()
+            .settingsToolbar()
         } label: {
             Label("Input", systemImage: "keyboard")
         }

--- a/Platform/pl.lproj/Localizable.strings
+++ b/Platform/pl.lproj/Localizable.strings
@@ -584,6 +584,7 @@
 "Upscaling" = "Skalowanie do wyższej rozdzielczości (Upscaling)";
 "Downscaling" = "Skalowanie do niższej rozdzielczości (Downscaling)";
 "Retina Mode" = "Tryb Retina";
+"Built-in Framebuffer" = "Wbudowany bufor ramki";
 
 /* VMConfigDisplayConsoleView.swift */
 "Style" = "Styl";

--- a/Platform/ru.lproj/Localizable.strings
+++ b/Platform/ru.lproj/Localizable.strings
@@ -199,6 +199,10 @@
 /* No comment provided by engineer. */
 "Browse…" = "Обзор…";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "Встроенный буфер кадра";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "Встроенный терминал";
 

--- a/Platform/zh-HK.lproj/Localizable.strings
+++ b/Platform/zh-HK.lproj/Localizable.strings
@@ -200,6 +200,10 @@ UTMQemuConstants */
 /* No comment provided by engineer. */
 "Build" = "構建";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "內建幀緩衝區";
+
 /* UTMAppleConfigurationTerminal
 UTMQemuConstants */
 "Built-in Terminal" = "內置終端機";

--- a/Platform/zh-HK.lproj/Localizable.strings
+++ b/Platform/zh-HK.lproj/Localizable.strings
@@ -203,6 +203,10 @@ UTMQemuConstants */
 /* No comment provided by engineer. */
 "Build" = "構建";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "內建幀緩衝區";
+
 /* UTMAppleConfigurationTerminal
 UTMQemuConstants */
 "Built-in Terminal" = "內置終端機";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -200,6 +200,10 @@ UTMQemuConstants */
 /* No comment provided by engineer. */
 "Build" = "构建版本";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "内置帧缓冲区";
+
 /* UTMAppleConfigurationTerminal
 UTMQemuConstants */
 "Built-in Terminal" = "内置终端";

--- a/Platform/zh-Hans.lproj/Localizable.strings
+++ b/Platform/zh-Hans.lproj/Localizable.strings
@@ -203,6 +203,10 @@ UTMQemuConstants */
 /* No comment provided by engineer. */
 "Build" = "构建版本";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "内置帧缓冲区";
+
 /* UTMAppleConfigurationTerminal
 UTMQemuConstants */
 "Built-in Terminal" = "内置终端";

--- a/Platform/zh-Hant.lproj/Localizable.strings
+++ b/Platform/zh-Hant.lproj/Localizable.strings
@@ -255,6 +255,10 @@
 /* No comment provided by engineer. */
 "Build" = "建置";
 
+/* VMConfigDisplayView
+VMToolbarDisplayMenuView */
+"Built-in Framebuffer" = "內建幀緩衝區";
+
 /* UTMQemuConstants */
 "Built-in Terminal" = "內建終端機";
 


### PR DESCRIPTION
closes #4827, closes #2574

I added experimental Raspberry Pi support to UTM. Localization strings are translated by an LLM, so they may contain mistranslations.

Changes:

- Added support for using the Raspberry Pi board's built-in framebuffer as a display
- Removed default PCI devices from `raspi*` machines by default to avoid crashes
- Added support for each machine constrained to fixed-size memory to avoid crashes

Test:

I verified that my hobby OS for Raspberry Pi 4 could boot with `raspi4b`.

https://github.com/utmapp/UTM/issues/4827#issuecomment-3830843385

Known issues, likely existing issues caused by a race condition in UTM event handling:

- (iOS) The initial framebuffer contents randomly fail to appear. (likely because the first frame is rendered before the GL context is fully initialized)
- (iOS) Serial output generated before the GUI terminal is opened is not displayed.
- (macOS) Serial output is not displayed if one or more display devices are attached.