### PR TITLE
fix(ui): prevent crash when window size is zero

### DIFF
--- a/Platform/macOS/Display/Base.lproj/VMDisplayWindow.xib
+++ b/Platform/macOS/Display/Base.lproj/VMDisplayWindow.xib
@@ -33,7 +33,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="UTM" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" toolbarStyle="compact" id="QvC-M9-y7g">
+        <window title="UTM" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" toolbarStyle="compact" id="QvC-M9-y7g" customClass="VMDisplayWindow" customModule="UTM" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/Platform/macOS/Display/VMDisplayWindow.swift
+++ b/Platform/macOS/Display/VMDisplayWindow.swift
@@ -1,0 +1,67 @@
+//
+// Copyright © 2026 osy. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import AppKit
+import Logging
+
+class VMDisplayWindow: NSWindow {
+    // Minimum window size to prevent UI issues and crashes
+    // Issue #7650: Setting bounds to {0, 0, 0, 0} causes crash.
+    // We enforce a safe minimum size to prevent layout engines from failing.
+    private let kMinWindowWidth: CGFloat = 400
+    private let kMinWindowHeight: CGFloat = 300
+    
+    private func sanitizeFrame(_ frameRect: NSRect) -> NSRect {
+        var frame = frameRect
+        
+        // Check for invalid or too small dimensions
+        if frame.size.width < kMinWindowWidth {
+            // Log warning only if it's significantly invalid (e.g. 0 or negative)
+            if frame.size.width <= 0 {
+                logger.warning("Attempted to set invalid window width: \(frame.size.width). Clamping to \(kMinWindowWidth).")
+            }
+            frame.size.width = kMinWindowWidth
+        }
+        
+        if frame.size.height < kMinWindowHeight {
+             if frame.size.height <= 0 {
+                logger.warning("Attempted to set invalid window height: \(frame.size.height). Clamping to \(kMinWindowHeight).")
+            }
+            frame.size.height = kMinWindowHeight
+        }
+        
+        return frame
+    }
+
+    override func setFrame(_ frameRect: NSRect, display flag: Bool) {
+        let validFrame = sanitizeFrame(frameRect)
+        super.setFrame(validFrame, display: flag)
+    }
+    
+    override func setFrame(_ frameRect: NSRect, display displayFlag: Bool, animate animateFlag: Bool) {
+        let validFrame = sanitizeFrame(frameRect)
+        super.setFrame(validFrame, display: displayFlag, animate: animateFlag)
+    }
+    
+    override var minSize: NSSize {
+        get {
+            return NSSize(width: kMinWindowWidth, height: kMinWindowHeight)
+        }
+        set {
+            super.minSize = newValue
+        }
+    }
+}


### PR DESCRIPTION
### Description
This PR addresses a critical issue reported in #7650 where setting a VM window's bounds to `{0, 0, 0, 0}` (e.g., via AppleScript or automation) causes the application to crash. This crash would forcefully terminate all running virtual machines, potentially leading to data loss.

The root cause was that the standard `NSWindow` allows setting a zero frame size, which subsequently causes failures in the layout or rendering pipeline (e.g., coordinate calculations resulting in NaN or division by zero).

### Changes
*   **New File**: `Platform/macOS/Display/VMDisplayWindow.swift`
    *   Implemented a custom `NSWindow` subclass named `VMDisplayWindow`.
    *   Added `sanitizeFrame(_:)` logic to enforce a minimum safe window size (400x300) and prevent invalid dimensions (width/height <= 0).
    *   Overrode `setFrame` methods to intercept all resize attempts and apply sanitized bounds.
    *   Added logging to warn developers/users when invalid window bounds are attempted.
*   **Modified**: `Platform/macOS/Display/Base.lproj/VMDisplayWindow.xib`
    *   Updated the window class from `NSWindow` to the custom `VMDisplayWindow` to activate the safe resizing logic.

### Testing Instructions
1.  Launch UTM and start a virtual machine.
2.  Open **Script Editor.app** and run the following AppleScript (replace `"vmname"` with your VM's window title):
    ```applescript
    tell application "UTM"
        set bounds of window "vmname" to {0, 0, 0, 0}
    end tell
    ```
3.  **Expected Result**:
    *   The app **does not crash**.
    *   The VM window resizes to the minimum allowed size (400x300).
    *   A warning is logged in the console: `"Attempted to set invalid window width..."`.

### Related Issue
Fixes #7650