### PR TITLE
Fix bug where `listRefresh()` would not deduplicate already existing VMs in list

### DIFF
--- a/Platform/UTMData.swift
+++ b/Platform/UTMData.swift
@@ -144,12 +144,18 @@ enum AlertItem: Identifiable {
     ///
     /// This removes stale entries (deleted/not accessible) and duplicate entries
     func listRefresh() async {
+        // deduplicate VM list
+        var list: [VMData] = [];
+        for vm in virtualMachines {
+            if !list.contains(where: { isSameFile($0.pathUrl, as: vm.pathUrl) }) {
+                list.append(vm)
+            }
+        }
         // create Documents directory if it doesn't exist
         if !fileManager.fileExists(atPath: Self.defaultStorageUrl.path) {
             try? fileManager.createDirectory(at: Self.defaultStorageUrl, withIntermediateDirectories: false)
         }
         // wrap stale VMs
-        var list = virtualMachines
         for i in list.indices.reversed() {
             let vm = list[i]
             if let registryEntry = vm.registryEntry, !fileManager.fileExists(atPath: registryEntry.package.path) {


### PR DESCRIPTION
While I was using UTM, I noticed that sometimes, after creating a VM, it would create two entries for that VM. On trying to delete one of the entries, the whole VM would be deleted though. 

I'm not sure why the duplicate entries are being created but after looking at the code for some time, I found this function which claims to remove duplicate entries.

The thing is, however, it only seemed to remove 'newly loaded' duplicates. I added some code at the very beginning that makes it remove already existing duplicates too.

I tested this myself (Macbook Air M2, macOS Tahoe 26.5) and a Windows VM that appeared twice on the regular UTM appears only once with this patch. 