### PR TITLE
Add an AppleScript command to reload machine configuration from disk

### DIFF
--- a/Scripting/UTM.sdef
+++ b/Scripting/UTM.sdef
@@ -397,8 +397,12 @@
             <responds-to command="update configuration">
               <cocoa method="updateConfiguration:"/>
             </responds-to>
+
+            <responds-to command="reload configuration">
+              <cocoa method="reloadConfiguration:"/>
+            </responds-to>
         </class-extension>
-        
+
         <command name="update configuration" code="UTMcUpDt" description="Update the configuration of the virtual machine. The VM must be in the stopped state.">
           <direct-parameter description="Virtual machine to configure." type="virtual machine"/>
           <parameter name="with" code="UpCf" description="The configuration to update the virtual machine. You cannot change the backend with this!">
@@ -406,6 +410,10 @@
             <type type="qemu configuration"/>
             <type type="apple configuration"/>
           </parameter>
+        </command>
+
+        <command name="reload configuration" code="UTMcReLd" description="Reload the configuration of the virtual machine from disk, discarding any unsaved in-memory changes. Useful when the .utm bundle has been modified externally (e.g. by an automation tool) and UTM's cached configuration needs to be refreshed. The VM must be in the stopped state.">
+          <direct-parameter description="Virtual machine to reload." type="virtual machine"/>
         </command>
 
         <record-type name="qemu configuration" code="QeCf" description="QEMU virtual machine configuration.">

--- a/Scripting/UTMScriptingVirtualMachineImpl.swift
+++ b/Scripting/UTMScriptingVirtualMachineImpl.swift
@@ -183,6 +183,15 @@ class UTMScriptingVirtualMachineImpl: NSObject, UTMScriptable {
             try await data.delete(vm: box, alsoRegistry: true)
         }
     }
+
+    @objc func reloadConfiguration(_ command: NSScriptCommand) {
+        withScriptCommand(command) { [self] in
+            guard vm.state == .stopped else {
+                throw ScriptingError.notStopped
+            }
+            try data.discardChanges(for: box)
+        }
+    }
     
     @objc func clone(_ command: NSCloneCommand) {
         let properties = command.evaluatedArguments?["WithProperties"] as? [AnyHashable : Any]


### PR DESCRIPTION
In some scripting scenarios, we would like to change the config.plist file, advanced config editing that would be too difficult to run with normal AppleScript configuration commands. However, editing the file on disk doesn't make UTM use it because it only re-reads it from disk in some specific situations (like machine settings -> cancel).

This adds an AppleScript `reload configuration` command to make UTM re-read the configuration from disk, and thus incorporate any change that would have been made there.