### PR TITLE
apple: explain macOS install failure when guest is newer than host

### DIFF
--- a/Services/UTMAppleVirtualMachine.swift
+++ b/Services/UTMAppleVirtualMachine.swift
@@ -591,9 +591,51 @@ final class UTMAppleVirtualMachine: UTMVirtualMachine {
             if error.domain == "VZErrorDomain" && error.code == 10006 {
                 throw UTMAppleVirtualMachineError.deviceSupportOutdated
             }
+            #if os(macOS) && arch(arm64)
+            if error.domain == "VZErrorDomain" && error.code == 10007,
+               let versions = await Self.restoreImageVersionIfNewerThanHost(at: ipswUrl) {
+                throw UTMAppleVirtualMachineError.installMacOSVersionTooNew(guestVersion: versions.guest, hostVersion: versions.host)
+            }
+            #endif
             throw error
         }
     }
+
+    #if os(macOS) && arch(arm64)
+    /// Returns the macOS version of a restore image when it is newer than the version running on this Mac.
+    ///
+    /// Installing a guest newer than the host is not supported by `VZMacOSInstaller`, but the restore only
+    /// fails partway through with a generic error. We check the versions after a failure so the user can be
+    /// told what to do about it. Returns nil if the versions cannot be compared or the guest is not newer.
+    @available(macOS 12, *)
+    private static func restoreImageVersionIfNewerThanHost(at ipswUrl: URL) async -> (guest: String, host: String)? {
+        let scopedAccess = ipswUrl.startAccessingSecurityScopedResource()
+        defer {
+            if scopedAccess {
+                ipswUrl.stopAccessingSecurityScopedResource()
+            }
+        }
+        guard let image = try? await VZMacOSRestoreImage.image(from: ipswUrl) else {
+            return nil
+        }
+        let guest = image.operatingSystemVersion
+        let host = ProcessInfo.processInfo.operatingSystemVersion
+        let guestComponents = [guest.majorVersion, guest.minorVersion, guest.patchVersion]
+        let hostComponents = [host.majorVersion, host.minorVersion, host.patchVersion]
+        guard hostComponents.lexicographicallyPrecedes(guestComponents) else {
+            return nil
+        }
+        return (guest: Self.versionString(guest), host: Self.versionString(host))
+    }
+
+    private static func versionString(_ version: OperatingSystemVersion) -> String {
+        if version.patchVersion == 0 {
+            return "\(version.majorVersion).\(version.minorVersion)"
+        } else {
+            return "\(version.majorVersion).\(version.minorVersion).\(version.patchVersion)"
+        }
+    }
+    #endif
     
     // taken from https://github.com/evansm7/vftool/blob/main/vftool/main.m
     private func createPty() throws -> (Int32, Int32, String) {
@@ -916,6 +958,7 @@ enum UTMAppleVirtualMachineError: Error {
     case operationNotAvailable
     case ipswNotReadable
     case deviceSupportOutdated
+    case installMacOSVersionTooNew(guestVersion: String, hostVersion: String)
 }
 
 extension UTMAppleVirtualMachineError: LocalizedError {
@@ -931,6 +974,8 @@ extension UTMAppleVirtualMachineError: LocalizedError {
             return NSLocalizedString("The recovery IPSW cannot be read. Please select a new IPSW in Boot settings.", comment: "UTMAppleVirtualMachine")
         case .deviceSupportOutdated:
             return NSLocalizedString("You need to update macOS to run this virtual machine. A separate pop-up should prompt you to install this update. If you are trying to install a new beta version of macOS, you must manually download the Device Support package from the Apple Developer website.", comment: "UTMAppleVirtualMachine")
+        case .installMacOSVersionTooNew(let guestVersion, let hostVersion):
+            return String.localizedStringWithFormat(NSLocalizedString("Installation failed because macOS %1$@ is newer than macOS %2$@ running on this Mac. Update this Mac to macOS %1$@ or later and try again, or install an older version of macOS.", comment: "UTMAppleVirtualMachine"), guestVersion, hostVersion)
         }
     }
 }


### PR DESCRIPTION
## Summary

`VZMacOSInstaller` does not support installing a macOS guest that is newer than the macOS running on the host. Instead of refusing up front, the restore runs for several minutes and then fails at around 78% with `VZErrorInstallationFailed` (10007). UTM surfaced that as the generic:

> An error occurred during installation. Installation failed.

which gives the user nothing to act on.

This change checks, **only on the failure path**, whether the restore image is newer than the host and, if so, reports both versions and what to do:

> Installation failed because macOS 26.6 is newer than macOS 26.5.2 running on this Mac. Update this Mac to macOS 26.6 or later and try again, or install an older version of macOS.

## Why this shape

The underlying limitation is in Virtualization.framework, not UTM — I reproduced the identical failure with a standalone `VZMacOSInstaller` program that does not involve UTM at all:

```
INSTALL FAILED: An error occurred during installation. Installation failed.
  domain=VZErrorDomain code=10007
  NSUnderlyingError: com.apple.MobileDevice.MobileRestore Code=-1
    "AMRestorePerformRestoreModeRestoreWithError failed with error: 11"
```

So this PR deliberately does **not** try to block the install or pre-validate in the wizard:

- `VZMacOSRestoreImage.mostFeaturefulSupportedConfiguration?.hardwareModel` returns non-nil for an IPSW that cannot actually install, so it is not a usable pre-flight signal.
- Some newer-guest-than-host combinations do work (Apple appears to have fixed this for hosts on macOS 26.6), so a hard block would produce false negatives.

Running the comparison only after a genuine `VZErrorInstallationFailed` avoids both problems. If the restore image cannot be read, the original error is rethrown unchanged.

## Context

Relates to #7746 — the guest-newer-than-host case, where an Apple engineer confirmed the installer incompatibility.
Relates to #7545 — reports this exact generic message with no further diagnosis available.

Neither is closed by this change: the install still cannot succeed. The failure just becomes explainable.

## Testing

**Testing:** Tested by a human on **macOS 26.5.2 (25F84), MacBook Pro (M5, Mac17,2)**. The bug was reproduced before the change (macOS 26.6 / build 25G72 IPSW failing at ~78% with the generic message) and the new message was observed in its place after applying it. The author acknowledges that this change has been tested and/or reviewed by a human in accordance with UTM's AI contribution guidelines.

I have read the AI contribution guidelines and have followed them to the best of my ability.
