### PR TITLE
Fix duplicate VM entries in sidebar and prevent data loss

### DIFF
--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -158,10 +158,10 @@ enum AlertItem: Identifiable {
         }
         // now look for and add new VMs in default storage
         do {
-            let files = try fileManager.contentsOfDirectory(at: UTMData.defaultStorageUrl, includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles)
+            let files = try fileManager.contentsOfDirectory(at: UTMData.defaultStorageUrl, includingPropertiesForKeys: [.isDirectoryKey, .fileResourceIdentifierKey], options: .skipsHiddenFiles)
             let newFiles = files.filter { newFile in
                 !list.contains { existingVM in
-                    existingVM.pathUrl.standardizedFileURL == newFile.standardizedFileURL
+                    Self.isSameFile(existingVM.pathUrl, as: newFile)
                 }
             }
             for file in newFiles {
@@ -498,12 +498,20 @@ enum AlertItem: Identifiable {
     /// - Returns: Index of item removed in VM list or nil if not in list
     @discardableResult func delete(vm: VMData, alsoRegistry: Bool = true) async throws -> Int? {
         if vm.isLoaded {
-            try fileManager.removeItem(at: vm.pathUrl)
+            let pathToDelete = vm.pathUrl
+            let otherReferencesExist = virtualMachines.contains { other in
+                other !== vm && Self.isSameFile(other.pathUrl, as: pathToDelete)
+            }
+            if otherReferencesExist {
+                logger.warning("Skipping file deletion: another VM entry references the same path")
+            } else {
+                try fileManager.removeItem(at: pathToDelete)
+            }
         }
-        
+
         // close any open window
         close(vm: vm)
-        
+
         if alsoRegistry, let registryEntry = vm.registryEntry {
             UTMRegistry.shared.remove(entry: registryEntry)
         }
@@ -660,7 +668,7 @@ enum AlertItem: Identifiable {
         let fileName = url.lastPathComponent
         let dest = documentsURL.appendingPathComponent(fileName, isDirectory: true)
         if let vm = virtualMachines.first(where: { vm -> Bool in
-            return vm.pathUrl.standardizedFileURL == url.standardizedFileURL
+            return Self.isSameFile(vm.pathUrl, as: url)
         }) {
             logger.info("found existing vm!")
             if !vm.isLoaded {
@@ -976,6 +984,18 @@ enum AlertItem: Identifiable {
             return
         }
         vm.changeUuid(to: UUID(), name: nil, copyingEntry: vm.registryEntry)
+    }
+
+    // MARK: - File identity
+
+    /// Compare two file URLs by filesystem identity (inode/device), falling back to canonical path comparison.
+    /// This avoids false negatives from bookmark-resolved URLs differing from filesystem-enumerated URLs.
+    nonisolated static func isSameFile(_ url1: URL, as url2: URL) -> Bool {
+        if let id1 = try? url1.resourceValues(forKeys: [.fileResourceIdentifierKey]).fileResourceIdentifier,
+           let id2 = try? url2.resourceValues(forKeys: [.fileResourceIdentifierKey]).fileResourceIdentifier {
+            return id1.isEqual(id2)
+        }
+        return url1.resolvingSymlinksInPath().path == url2.resolvingSymlinksInPath().path
     }
 
     // MARK: - Change listener

--- a/Platform/VMData.swift
+++ b/Platform/VMData.swift
@@ -276,10 +276,16 @@ extension VMData: Identifiable {
 extension VMData: Equatable {
     static func == (lhs: VMData, rhs: VMData) -> Bool {
         if lhs.isLoaded && rhs.isLoaded {
-            return lhs.wrapped === rhs.wrapped
+            if lhs.wrapped === rhs.wrapped {
+                return true
+            }
+            return UTMData.isSameFile(lhs.pathUrl, as: rhs.pathUrl)
         }
         if let lhsEntry = lhs.registryEntryWrapped, let rhsEntry = rhs.registryEntryWrapped {
             return lhsEntry == rhsEntry
+        }
+        if lhs.isLoaded || rhs.isLoaded {
+            return UTMData.isSameFile(lhs.pathUrl, as: rhs.pathUrl)
         }
         return false
     }
@@ -287,9 +293,7 @@ extension VMData: Equatable {
 
 extension VMData: Hashable {
     func hash(into hasher: inout Hasher) {
-        hasher.combine(pathUrl)
-        hasher.combine(registryEntryWrapped)
-        hasher.combine(isDeleted)
+        hasher.combine(pathUrl.resolvingSymlinksInPath().path)
     }
 }
 


### PR DESCRIPTION
## Summary

- Fix path comparison in `listRefresh()` to use filesystem identity (`fileResourceIdentifier`) instead of `standardizedFileURL` string comparison, preventing duplicate VM entries when security-scoped bookmark resolution returns a different URL form than `FileManager.contentsOfDirectory`
- Fix `VMData` equality operator to detect duplicates pointing to the same file on disk, even across different object instances
- Add safety check in `delete()` to skip file removal when another VM entry references the same `.utm` bundle, preventing data loss

## Context

On macOS 26.x, security-scoped bookmark resolution can produce URLs with different path forms (e.g., `/System/Volumes/Data/...` vs the regular mount point). This causes `listRefresh()` to fail to recognize an already-loaded VM when scanning the filesystem, creating a second entry for the same `.utm` file. When users delete what appears to be a "ghost" duplicate, the actual file is destroyed, breaking the remaining entry.

Full root cause analysis: https://github.com/utmapp/UTM/issues/7533#issuecomment-4326459068

Fixes #7533

## Test plan

- [ ] Verify VMs in the default storage directory appear exactly once in the sidebar
- [ ] Verify that after a bookmark-resolved URL differs from the filesystem path (can be tested by creating a symlink scenario), no duplicate appears
- [ ] Verify deleting a VM still removes the file when no duplicate references exist
- [ ] Verify that if a duplicate somehow exists, deleting one entry removes only the list entry, not the file

🤖 Generated with [Claude Code](https://claude.ai/claude-code)