### PR TITLE
ui: use cable.connector SF Symbol for USB toolbar item

### DIFF
--- a/Platform/iOS/VMToolbarUSBMenuView.swift
+++ b/Platform/iOS/VMToolbarUSBMenuView.swift
@@ -41,6 +41,10 @@ struct VMToolbarUSBMenuView: View {
         } label: {
             if session.isUsbBusy {
                 Spinner(size: .regular)
+            } else if #available(iOS 15, macOS 12, visionOS 1, *) {
+                // cable.connector ships in SF Symbols 3, so it matches the
+                // stroke weight and sizing of the surrounding toolbar items.
+                Label("USB", systemImage: "cable.connector")
             } else {
                 Label("USB", image: "Toolbar USB")
             }

--- a/Platform/macOS/Display/VMDisplayWindowController.swift
+++ b/Platform/macOS/Display/VMDisplayWindowController.swift
@@ -220,14 +220,26 @@ class VMDisplayWindowController: NSWindowController, UTMVirtualMachineDelegate {
         window!.recalculateKeyViewLoop()
         setupStopButtonMenu()
         setupMainMenu()
+        setupToolbarIcons()
 
         if vm.state == .stopped {
             enterSuspended(isBusy: false)
         } else {
             enterLive()
         }
-        
+
         super.windowDidLoad()
+    }
+
+    private func setupToolbarIcons() {
+        // cable.connector ships in SF Symbols 3 (macOS 12+); use it so the
+        // USB toolbar item visually matches the surrounding system symbols.
+        // Older systems fall back to the bundled "Toolbar USB" template
+        // image from the nib.
+        if #available(macOS 12, *) {
+            usbToolbarItem.image = NSImage(systemSymbolName: "cable.connector",
+                                           accessibilityDescription: usbToolbarItem.label)
+        }
     }
     
     public func requestAutoStart(options: UTMVirtualMachineStartOptions = []) {


### PR DESCRIPTION
## Summary

The USB toolbar item was the only icon in the VM session window using a bundled bitmap (`Toolbar USB.imageset`) instead of an SF Symbol. Its stroke weight and overall sizing visibly differed from the surrounding system symbols (`cursorarrow.rays`, `arrow.up.left.and.arrow.down.right`, `opticaldisc`, `folder.badge.person.crop`, `rectangle.on.rectangle`, …). The mismatch is especially noticeable on the floating capsule toolbar introduced in macOS 26 (Tahoe), where the lighter USB stroke sticks out next to its neighbours.

<img width="1020" height="198" alt="usb-icon-before-after" src="https://github.com/user-attachments/assets/f5d31a82-69f7-47bf-b98d-8131f1342b9e" />
*(Before / After comparison)*

## Changes

* `Platform/macOS/Display/VMDisplayWindowController.swift` — override `usbToolbarItem.image` with `NSImage(systemSymbolName: "cable.connector", …)` on macOS 12+ inside a new `setupToolbarIcons()` helper called from `windowDidLoad`. Older macOS releases (macOS 11.3) keep using the bundled template image from the nib.
* `Platform/iOS/VMToolbarUSBMenuView.swift` — use `Label("USB", systemImage: "cable.connector")` on iOS 15 / macOS 12 / visionOS 1 or later. Older releases (iOS 14) still fall back to `Label("USB", image: "Toolbar USB")`.

`cable.connector` was introduced in SF Symbols 3, so the symbol path covers every deployment target down to the documented minimum and the bundled `Toolbar USB` PNG only renders on iOS 14 / macOS 11.3.

## Testing

**Testing:** Tested by a human on **MacBook Pro M1 Max, macOS 26.5 (Tahoe)**. The author acknowledges that this change has been tested and/or reviewed by a human in accordance with UTM's AI contribution guidelines.

### Verified

- [x] USB toolbar item now matches the stroke weight and visual size of the adjacent SF Symbols (`cursorarrow.rays`, `arrow.up.left.and.arrow.down.right`, `opticaldisc`, `folder.badge.person.crop`, `rectangle.on.rectangle`) in the floating capsule toolbar on macOS 26 Tahoe — see the Before / After comparison above.

### Not verified (out of scope for this change)

- Live USB device connect / disconnect through the menu — the local development build is unsigned and lacks the Hypervisor / SPICE entitlements required to actually start a guest, so the VM session itself could not be exercised. The change only swaps the `image` on the existing `usbToolbarItem` / SwiftUI `Label`; no IBAction, target, menu, or `enterSuspended` wiring is touched, so functional behaviour should be unaffected.
- macOS 11.3 host — I do not have that system available; the fallback path keeps the existing `Toolbar USB` template image from the nib, so behaviour on that release should be identical to before.
- iOS / iPadOS / visionOS — not built locally. The SwiftUI change is gated by `#available(iOS 15, macOS 12, visionOS 1, *)` and falls back to the same bundled image on iOS 14.

## Notes

Code is AI-assisted. The commit carries `Assisted-by: Claude:claude-opus-4-7` per UTM's attribution policy.

I have read the AI contribution guidelines and have followed them to the best of my ability.
