### PR TITLE
Disable slide to delete on iOS

### DIFF
--- a/Platform/Shared/VMNavigationListView.swift
+++ b/Platform/Shared/VMNavigationListView.swift
@@ -67,8 +67,11 @@ struct VMNavigationListView: View {
                 }
             }
         }.onMove(perform: move)
+        
+        #if !os(iOS) // Disable slide to delete on iOS
         #if !WITH_REMOTE // FIXME: implement remote feature
         .onDelete(perform: delete)
+        #endif
         #endif
 
         if data.pendingVMs.count > 0 {


### PR DESCRIPTION
It is easy to slide to delete a VM on iOS and no confirmation is provided, so this has been removed via an ifdef for iOS. VMs can still be deleted by holding down on the name for the context menu and pressing "Delete", which provides an appropriate deletion confirmation.

Resolves https://github.com/utmapp/UTM/issues/3086