### PR TITLE
ci: make Xcode path configurable via HOST_XCODE_PATH variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ on:
         default: 'false'
 
 env:
-  BUILD_XCODE_PATH: /Applications/Xcode_26.0.app
+  BUILD_XCODE_PATH: ${{ vars.HOST_XCODE_PATH || '/Applications/Xcode_26.0.app' }}
   RUNNER_IMAGE: macos-15
   SEGMENT_DOWNLOAD_TIMEOUT_MINS: 60
 


### PR DESCRIPTION
The hardcoded path /Applications/Xcode_26.0.app works fine for the today self-hosted runner, another one may have Xcode installed at a different path.
By using vars.HOST_XCODE_PATH, you can update the path via the GitHub repo's Settings → Variables without touching the workflow file or making a new commit.