### PR TITLE
Expose VLAN guest/DHCP addresses on AppleScript network settings

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -527,6 +527,21 @@
             description="Only used in emulated mode. Allows port forwarding from guest to host.">
             <type type="qemu port forward" list="yes"/>
           </property>
+
+          <property name="vlan guest address" code="VgAd" type="text"
+            description="IPv4 subnet of the emulated VLAN in CIDR notation (e.g. 192.168.222.0/24). Only used in shared or host mode. If empty, the existing value is preserved."/>
+
+          <property name="vlan guest address ipv6" code="Vga6" type="text"
+            description="IPv6 prefix of the emulated VLAN (e.g. fec0::/64). Only used in shared or host mode. If empty, the existing value is preserved."/>
+
+          <property name="vlan dhcp start address" code="VdSt" type="text"
+            description="First IPv4 address of the DHCP pool handed to the guest. Only used in shared or host mode. If empty, the existing value is preserved."/>
+
+          <property name="vlan dhcp end address" code="VdEn" type="text"
+            description="Last IPv4 address of the DHCP pool handed to the guest. Only used in shared or host mode. If empty, the existing value is preserved."/>
+
+          <property name="isolate from host" code="IsFh" type="boolean"
+            description="When true, the guest is isolated from the host on the shared network."/>
         </record-type>
         
         <enumeration name="qemu network mode" code="QeNm" description="Mode for networking device.">

--- a/Scripting/UTMScriptingConfigImpl.swift
+++ b/Scripting/UTMScriptingConfigImpl.swift
@@ -154,6 +154,11 @@ extension UTMScriptingConfigImpl {
             "address": config.macAddress,
             "hostInterface": config.bridgeInterface ?? "",
             "portForwards": config.portForward.map({ serializeQemuPortForward($0) }),
+            "vlanGuestAddress": config.vlanGuestAddress ?? "",
+            "vlanGuestAddressIpv6": config.vlanGuestAddressIPv6 ?? "",
+            "vlanDhcpStartAddress": config.vlanDhcpStartAddress ?? "",
+            "vlanDhcpEndAddress": config.vlanDhcpEndAddress ?? "",
+            "isolateFromHost": config.isIsolateFromHost,
         ]
     }
     
@@ -486,6 +491,21 @@ extension UTMScriptingConfigImpl {
         }
         if let portForwards = record["portForwards"] as? [[AnyHashable : Any]] {
             network.portForward = portForwards.map({ unserializeQemuPortForward(from: $0) })
+        }
+        if let value = record["vlanGuestAddress"] as? String, !value.isEmpty {
+            network.vlanGuestAddress = value
+        }
+        if let value = record["vlanGuestAddressIpv6"] as? String, !value.isEmpty {
+            network.vlanGuestAddressIPv6 = value
+        }
+        if let value = record["vlanDhcpStartAddress"] as? String, !value.isEmpty {
+            network.vlanDhcpStartAddress = value
+        }
+        if let value = record["vlanDhcpEndAddress"] as? String, !value.isEmpty {
+            network.vlanDhcpEndAddress = value
+        }
+        if let value = record["isolateFromHost"] as? Bool {
+            network.isIsolateFromHost = value
         }
     }
     


### PR DESCRIPTION
This PR exposes some additional fields to AppleScript, so those values can be set by scripts like the vagrant utm plugin (https://github.com/naveenrajm7/vagrant_utm). This would help with the issue https://github.com/utmapp/UTM/issues/3294 that currently requires setting those values manually through the UTM.app setting pane.