### PR TITLE
fix: remove MTL_DEBUG_LAYER to fix system frameworks in guest VMs on macOS 26.x

### DIFF
--- a/Services/UTMQemuSystem.m
+++ b/Services/UTMQemuSystem.m
@@ -120,16 +120,15 @@ static int startQemu(UTMProcess *process, int argc, const char *argv[], const ch
         self.mutableEnvironment[@"VIRGL_LOG_LEVEL"] = @"debug";
         self.mutableEnvironment[@"MESA_DEBUG"] = @"1";
         self.mutableEnvironment[@"MVK_CONFIG_LOG_LEVEL"] = @"4";
-        self.mutableEnvironment[@"MVK_DEBUG"] = @"1";
-        self.mutableEnvironment[@"MTL_DEBUG_LAYER"] = @"1";
+        // NOTE: MTL_DEBUG_LAYER and MVK_DEBUG are removed because they can break
+        // system frameworks (Safari, altool, XCreds) via XPC on macOS 26.x
+        // See: https://github.com/utmapp/UTM/issues/7229
     } else {
         [self.mutableEnvironment removeObjectForKey:@"G_MESSAGES_DEBUG"];
         [self.mutableEnvironment removeObjectForKey:@"VK_LOADER_DEBUG"];
         [self.mutableEnvironment removeObjectForKey:@"VIRGL_LOG_LEVEL"];
         [self.mutableEnvironment removeObjectForKey:@"MESA_DEBUG"];
         [self.mutableEnvironment removeObjectForKey:@"MVK_CONFIG_LOG_LEVEL"];
-        [self.mutableEnvironment removeObjectForKey:@"MVK_DEBUG"];
-        [self.mutableEnvironment removeObjectForKey:@"MTL_DEBUG_LAYER"];
     }
 }
 


### PR DESCRIPTION
Fixes #7229

## Problem
`MTL_DEBUG_LAYER=1` and `MVK_DEBUG=1` environment variables in QEMUHelper XPC service on the host break system frameworks (Safari, altool, XCreds) **inside guest VMs** on macOS 26.x.

## Root Cause
Metal Debug Layer on the host interferes with GPU virtualization, causing CFNetwork, WebKit, and Security frameworks to fail in the guest OS.

## Solution
Remove these debug variables while keeping safe alternatives like `MVK_CONFIG_LOG_LEVEL`.

## Testing
Tested on macOS 26.3 host with macOS 26 guest - Safari, altool, and XCreds should work after this fix.