### PR TITLE
fix: prevent crash from force unwrap in UTMRegistry and memory leak in UTMAppleVirtualMachine

### DIFF
--- a/Services/UTMAppleVirtualMachine.swift
+++ b/Services/UTMAppleVirtualMachine.swift
@@ -582,6 +582,8 @@ final class UTMAppleVirtualMachine: UTMVirtualMachine {
             throw UTMAppleVirtualMachineError.operatingSystemInstallNotSupported
             #endif
         } catch {
+            progressObserver = nil
+            installProgress = nil
             await stopAccesingResources()
             delegate?.virtualMachine(self, didCompleteInstallation: false)
             state = .stopped

--- a/Services/UTMRegistry.swift
+++ b/Services/UTMRegistry.swift
@@ -37,8 +37,9 @@ class UTMRegistry: NSObject {
     @Published private var entries: [String: UTMRegistryEntry] {
         didSet {
             let toAdd = entries.keys.filter({ !changeListeners.keys.contains($0) })
-            for key in toAdd {
-                let entry = entries[key]!
+                .compactMap { entries[$0] }
+            for entry in toAdd {
+                let key = entry.uuid.uuidString
                 changeListeners[key] = entry.objectWillChange
                     .debounce(for: .seconds(1), scheduler: DispatchQueue.global(qos: .utility))
                     .sink { [weak self, weak entry] in
@@ -122,8 +123,7 @@ class UTMRegistry: NSObject {
     /// - Parameter entries: All entries to commit
     private func commitAll(entries: [String: UTMRegistryEntry]) {
         var newSerializedEntries: [String: Any] = [:]
-        for key in entries.keys {
-            let entry = entries[key]!
+        for entry in entries.values {
             commit(entry: entry, to: &newSerializedEntries)
         }
         serializedEntries = newSerializedEntries


### PR DESCRIPTION
## Fix 1: Prevent crash from force unwrap in UTMRegistry

Replace unsafe force unwraps with compactMap and direct value iteration to prevent crashes during concurrent registry access.

- **Line 41**: Use `compactMap` instead of `entries[key]!` in the `didSet` observer
- **Line 126**: Iterate `entries.values` instead of force-unwrapping by key in `commitAll()`

This prevents potential crashes when registry entries are modified concurrently during debounce callbacks, which could occur when users rapidly create/delete VMs.

## Fix 2: Memory leak in UTMAppleVirtualMachine when installation fails

Clear `progressObserver` and `installProgress` in the error path of `installVM()` to break the retain cycle caused by the KVO observation closure capturing `self` strongly.

Without this fix, failed macOS installations cause the VM instance to be retained in memory until the next successful installation or app termination.

## Testing
Both fixes were verified by successful builds.