### PR TITLE
Apple: fix coreaudiod CPU spike and mic loss by using single virtio-sound device

### DIFF
--- a/Configuration/UTMAppleConfigurationVirtualization.swift
+++ b/Configuration/UTMAppleConfigurationVirtualization.swift
@@ -142,15 +142,13 @@ extension UTMAppleConfigurationVirtualization {
         }
         if #available(macOS 12, *) {
             if hasAudio {
-                let audioInputConfiguration = VZVirtioSoundDeviceConfiguration()
+                let audioConfiguration = VZVirtioSoundDeviceConfiguration()
                 let audioInput = VZVirtioSoundDeviceInputStreamConfiguration()
                 audioInput.source = VZHostAudioInputStreamSource()
-                audioInputConfiguration.streams = [audioInput]
-                let audioOutputConfiguration = VZVirtioSoundDeviceConfiguration()
                 let audioOutput = VZVirtioSoundDeviceOutputStreamConfiguration()
                 audioOutput.sink = VZHostAudioOutputStreamSink()
-                audioOutputConfiguration.streams = [audioOutput]
-                vzconfig.audioDevices = [audioInputConfiguration, audioOutputConfiguration]
+                audioConfiguration.streams = [audioInput, audioOutput]
+                vzconfig.audioDevices = [audioConfiguration]
             }
             if keyboard != .disabled {
                 vzconfig.keyboards = [VZUSBKeyboardConfiguration()]


### PR DESCRIPTION
**Problem:** The current implementation treats the VM's microphone and speakers as two separate audio devices, which forces macOS to constantly sync two independent timing rhythms, which causes CPU >100% and eventually jamms the microphone. Temporary fix was to manually kill `coreaudiod` in terminal

**Solution:** Use a single VZVirtioSoundDeviceConfiguration for Apple VM audio. Combine microphone and speakers into one device with one rhythm, so macOS has nothing to sync, CPU drops back to normal, and the microphone stays available. 

**Tested on:** macOS 26.4.1 M1 Max running VM of macOS 26.4.1