### PR TITLE
Fix README links to MacStadium opensource

### DIFF
--- a/README.bn.md
+++ b/README.bn.md
@@ -71,7 +71,7 @@ Some icons made by [Freepik](https://www.freepik.com)  [www.flaticon.com](https:
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-কন্টিনিউয়াস ইন্টিগ্রেশন হোস্টিং টি [MacStadium](https://www.macstadium.com/opensource) প্রোভাইড করছে 
+কন্টিনিউয়াস ইন্টিগ্রেশন হোস্টিং টি [MacStadium](https://macstadium.com/company/opensource) প্রোভাইড করছে 
 
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)

--- a/README.cz.md
+++ b/README.cz.md
@@ -69,7 +69,7 @@ Frontend UTM navíc využívá následující komponenty pod licencí MIT/BSD:
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-Kontinuální hostování integrace zajišťuje [MacStadium](https://www.macstadium.com/opensource).
+Kontinuální hostování integrace zajišťuje [MacStadium](https://macstadium.com/company/opensource).
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="Logo de MacStadium" width="250">](https://www.macstadium.com)
 

--- a/README.de.md
+++ b/README.de.md
@@ -68,7 +68,7 @@ Zusätzlich verwendet das UTM-Frontend die folgenden Komponenten unter der MIT-/
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-Das Hosting für kontinuierliche Integration wird bereitgestellt von [MacStadium](https://www.macstadium.com/opensource)
+Das Hosting für kontinuierliche Integration wird bereitgestellt von [MacStadium](https://macstadium.com/company/opensource)
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.es.md
+++ b/README.es.md
@@ -68,7 +68,7 @@ Adicionalmente, el frontend de UTM depende en los siguientes componentes bajo la
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-El alojamiento de la integración continua es proporcionado por [MacStadium](https://www.macstadium.com/opensource).
+El alojamiento de la integración continua es proporcionado por [MacStadium](https://macstadium.com/company/opensource).
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="Logo de MacStadium" width="250">](https://www.macstadium.com)
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -62,7 +62,7 @@ De plus, le frontend d'UTM dépend de ces composants qui sont sous licence MIT :
 * [SwiftTerm](https://github.com/migueldeicaza/SwiftTerm)
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 
-L'hébergement en intégration continue est fourni par [MacStadium](https://www.macstadium.com/opensource)
+L'hébergement en intégration continue est fourni par [MacStadium](https://macstadium.com/company/opensource)
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
   

--- a/README.ja.md
+++ b/README.ja.md
@@ -67,7 +67,7 @@ UTMは、寛容なApache 2.0ライセンスで配布されています。しか�
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-[MacStadium](https://www.macstadium.com/opensource)によって継続的インテグレーションのホスティングが提供されています
+[MacStadium](https://macstadium.com/company/opensource)によって継続的インテグレーションのホスティングが提供されています
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -67,7 +67,7 @@ UTM은 Permissive 형태인 Apache 2.0 라이선스 하에 배포됩니다. (L)G
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-지속적 통합(CI) 호스팅은 [MacStadium](https://www.macstadium.com/opensource)에서 제공하고 있습니다.
+지속적 통합(CI) 호스팅은 [MacStadium](https://macstadium.com/company/opensource)에서 제공하고 있습니다.
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Additionally, UTM frontend depends on the following MIT/BSD License components:
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-Continuous integration hosting is provided by [MacStadium](https://www.macstadium.com/opensource)
+Continuous integration hosting is provided by [MacStadium](https://macstadium.com/company/opensource)
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.pl-PL.md
+++ b/README.pl-PL.md
@@ -67,7 +67,7 @@ Dodatkowo, interfejs UTM (frontend) jest zależny od komponentów na licencji MI
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-Continuous integration hosting jest zapewniony przez [MacStadium](https://www.macstadium.com/opensource)
+Continuous integration hosting jest zapewniony przez [MacStadium](https://macstadium.com/company/opensource)
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -64,6 +64,6 @@ UTM распространяется по лицензии Apache 2.0.
 
 Некоторые значки взяты с [Flaticon](https://www.flaticon.com/) и сгенерированы с помощью [Freepik](https://www.freepik.com/).
 
-Хостинг для CI предоставлен [MacStadium](https://www.macstadium.com/opensource).
+Хостинг для CI предоставлен [MacStadium](https://macstadium.com/company/opensource).
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)

--- a/README.uk.md
+++ b/README.uk.md
@@ -67,7 +67,7 @@ UTM розповсюджується на умовах ліцензії Apache 2
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-Хостинг для безперервної інтеграції забезпечується компанією [MacStadium](https://www.macstadium.com/opensource)
+Хостинг для безперервної інтеграції забезпечується компанією [MacStadium](https://macstadium.com/company/opensource)
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.zh-HK.md
+++ b/README.zh-HK.md
@@ -67,7 +67,7 @@ UTM 於允許的 Apache 2.0 許可證下分發。然而，它使用了幾個 (L)
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-持續整合託管由 [MacStadium](https://www.macstadium.com/opensource) 提供。
+持續整合託管由 [MacStadium](https://macstadium.com/company/opensource) 提供。
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.zh-Hans.md
+++ b/README.zh-Hans.md
@@ -67,7 +67,7 @@ UTM是在宽容的Apache 2.0许可证下分发的。然而，它使用了若干�
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-持续集成托管由 [MacStadium](https://www.macstadium.com/opensource) 提供。
+持续集成托管由 [MacStadium](https://macstadium.com/company/opensource) 提供。
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 

--- a/README.zh-Hant.md
+++ b/README.zh-Hant.md
@@ -67,7 +67,7 @@ UTM 是在寬鬆的 Apache 2.0 授權下釋出。然而，它使用了幾個 (L)
 * [ZIP Foundation](https://github.com/weichsel/ZIPFoundation)
 * [InAppSettingsKit](https://github.com/futuretap/InAppSettingsKit)
 
-持續整合主機由 [MacStadium](https://www.macstadium.com/opensource) 提供
+持續整合主機由 [MacStadium](https://macstadium.com/company/opensource) 提供
 
 [<img src="https://uploads-ssl.webflow.com/5ac3c046c82724970fc60918/5c019d917bba312af7553b49_MacStadium-developerlogo.png" alt="MacStadium logo" width="250">](https://www.macstadium.com)
 


### PR DESCRIPTION
Fixes broken MacStadium opensource link in all language versions of README.md

No AI tools used.

## Method

```shell
% brew install muffet

% muffet -b 12345 -e ".+github.+" https://github.com/utmapp/UTM
https://github.com/utmapp/UTM
	403	https://www.flaticon.com/
	403	https://www.freepik.com
	404	https://www.macstadium.com/opensource
```

Note MacStadium is the only 404 error. The two other listed items are 403 (forbidden) errors:
* The flaticon.com link is fine. That site just rejects the muffet user agent (bot prevention).
* Freepik.com similarly doesn't like being scanned. It automatically redirects Magnific https://www.magnific.com/