### PR TITLE
config: use linear upscaling except on classic guests

### DIFF
--- a/Configuration/UTMQemuConfigurationDisplay.swift
+++ b/Configuration/UTMQemuConfigurationDisplay.swift
@@ -28,7 +28,12 @@ struct UTMQemuConfigurationDisplay: Codable, Identifiable {
     var isDynamicResolution: Bool = true
     
     /// Filter to use when upscaling.
-    var upscalingFilter: QEMUScaler = .nearest
+    ///
+    /// Nearest neighbour is only a good fit for low-resolution guests, where it keeps the image
+    /// sharp instead of washing it out (#3371); the wizard selects it for those. For a modern
+    /// guest the upscale is rarely an integer ratio, so nearest duplicates source pixels
+    /// unevenly and looks blocky rather than sharp.
+    var upscalingFilter: QEMUScaler = .linear
     
     /// Filter to use when downscaling.
     var downscalingFilter: QEMUScaler = .linear

--- a/Platform/Shared/VMWizardState.swift
+++ b/Platform/Shared/VMWizardState.swift
@@ -475,6 +475,17 @@ struct AlertMessage: Identifiable {
                 config.displays[0].hardware = AnyQEMUConstant(rawValue: newCard)!
             }
         }
+        // Low-resolution guests upscale better with nearest neighbour: linear washes out
+        // their already-chunky text (#3371). Legacy hardware is checked on its own rather
+        // than folded into the Windows case so that picking a legacy machine opts in under
+        // any OS, and because the summary page can enable it after the Windows page has
+        // latched isWindows10OrHigher. Modern guests keep the linear default, where the
+        // upscale is a non-integer ratio and nearest looks blocky instead of sharp.
+        if operatingSystem == .ClassicMacOS || legacyHardware || (operatingSystem == .Windows && !isWindows10OrHigher) {
+            for i in config.displays.indices {
+                config.displays[i].upscalingFilter = .nearest
+            }
+        }
         if operatingSystem == .Linux && !isDisplayEnabled {
             config.displays = []
             let newSerial = UTMQemuConfigurationSerial(forArchitecture: systemArchitecture, target: systemTarget)!


### PR DESCRIPTION
The nearest-neighbour upscaling default (#3371, ba5f7f7f, shipped in v3.0.1) was chosen for low-resolution guests, where linear washes out already-chunky text. It is the wrong choice everywhere else: a modern guest rarely upscales by an integer ratio, so nearest duplicates source pixels unevenly and the result looks blocky rather than sharp.

This defaults `upscalingFilter` to linear, and has the VM wizard select nearest for the guests the original change was about: Classic Mac OS, Windows 7 and below, and any OS configured for legacy hardware. Legacy hardware is checked on its own rather than folded into the Windows case so that choosing a legacy machine opts in under any OS, and because the summary page can enable it after the Windows page has already latched `isWindows10OrHigher`.

Existing VMs are unaffected: `upscalingFilter` is a required coding key, so a saved configuration always carries its own value. The UTM 2.x migration path is likewise unchanged, since an absent `displayUpscaler` already defaulted to linear.

**Testing:** Tested by a human on **macOS 15.6 (24G84), Mac16,11 — Apple M4 Pro**. The author acknowledges that this change has been tested and/or reviewed by a human in accordance with UTM's AI contribution guidelines.

